### PR TITLE
Phase 21A Azure: Initialize Azure AD B2C provider branch

### DIFF
--- a/portal/sso/providers/azure.py
+++ b/portal/sso/providers/azure.py
@@ -1,0 +1,4 @@
+"""Azure AD B2C SAML 2.0 Service Provider.
+
+Metadata parsing, ACS handler, conditional access events, risk tracking.
+"""


### PR DESCRIPTION
Closing: superseded by PR #40 (manus/PHASE-21A-azure-google) which contains the complete Azure AD and Google Workspace OIDC provider implementations with 62/62 tests passing. This was a scaffolding stub only.