### PR TITLE
Phase 21A Google: Initialize Google Workspace provider branch

### DIFF
--- a/portal/sso/providers/google.py
+++ b/portal/sso/providers/google.py
@@ -1,0 +1,4 @@
+"""Google Workspace SAML 2.0 Service Provider.
+
+Metadata ingestion, assertion validation, custom attributes, JIT provisioning.
+"""


### PR DESCRIPTION
Closing: superseded by PR #40 (manus/PHASE-21A-azure-google) which contains the complete Azure AD and Google Workspace OIDC provider implementations with 62/62 tests passing. This was a scaffolding stub only.