### PR TITLE
feat(sso-routes): Phase 21B — SSO route registration (Okta, Azure, Google)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,3 +123,31 @@ OKTA_REDIRECT_URI=https://your-app.example.com/auth/okta/callback
 OKTA_SCOPES=openid,profile,email
 # OPTIONAL — HTTP timeout in seconds for Okta API calls (default: 30)
 OKTA_TIMEOUT_SECONDS=30
+
+# ── SSO / OAuth 2.0 ──────────────────────────────────────────────────────────
+# WARNING: Never commit real secrets. Use placeholder values only.
+# Shared session
+SSO_SESSION_SECRET=CHANGE-ME-SSO-SESSION-SECRET-256-BIT
+SSO_ISSUER=https://portal.sintraprime.ai
+SSO_AUDIENCE=sintraprime-portal
+SSO_SESSION_TTL_SECONDS=3600
+SSO_REFRESH_TTL_SECONDS=2592000
+
+# Okta OIDC
+OKTA_DOMAIN=dev-XXXXXXXX.okta.com
+OKTA_CLIENT_ID=CHANGE-ME-OKTA-CLIENT-ID
+OKTA_CLIENT_SECRET=CHANGE-ME-OKTA-CLIENT-SECRET
+OKTA_REDIRECT_URI=https://portal.sintraprime.ai/api/v1/sso/okta/callback
+OKTA_SCOPES=openid email profile offline_access
+
+# Azure AD OIDC
+AZURE_TENANT_ID=CHANGE-ME-AZURE-TENANT-ID
+AZURE_CLIENT_ID=CHANGE-ME-AZURE-CLIENT-ID
+AZURE_CLIENT_SECRET=CHANGE-ME-AZURE-CLIENT-SECRET
+AZURE_REDIRECT_URI=https://portal.sintraprime.ai/api/v1/sso/azure/callback
+
+# Google Workspace OIDC
+GOOGLE_CLIENT_ID=CHANGE-ME-GOOGLE-CLIENT-ID
+GOOGLE_CLIENT_SECRET=CHANGE-ME-GOOGLE-CLIENT-SECRET
+GOOGLE_REDIRECT_URI=https://portal.sintraprime.ai/api/v1/sso/google/callback
+GOOGLE_HOSTED_DOMAIN=yourdomain.com

--- a/ops/receipts/PHASE-21A-azure-google-manus.md
+++ b/ops/receipts/PHASE-21A-azure-google-manus.md
@@ -1,0 +1,65 @@
+# Receipt: PHASE-21A Azure + Google SSO Providers
+
+**Agent:** Manus AI
+**Branch:** `manus/PHASE-21A-azure-google`
+**Base:** `agent/tasklet/PHASE-21A-okta` (PR #36 head — `a9bfc21`)
+**Date:** 2026-04-30
+**Status:** Ready for review (PR #40)
+
+---
+
+## Context
+
+PR #39 (`manus/PHASE-21A-providers`) was closed per Commander Option A resolution — it contained a duplicate Okta implementation that conflicted with Tasklet's PR #36. This PR extracts only the Azure and Google providers from that work, rebased cleanly on top of Tasklet's Okta foundation.
+
+---
+
+## Files Added
+
+| File | Lines | Purpose |
+|---|---|---|
+| `portal/sso/providers/azure.py` | 191 | Azure AD OIDC provider (PKCE, JWKS validation) |
+| `portal/sso/providers/google.py` | 107 | Google Workspace OIDC provider (hosted domain enforcement) |
+| `portal/sso/tests/test_azure.py` | 393 | 27 unit tests for Azure provider |
+| `portal/sso/tests/test_google.py` | 378 | 35 unit tests for Google provider |
+
+**Total: 62 tests, 1,069 lines added. No Okta files touched.**
+
+---
+
+## Verification Results
+
+| Check | Result | Evidence |
+|---|---|---|
+| Azure tests | 27/27 ✅ | `pytest portal/sso/tests/test_azure.py` |
+| Google tests | 35/35 ✅ | `pytest portal/sso/tests/test_google.py` |
+| Bandit (azure.py) | 0 issues ✅ | `bandit portal/sso/providers/azure.py -ll` |
+| Bandit (google.py) | 0 issues ✅ | `bandit portal/sso/providers/google.py -ll` (B105 false-positive suppressed with `# nosec` — public OAuth2 endpoint URL, not a password) |
+
+---
+
+## Security Notes
+
+**Azure provider:** PKCE enforced on all authorization requests; JWKS-based token validation using `PyJWKClient`; `timeout=10` on all HTTP calls (bandit B113 clean); tenant ID validated at config init.
+
+**Google provider:** Hosted domain enforcement via `hd` claim validation; JWKS-based token validation; `timeout=10` on all HTTP calls; `# nosec B105` on `self.token_url` — bandit incorrectly flags the string `"https://oauth2.googleapis.com/token"` as a hardcoded password because the variable is named `token_url`. This is a well-known false positive for OAuth2 endpoint constants.
+
+---
+
+## Collision Avoidance
+
+This PR deliberately excludes:
+- `portal/sso/providers/okta.py` — owned by Tasklet (PR #36)
+- `portal/sso/__init__.py` — owned by Tasklet (PR #36)
+- `.env.example` — owned by Tasklet (PR #36)
+- `portal/sso/tests/test_okta.py` — owned by Tasklet (PR #36)
+
+---
+
+## Merge Sequence
+
+```
+PR #36 (Tasklet — Okta)  →  merge first
+  ↓
+PR #40 (Manus — Azure + Google)  →  merge after #36
+```

--- a/ops/receipts/PHASE-21B-sso-routes-tasklet.md
+++ b/ops/receipts/PHASE-21B-sso-routes-tasklet.md
@@ -1,0 +1,39 @@
+# Phase 21B: SSO Route Registration
+
+**Status:** Complete
+**Date:** April 30, 2026
+**Branch:** `manus/PHASE-21B-sso-routes`
+**PR:** [#42](https://github.com/ihoward40/SintraPrime-Unified/pull/42)
+**Head Commit:** `5643a50`
+
+## Overview
+This phase successfully wired the three SSO provider modules (Okta, Azure, Google) developed in Phase 21A into the FastAPI portal application. It exposes five HTTP endpoints per provider, enabling full end-to-end authentication flows including CSRF protection, secure cookie management, and session introspection.
+
+## Implementation Details
+
+### 1. FastAPI Router (`portal/routers/sso.py`)
+Created a new dedicated router for SSO endpoints, registered at `/api/v1/sso`. For each provider (`okta`, `azure`, `google`), the following five endpoints were implemented:
+
+*   **`GET /{provider}/authorize`**: Generates a cryptographically secure CSRF state token, stores it in the Starlette session cookie, and redirects the user to the Identity Provider's authorization URL.
+*   **`GET /{provider}/callback`**: Validates the CSRF state using constant-time comparison (`hmac.compare_digest`), exchanges the authorization code for tokens, fetches user info, creates a new session via `SessionManager`, and sets the refresh token as an `HttpOnly`, `SameSite=Lax`, `Secure` cookie.
+*   **`POST /{provider}/refresh`**: Reads the refresh token from the secure cookie, validates it, and issues a new access token.
+*   **`POST /{provider}/logout`**: Revokes the session in the database and clears the refresh token cookie.
+*   **`GET /{provider}/me`**: Introspects the current session using the `Authorization: Bearer <access_token>` header and returns the user's profile and session metadata.
+
+### 2. Security Enhancements
+*   **CSRF Protection**: Implemented strict state validation to prevent Cross-Site Request Forgery attacks during the OAuth callback phase.
+*   **Secure Cookies**: Configured the refresh token cookie with `httponly=True`, `secure=True`, and `samesite="lax"` to protect against XSS and CSRF.
+*   **Error Handling**: Added robust error handling for unconfigured providers (503 Service Unavailable), IdP exchange failures (502 Bad Gateway), and invalid states/tokens (400/401).
+
+### 3. Configuration Updates
+*   Updated `portal/config.py` to include all necessary SSO settings (Client IDs, Secrets, Redirect URIs, etc.) for Okta, Azure, and Google.
+*   Updated `.env.example` with placeholders for the new environment variables.
+
+## Testing & Validation
+*   **Unit Tests**: Wrote 46 comprehensive tests in `portal/routers/tests/test_sso_routes.py` covering happy paths, CSRF failures, missing cookies/tokens, and IdP errors for all three providers.
+*   **Test Results**: 46/46 route tests passing. Total SSO test suite (including Phase 21A provider tests) is now at 155/155 passing.
+*   **Security Scan**: Ran `bandit` on the new router and config files. 0 issues found (suppressed one false-positive B106 warning on a string literal).
+
+## Next Steps
+1.  Review and merge PR #42.
+2.  Proceed to the next phase of the SSO implementation or frontend integration as defined in the project roadmap.

--- a/portal/config.py
+++ b/portal/config.py
@@ -139,6 +139,33 @@ class Settings(BaseSettings):
     SHARE_LINK_MAX_EXPIRY_DAYS: int = 90
     SHARE_LINK_BASE_URL: str = "https://share.sintraprime.ai"
 
+    # ── SSO / OAuth 2.0 ──────────────────────────────────────────────────────
+    # Shared session settings
+    SSO_SESSION_SECRET: str = "CHANGE-ME-SSO-SESSION-SECRET-256-BIT"
+    SSO_ISSUER: str = "https://portal.sintraprime.ai"
+    SSO_AUDIENCE: str = "sintraprime-portal"
+    SSO_SESSION_TTL_SECONDS: int = 3600          # 1 hour
+    SSO_REFRESH_TTL_SECONDS: int = 2592000       # 30 days
+
+    # Okta
+    OKTA_DOMAIN: str = ""                        # e.g. dev-123456.okta.com
+    OKTA_CLIENT_ID: str = ""
+    OKTA_CLIENT_SECRET: str = ""
+    OKTA_REDIRECT_URI: str = "https://portal.sintraprime.ai/api/v1/sso/okta/callback"
+    OKTA_SCOPES: str = "openid email profile offline_access"
+
+    # Azure AD
+    AZURE_TENANT_ID: str = ""
+    AZURE_CLIENT_ID: str = ""
+    AZURE_CLIENT_SECRET: str = ""
+    AZURE_REDIRECT_URI: str = "https://portal.sintraprime.ai/api/v1/sso/azure/callback"
+
+    # Google Workspace
+    GOOGLE_CLIENT_ID: str = ""
+    GOOGLE_CLIENT_SECRET: str = ""
+    GOOGLE_REDIRECT_URI: str = "https://portal.sintraprime.ai/api/v1/sso/google/callback"
+    GOOGLE_HOSTED_DOMAIN: str = ""              # e.g. yourdomain.com; empty = any Google account
+
     @field_validator("ENCRYPTION_KEY")
     @classmethod
     def validate_encryption_key(cls, v: str) -> str:

--- a/portal/main.py
+++ b/portal/main.py
@@ -28,6 +28,7 @@ from .routers import (
     documents,
     messages,
     notifications,
+    sso,
     users,
 )
 from .websocket.connection_manager import ws_manager
@@ -151,6 +152,7 @@ def create_app() -> FastAPI:
     app.include_router(billing.router, prefix=f"{API_PREFIX}/billing", tags=["Billing"])
     app.include_router(notifications.router, prefix=f"{API_PREFIX}/notifications", tags=["Notifications"])
     app.include_router(admin.router, prefix=f"{API_PREFIX}/admin", tags=["Administration"])
+    app.include_router(sso.router, prefix=f"{API_PREFIX}/sso", tags=["SSO"])
 
     # ── WebSocket ─────────────────────────────────────────────────────────────────
     from .websocket.message_handler import websocket_endpoint

--- a/portal/routers/sso.py
+++ b/portal/routers/sso.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import hmac
 import logging
+import os
 import secrets
 from typing import Annotated, Literal, Optional
 
@@ -36,10 +37,9 @@ from ..sso import (
 )
 from ..sso.providers.azure import AzureADProvider, AzureConfig
 from ..sso.providers.google import GoogleWorkspaceProvider, GoogleConfig
+from ..sso.session_store import RedisSessionStore
 
 logger = logging.getLogger(__name__)
-settings = get_settings()
-
 router = APIRouter()
 
 # ── Cookie / session constants ────────────────────────────────────────────────
@@ -76,15 +76,22 @@ class SSORefreshResponse(BaseModel):
 
 # ── Provider / SessionManager factories ──────────────────────────────────────
 def _get_session_manager() -> SessionManager:
-    """Build a SessionManager from app settings."""
+    """Build a SessionManager from app settings.
+
+    Uses RedisSessionStore when REDIS_URL is set in the environment (production),
+    and falls back to InMemorySessionStore for local development and testing.
+    """
+    s = get_settings()
     cfg = SessionConfig(
-        secret_key=settings.SSO_SESSION_SECRET,
-        issuer=settings.SSO_ISSUER,
-        audience=settings.SSO_AUDIENCE,
-        session_ttl_seconds=settings.SSO_SESSION_TTL_SECONDS,
-        refresh_token_ttl_seconds=settings.SSO_REFRESH_TTL_SECONDS,
+        secret_key=s.SSO_SESSION_SECRET,
+        issuer=s.SSO_ISSUER,
+        audience=s.SSO_AUDIENCE,
+        session_ttl_seconds=s.SSO_SESSION_TTL_SECONDS,
+        refresh_token_ttl_seconds=s.SSO_REFRESH_TTL_SECONDS,
     )
-    return SessionManager(cfg, store=InMemorySessionStore())
+    redis_url = os.environ.get("REDIS_URL", "")
+    store = RedisSessionStore(redis_url=redis_url) if redis_url else InMemorySessionStore()
+    return SessionManager(cfg, store=store)
 
 
 def _get_okta_provider() -> OktaProvider:
@@ -93,21 +100,23 @@ def _get_okta_provider() -> OktaProvider:
 
 
 def _get_azure_provider() -> AzureADProvider:
+    s = get_settings()
     cfg = AzureConfig(
-        tenant_id=settings.AZURE_TENANT_ID,
-        client_id=settings.AZURE_CLIENT_ID,
-        client_secret=settings.AZURE_CLIENT_SECRET,
-        redirect_uri=settings.AZURE_REDIRECT_URI,
+        tenant_id=s.AZURE_TENANT_ID,
+        client_id=s.AZURE_CLIENT_ID,
+        client_secret=s.AZURE_CLIENT_SECRET,
+        redirect_uri=s.AZURE_REDIRECT_URI,
     )
     return AzureADProvider(cfg)
 
 
 def _get_google_provider() -> GoogleWorkspaceProvider:
+    s = get_settings()
     cfg = GoogleConfig(
-        client_id=settings.GOOGLE_CLIENT_ID,
-        client_secret=settings.GOOGLE_CLIENT_SECRET,
-        redirect_uri=settings.GOOGLE_REDIRECT_URI,
-        hosted_domain=settings.GOOGLE_HOSTED_DOMAIN or None,
+        client_id=s.GOOGLE_CLIENT_ID,
+        client_secret=s.GOOGLE_CLIENT_SECRET,
+        redirect_uri=s.GOOGLE_REDIRECT_URI,
+        hosted_domain=s.GOOGLE_HOSTED_DOMAIN or None,
     )
     return GoogleWorkspaceProvider(cfg)
 
@@ -230,6 +239,10 @@ async def okta_callback(
         logger.error("sso.okta.callback.error", extra={"error": str(exc)})
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Okta token exchange failed")
 
+    if not user_info.sub:
+        logger.error("sso.okta.callback.missing_sub")
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="IdP did not return a subject identifier")
+
     sm = _get_session_manager()
     token_pair = await sm.create_session(
         user_id=user_info.sub,
@@ -244,7 +257,7 @@ async def okta_callback(
     logger.info("sso.okta.callback.success", extra={"sub": user_info.sub})
     return SSOTokenResponse(
         access_token=token_pair.access_token,
-        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+        expires_in=get_settings().SSO_SESSION_TTL_SECONDS,
         provider="okta",
         email=user_info.email,
         name=getattr(user_info, "preferred_username", None),
@@ -266,7 +279,7 @@ async def okta_refresh(
     _set_refresh_cookie(response, token_pair.refresh_token)
     return SSORefreshResponse(
         access_token=token_pair.access_token,
-        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+        expires_in=get_settings().SSO_SESSION_TTL_SECONDS,
     )
 
 
@@ -343,8 +356,12 @@ async def azure_callback(
         logger.error("sso.azure.callback.error", extra={"error": str(exc)})
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Azure token exchange failed")
 
+     # Azure returns email in either 'email' or 'preferred_username' (UPN)
     email = user_info.get("email") or user_info.get("preferred_username", "")
     sub = user_info.get("sub", "")
+    if not sub:
+        logger.error("sso.azure.callback.missing_sub")
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="IdP did not return a subject identifier")
 
     sm = _get_session_manager()
     token_pair = await sm.create_session(
@@ -360,7 +377,7 @@ async def azure_callback(
     logger.info("sso.azure.callback.success", extra={"sub": sub})
     return SSOTokenResponse(
         access_token=token_pair.access_token,
-        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+        expires_in=get_settings().SSO_SESSION_TTL_SECONDS,
         provider="azure",
         email=email,
         name=user_info.get("name"),
@@ -381,7 +398,7 @@ async def azure_refresh(
     _set_refresh_cookie(response, token_pair.refresh_token)
     return SSORefreshResponse(
         access_token=token_pair.access_token,
-        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+        expires_in=get_settings().SSO_SESSION_TTL_SECONDS,
     )
 
 
@@ -458,6 +475,9 @@ async def google_callback(
 
     email = user_info.get("email", "")
     sub = user_info.get("sub", "")
+    if not sub:
+        logger.error("sso.google.callback.missing_sub")
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="IdP did not return a subject identifier")
 
     sm = _get_session_manager()
     token_pair = await sm.create_session(
@@ -473,7 +493,7 @@ async def google_callback(
     logger.info("sso.google.callback.success", extra={"sub": sub})
     return SSOTokenResponse(
         access_token=token_pair.access_token,
-        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+        expires_in=get_settings().SSO_SESSION_TTL_SECONDS,
         provider="google",
         email=email,
         name=user_info.get("name"),
@@ -494,7 +514,7 @@ async def google_refresh(
     _set_refresh_cookie(response, token_pair.refresh_token)
     return SSORefreshResponse(
         access_token=token_pair.access_token,
-        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+        expires_in=get_settings().SSO_SESSION_TTL_SECONDS,
     )
 
 

--- a/portal/routers/sso.py
+++ b/portal/routers/sso.py
@@ -1,0 +1,530 @@
+"""
+SSO Router — Phase 21B
+Wires Okta, Azure AD, and Google Workspace OIDC providers into FastAPI.
+
+Routes per provider (prefix: /api/v1/sso/{provider}):
+  GET  /authorize          → redirect to IdP authorization URL
+  GET  /callback           → exchange code, create session, set secure cookie
+  POST /refresh            → rotate refresh token, return new access token
+  POST /logout             → revoke session, clear cookie
+  GET  /me                 → return current SSO session info
+
+Security:
+  - CSRF state validated on callback (constant-time comparison)
+  - Refresh token in HttpOnly, Secure, SameSite=Lax cookie
+  - State stored in signed server-side session (Starlette SessionMiddleware)
+  - All errors logged; no IdP internals leaked to client
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+import secrets
+from typing import Annotated, Literal, Optional
+
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+
+from ..config import get_settings
+from ..sso import (
+    OktaConfig,
+    OktaProvider,
+    SessionConfig,
+    SessionManager,
+    InMemorySessionStore,
+)
+from ..sso.providers.azure import AzureADProvider, AzureConfig
+from ..sso.providers.google import GoogleWorkspaceProvider, GoogleConfig
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+router = APIRouter()
+
+# ── Cookie / session constants ────────────────────────────────────────────────
+SSO_REFRESH_COOKIE = "sso_refresh_token"
+SSO_STATE_SESSION_KEY = "sso_oauth_state"
+COOKIE_MAX_AGE = 30 * 24 * 60 * 60  # 30 days in seconds
+
+ProviderName = Literal["okta", "azure", "google"]
+
+
+# ── Response schemas ──────────────────────────────────────────────────────────
+class SSOTokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int
+    provider: str
+    email: str
+    name: Optional[str] = None
+
+
+class SSOSessionResponse(BaseModel):
+    user_id: str
+    email: str
+    provider: str
+    session_id: str
+    expires_at: str
+
+
+class SSORefreshResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    expires_in: int
+
+
+# ── Provider / SessionManager factories ──────────────────────────────────────
+def _get_session_manager() -> SessionManager:
+    """Build a SessionManager from app settings."""
+    cfg = SessionConfig(
+        secret_key=settings.SSO_SESSION_SECRET,
+        issuer=settings.SSO_ISSUER,
+        audience=settings.SSO_AUDIENCE,
+        session_ttl_seconds=settings.SSO_SESSION_TTL_SECONDS,
+        refresh_token_ttl_seconds=settings.SSO_REFRESH_TTL_SECONDS,
+    )
+    return SessionManager(cfg, store=InMemorySessionStore())
+
+
+def _get_okta_provider() -> OktaProvider:
+    cfg = OktaConfig.from_env()
+    return OktaProvider(cfg)
+
+
+def _get_azure_provider() -> AzureADProvider:
+    cfg = AzureConfig(
+        tenant_id=settings.AZURE_TENANT_ID,
+        client_id=settings.AZURE_CLIENT_ID,
+        client_secret=settings.AZURE_CLIENT_SECRET,
+        redirect_uri=settings.AZURE_REDIRECT_URI,
+    )
+    return AzureADProvider(cfg)
+
+
+def _get_google_provider() -> GoogleWorkspaceProvider:
+    cfg = GoogleConfig(
+        client_id=settings.GOOGLE_CLIENT_ID,
+        client_secret=settings.GOOGLE_CLIENT_SECRET,
+        redirect_uri=settings.GOOGLE_REDIRECT_URI,
+        hosted_domain=settings.GOOGLE_HOSTED_DOMAIN or None,
+    )
+    return GoogleWorkspaceProvider(cfg)
+
+
+# ── CSRF helpers ──────────────────────────────────────────────────────────────
+def _generate_state() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def _verify_state(received: str, expected: str) -> bool:
+    """Constant-time state comparison to prevent timing attacks."""
+    return hmac.compare_digest(received.encode(), expected.encode())
+
+
+def _store_state(request: Request, state: str) -> None:
+    request.session[SSO_STATE_SESSION_KEY] = state
+
+
+def _pop_state(request: Request) -> Optional[str]:
+    return request.session.pop(SSO_STATE_SESSION_KEY, None)
+
+
+# ── Shared dependency: validate SSO refresh cookie ───────────────────────────
+def _get_sso_refresh_token(
+    sso_refresh_token: Annotated[Optional[str], Cookie()] = None,
+) -> str:
+    if not sso_refresh_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="No SSO refresh token",
+        )
+    return sso_refresh_token
+
+
+def _decode_refresh_token_session_id(refresh_token: str, sm: SessionManager) -> str:
+    """Decode a refresh token and return its session_id."""
+    try:
+        payload = sm.jwt_service.validate_token(refresh_token, token_type="refresh")  # nosec B106
+        session_id = payload.get("session_id")
+        if not session_id:
+            raise ValueError("No session_id in refresh token")
+        return session_id
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid refresh token",
+        ) from exc
+
+
+def _get_sso_access_token(request: Request) -> str:
+    """Extract Bearer access token from Authorization header."""
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or invalid Authorization header",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return auth[7:]
+
+
+def _set_refresh_cookie(response: Response, token: str) -> None:
+    response.set_cookie(
+        key=SSO_REFRESH_COOKIE,
+        value=token,
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=COOKIE_MAX_AGE,
+        path="/api/v1/sso",
+    )
+
+
+def _clear_refresh_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=SSO_REFRESH_COOKIE,
+        path="/api/v1/sso",
+        httponly=True,
+        secure=True,
+        samesite="lax",
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# OKTA ROUTES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@router.get("/okta/authorize", summary="Redirect to Okta authorization endpoint")
+async def okta_authorize(request: Request) -> RedirectResponse:
+    """Generate a CSRF state token, store it in the session, and redirect to Okta."""
+    try:
+        provider = _get_okta_provider()
+        state = _generate_state()
+        _store_state(request, state)
+        auth_url, _ = provider.get_authorization_url(state=state)
+        logger.info("sso.okta.authorize", extra={"ip": request.client.host if request.client else "unknown"})
+        return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
+    except (ValueError, KeyError) as exc:
+        logger.error("sso.okta.authorize.error", extra={"error": str(exc)})
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Okta SSO not configured")
+
+
+@router.get("/okta/callback", response_model=SSOTokenResponse, summary="Handle Okta OAuth callback")
+async def okta_callback(
+    code: str,
+    state: str,
+    request: Request,
+    response: Response,
+) -> SSOTokenResponse:
+    """Validate CSRF state, exchange code for tokens, create session, set cookie."""
+    stored_state = _pop_state(request)
+    if not stored_state or not _verify_state(state, stored_state):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid state parameter")
+
+    try:
+        async with OktaProvider(_get_okta_provider().config) as provider:
+            token_resp = await provider.exchange_code_for_token(code)
+            user_info = await provider.get_user_info(token_resp.access_token)
+    except ValueError as exc:
+        logger.error("sso.okta.callback.error", extra={"error": str(exc)})
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Okta token exchange failed")
+
+    sm = _get_session_manager()
+    token_pair = await sm.create_session(
+        user_id=user_info.sub,
+        email=user_info.email,
+        identity_provider="okta",
+        auth_method="oidc",
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    _set_refresh_cookie(response, token_pair.refresh_token)
+    logger.info("sso.okta.callback.success", extra={"sub": user_info.sub})
+    return SSOTokenResponse(
+        access_token=token_pair.access_token,
+        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+        provider="okta",
+        email=user_info.email,
+        name=getattr(user_info, "preferred_username", None),
+    )
+
+
+@router.post("/okta/refresh", response_model=SSORefreshResponse, summary="Refresh Okta SSO session")
+async def okta_refresh(
+    response: Response,
+    refresh_token: str = Depends(_get_sso_refresh_token),
+) -> SSORefreshResponse:
+    """Rotate the SSO refresh token and return a new access token."""
+    sm = _get_session_manager()
+    token_pair = await sm.refresh_session(refresh_token)
+    if not token_pair:
+        logger.warning("sso.okta.refresh.failed")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired refresh token")
+
+    _set_refresh_cookie(response, token_pair.refresh_token)
+    return SSORefreshResponse(
+        access_token=token_pair.access_token,
+        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+    )
+
+
+@router.post("/okta/logout", status_code=status.HTTP_204_NO_CONTENT, summary="Logout from Okta SSO")
+async def okta_logout(
+    response: Response,
+    refresh_token: str = Depends(_get_sso_refresh_token),
+) -> None:
+    """Revoke the SSO session and clear the refresh cookie."""
+    sm = _get_session_manager()
+    session_id = _decode_refresh_token_session_id(refresh_token, sm)
+    try:
+        await sm.revoke_session(session_id)
+    except Exception as exc:  # fail-open on logout
+        logger.warning("sso.okta.logout.revoke_failed", extra={"error": str(exc)})
+    _clear_refresh_cookie(response)
+
+
+@router.get("/okta/me", response_model=SSOSessionResponse, summary="Get current Okta SSO session")
+async def okta_me(
+    request: Request,
+    access_token: str = Depends(_get_sso_access_token),
+) -> SSOSessionResponse:
+    """Return current SSO session information from the access token."""
+    sm = _get_session_manager()
+    session = await sm.validate_session(access_token)
+    if not session:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired session")
+    return SSOSessionResponse(
+        user_id=session.user_id,
+        email=session.email,
+        provider="okta",
+        session_id=session.session_id,
+        expires_at=session.expires_at.isoformat() if hasattr(session, "expires_at") else "",
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# AZURE AD ROUTES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@router.get("/azure/authorize", summary="Redirect to Azure AD authorization endpoint")
+async def azure_authorize(request: Request) -> RedirectResponse:
+    """Generate CSRF state and redirect to Azure AD."""
+    try:
+        provider = _get_azure_provider()
+        state = _generate_state()
+        _store_state(request, state)
+        auth_url = provider.get_authorization_url(state=state)
+        logger.info("sso.azure.authorize", extra={"ip": request.client.host if request.client else "unknown"})
+        return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
+    except (ValueError, KeyError) as exc:
+        logger.error("sso.azure.authorize.error", extra={"error": str(exc)})
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Azure SSO not configured")
+
+
+@router.get("/azure/callback", response_model=SSOTokenResponse, summary="Handle Azure AD OAuth callback")
+async def azure_callback(
+    code: str,
+    state: str,
+    request: Request,
+    response: Response,
+) -> SSOTokenResponse:
+    """Validate CSRF state, exchange code for tokens, create session."""
+    stored_state = _pop_state(request)
+    if not stored_state or not _verify_state(state, stored_state):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid state parameter")
+
+    try:
+        provider = _get_azure_provider()
+        tokens = provider.exchange_code_for_tokens(code)
+        user_info = provider.get_user_info(tokens["access_token"])
+    except Exception as exc:
+        logger.error("sso.azure.callback.error", extra={"error": str(exc)})
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Azure token exchange failed")
+
+    email = user_info.get("email") or user_info.get("preferred_username", "")
+    sub = user_info.get("sub", "")
+
+    sm = _get_session_manager()
+    token_pair = await sm.create_session(
+        user_id=sub,
+        email=email,
+        identity_provider="azure",
+        auth_method="oidc",
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    _set_refresh_cookie(response, token_pair.refresh_token)
+    logger.info("sso.azure.callback.success", extra={"sub": sub})
+    return SSOTokenResponse(
+        access_token=token_pair.access_token,
+        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+        provider="azure",
+        email=email,
+        name=user_info.get("name"),
+    )
+
+
+@router.post("/azure/refresh", response_model=SSORefreshResponse, summary="Refresh Azure SSO session")
+async def azure_refresh(
+    response: Response,
+    refresh_token: str = Depends(_get_sso_refresh_token),
+) -> SSORefreshResponse:
+    sm = _get_session_manager()
+    token_pair = await sm.refresh_session(refresh_token)
+    if not token_pair:
+        logger.warning("sso.azure.refresh.failed")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired refresh token")
+
+    _set_refresh_cookie(response, token_pair.refresh_token)
+    return SSORefreshResponse(
+        access_token=token_pair.access_token,
+        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+    )
+
+
+@router.post("/azure/logout", status_code=status.HTTP_204_NO_CONTENT, summary="Logout from Azure SSO")
+async def azure_logout(
+    response: Response,
+    refresh_token: str = Depends(_get_sso_refresh_token),
+) -> None:
+    sm = _get_session_manager()
+    session_id = _decode_refresh_token_session_id(refresh_token, sm)
+    try:
+        await sm.revoke_session(session_id)
+    except Exception as exc:
+        logger.warning("sso.azure.logout.revoke_failed", extra={"error": str(exc)})
+    _clear_refresh_cookie(response)
+
+
+@router.get("/azure/me", response_model=SSOSessionResponse, summary="Get current Azure SSO session")
+async def azure_me(
+    request: Request,
+    access_token: str = Depends(_get_sso_access_token),
+) -> SSOSessionResponse:
+    sm = _get_session_manager()
+    session = await sm.validate_session(access_token)
+    if not session:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired session")
+    return SSOSessionResponse(
+        user_id=session.user_id,
+        email=session.email,
+        provider="azure",
+        session_id=session.session_id,
+        expires_at=session.expires_at.isoformat() if hasattr(session, "expires_at") else "",
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GOOGLE WORKSPACE ROUTES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@router.get("/google/authorize", summary="Redirect to Google authorization endpoint")
+async def google_authorize(request: Request) -> RedirectResponse:
+    """Generate CSRF state and redirect to Google OAuth."""
+    try:
+        provider = _get_google_provider()
+        state = _generate_state()
+        _store_state(request, state)
+        auth_url = provider.get_authorization_url(state=state)
+        logger.info("sso.google.authorize", extra={"ip": request.client.host if request.client else "unknown"})
+        return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
+    except (ValueError, KeyError) as exc:
+        logger.error("sso.google.authorize.error", extra={"error": str(exc)})
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Google SSO not configured")
+
+
+@router.get("/google/callback", response_model=SSOTokenResponse, summary="Handle Google OAuth callback")
+async def google_callback(
+    code: str,
+    state: str,
+    request: Request,
+    response: Response,
+) -> SSOTokenResponse:
+    """Validate CSRF state, exchange code for tokens, create session."""
+    stored_state = _pop_state(request)
+    if not stored_state or not _verify_state(state, stored_state):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid state parameter")
+
+    try:
+        provider = _get_google_provider()
+        tokens = provider.exchange_code_for_tokens(code)
+        user_info = provider.get_user_info(tokens["access_token"])
+    except Exception as exc:
+        logger.error("sso.google.callback.error", extra={"error": str(exc)})
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Google token exchange failed")
+
+    email = user_info.get("email", "")
+    sub = user_info.get("sub", "")
+
+    sm = _get_session_manager()
+    token_pair = await sm.create_session(
+        user_id=sub,
+        email=email,
+        identity_provider="google",
+        auth_method="oidc",
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    _set_refresh_cookie(response, token_pair.refresh_token)
+    logger.info("sso.google.callback.success", extra={"sub": sub})
+    return SSOTokenResponse(
+        access_token=token_pair.access_token,
+        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+        provider="google",
+        email=email,
+        name=user_info.get("name"),
+    )
+
+
+@router.post("/google/refresh", response_model=SSORefreshResponse, summary="Refresh Google SSO session")
+async def google_refresh(
+    response: Response,
+    refresh_token: str = Depends(_get_sso_refresh_token),
+) -> SSORefreshResponse:
+    sm = _get_session_manager()
+    token_pair = await sm.refresh_session(refresh_token)
+    if not token_pair:
+        logger.warning("sso.google.refresh.failed")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired refresh token")
+
+    _set_refresh_cookie(response, token_pair.refresh_token)
+    return SSORefreshResponse(
+        access_token=token_pair.access_token,
+        expires_in=settings.SSO_SESSION_TTL_SECONDS,
+    )
+
+
+@router.post("/google/logout", status_code=status.HTTP_204_NO_CONTENT, summary="Logout from Google SSO")
+async def google_logout(
+    response: Response,
+    refresh_token: str = Depends(_get_sso_refresh_token),
+) -> None:
+    sm = _get_session_manager()
+    session_id = _decode_refresh_token_session_id(refresh_token, sm)
+    try:
+        await sm.revoke_session(session_id)
+    except Exception as exc:
+        logger.warning("sso.google.logout.revoke_failed", extra={"error": str(exc)})
+    _clear_refresh_cookie(response)
+
+
+@router.get("/google/me", response_model=SSOSessionResponse, summary="Get current Google SSO session")
+async def google_me(
+    request: Request,
+    access_token: str = Depends(_get_sso_access_token),
+) -> SSOSessionResponse:
+    sm = _get_session_manager()
+    session = await sm.validate_session(access_token)
+    if not session:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired session")
+    return SSOSessionResponse(
+        user_id=session.user_id,
+        email=session.email,
+        provider="google",
+        session_id=session.session_id,
+        expires_at=session.expires_at.isoformat() if hasattr(session, "expires_at") else "",
+    )

--- a/portal/routers/tests/__init__.py
+++ b/portal/routers/tests/__init__.py
@@ -1,0 +1,1 @@
+# Router tests package

--- a/portal/routers/tests/test_sso_routes.py
+++ b/portal/routers/tests/test_sso_routes.py
@@ -1,0 +1,612 @@
+"""
+Phase 21B — SSO Route Tests
+
+Tests all five endpoints for each of the three providers:
+  authorize, callback, refresh, logout, me
+
+Coverage:
+  - Happy path for each route
+  - CSRF state mismatch → 400
+  - Missing refresh cookie → 401
+  - Missing/invalid Bearer token → 401
+  - IdP exchange failure → 502
+  - Unconfigured provider → 503
+  - Refresh token rotation
+  - Logout clears cookie
+  - validate_session returns None → 401
+  - Cookie security attributes (HttpOnly, SameSite)
+"""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.sessions import SessionMiddleware
+
+from portal.routers.sso import router as sso_router
+from portal.sso.session_models import TokenPair, SessionData
+
+
+# ── App factory ───────────────────────────────────────────────────────────────
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test-secret-key-for-testing-only")
+    app.include_router(sso_router, prefix="/api/v1/sso")
+    return app
+
+
+@pytest.fixture
+def client():
+    app = _make_app()
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+# ── Shared test data ──────────────────────────────────────────────────────────
+
+def _make_token_pair() -> TokenPair:
+    return TokenPair(
+        access_token="test-access-token-abc123",
+        refresh_token="test-refresh-token-xyz789",
+    )
+
+
+def _make_session_data(provider: str = "okta") -> SessionData:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return SessionData(
+        session_id="sess-001",
+        user_id="user-sub-001",
+        email="test@example.com",
+        issuer="https://portal.sintraprime.ai",
+        audience="sintraprime-portal",
+        created_at=now,
+        expires_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+        identity_provider=provider,
+        auth_method="oidc",
+    )
+
+
+# ── Mock settings ─────────────────────────────────────────────────────────────
+
+MOCK_SETTINGS = MagicMock()
+MOCK_SETTINGS.SSO_SESSION_SECRET = "test-sso-secret-256-bit-key-here"
+MOCK_SETTINGS.SSO_ISSUER = "https://portal.sintraprime.ai"
+MOCK_SETTINGS.SSO_AUDIENCE = "sintraprime-portal"
+MOCK_SETTINGS.SSO_SESSION_TTL_SECONDS = 3600
+MOCK_SETTINGS.SSO_REFRESH_TTL_SECONDS = 2592000
+MOCK_SETTINGS.OKTA_DOMAIN = "dev-test.okta.com"
+MOCK_SETTINGS.OKTA_CLIENT_ID = "test-okta-client-id"
+MOCK_SETTINGS.OKTA_CLIENT_SECRET = "test-okta-client-secret"
+MOCK_SETTINGS.OKTA_REDIRECT_URI = "https://portal.sintraprime.ai/api/v1/sso/okta/callback"
+MOCK_SETTINGS.OKTA_SCOPES = "openid email profile offline_access"
+MOCK_SETTINGS.AZURE_TENANT_ID = "test-azure-tenant-id"
+MOCK_SETTINGS.AZURE_CLIENT_ID = "test-azure-client-id"
+MOCK_SETTINGS.AZURE_CLIENT_SECRET = "test-azure-client-secret"
+MOCK_SETTINGS.AZURE_REDIRECT_URI = "https://portal.sintraprime.ai/api/v1/sso/azure/callback"
+MOCK_SETTINGS.GOOGLE_CLIENT_ID = "test-google-client-id"
+MOCK_SETTINGS.GOOGLE_CLIENT_SECRET = "test-google-client-secret"
+MOCK_SETTINGS.GOOGLE_REDIRECT_URI = "https://portal.sintraprime.ai/api/v1/sso/google/callback"
+MOCK_SETTINGS.GOOGLE_HOSTED_DOMAIN = ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CSRF / STATE TESTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCSRFProtection:
+    """State parameter validation is the same for all three providers."""
+
+    @pytest.mark.parametrize("provider", ["okta", "azure", "google"])
+    def test_callback_rejects_missing_state(self, client, provider):
+        """Callback with no stored state returns 400."""
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._pop_state", return_value=None):
+            resp = client.get(
+                f"/api/v1/sso/{provider}/callback",
+                params={"code": "auth-code-123", "state": "attacker-state"},
+                follow_redirects=False,
+            )
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize("provider", ["okta", "azure", "google"])
+    def test_callback_rejects_mismatched_state(self, client, provider):
+        """Callback with wrong state returns 400."""
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._pop_state", return_value="correct-state-value"):
+            resp = client.get(
+                f"/api/v1/sso/{provider}/callback",
+                params={"code": "auth-code-123", "state": "wrong-state-value"},
+                follow_redirects=False,
+            )
+        assert resp.status_code == 400
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MISSING COOKIE / TOKEN TESTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestMissingCredentials:
+    """Routes that require a cookie or Bearer token return 401 when absent."""
+
+    @pytest.mark.parametrize("provider", ["okta", "azure", "google"])
+    def test_refresh_without_cookie_returns_401(self, client, provider):
+        resp = client.post(f"/api/v1/sso/{provider}/refresh")
+        assert resp.status_code == 401
+
+    @pytest.mark.parametrize("provider", ["okta", "azure", "google"])
+    def test_logout_without_cookie_returns_401(self, client, provider):
+        resp = client.post(f"/api/v1/sso/{provider}/logout")
+        assert resp.status_code == 401
+
+    @pytest.mark.parametrize("provider", ["okta", "azure", "google"])
+    def test_me_without_bearer_returns_401(self, client, provider):
+        resp = client.get(f"/api/v1/sso/{provider}/me")
+        assert resp.status_code == 401
+
+    @pytest.mark.parametrize("provider", ["okta", "azure", "google"])
+    def test_me_with_invalid_bearer_returns_401(self, client, provider):
+        resp = client.get(
+            f"/api/v1/sso/{provider}/me",
+            headers={"Authorization": "NotBearer token"},
+        )
+        assert resp.status_code == 401
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# OKTA ROUTES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestOktaAuthorize:
+    def test_authorize_redirects_to_okta(self, client):
+        mock_provider = MagicMock()
+        mock_provider.get_authorization_url.return_value = (
+            "https://dev-test.okta.com/oauth2/v1/authorize?client_id=test&state=abc",
+            "abc",
+        )
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_okta_provider", return_value=mock_provider):
+            resp = client.get("/api/v1/sso/okta/authorize", follow_redirects=False)
+        assert resp.status_code == 302
+        assert "okta.com" in resp.headers["location"]
+
+    def test_authorize_503_when_not_configured(self, client):
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_okta_provider", side_effect=ValueError("missing config")):
+            resp = client.get("/api/v1/sso/okta/authorize", follow_redirects=False)
+        assert resp.status_code == 503
+
+
+class TestOktaCallback:
+    def test_callback_happy_path(self, client):
+        state = "valid-csrf-state"
+        mock_token_resp = MagicMock()
+        mock_token_resp.access_token = "okta-access-token"
+        mock_user_info = MagicMock()
+        mock_user_info.sub = "okta-sub-001"
+        mock_user_info.email = "user@example.com"
+        mock_user_info.preferred_username = "user@example.com"
+        mock_provider = AsyncMock()
+        mock_provider.config = MagicMock()
+        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
+        mock_provider.__aexit__ = AsyncMock(return_value=False)
+        mock_provider.exchange_code_for_token = AsyncMock(return_value=mock_token_resp)
+        mock_provider.get_user_info = AsyncMock(return_value=mock_user_info)
+        mock_sm = AsyncMock()
+        mock_sm.create_session = AsyncMock(return_value=_make_token_pair())
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._pop_state", return_value=state), \
+             patch("portal.routers.sso.OktaProvider", return_value=mock_provider), \
+             patch("portal.routers.sso._get_okta_provider", return_value=mock_provider), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.get(
+                "/api/v1/sso/okta/callback",
+                params={"code": "auth-code", "state": state},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["provider"] == "okta"
+        assert body["access_token"] == "test-access-token-abc123"
+        assert "sso_refresh_token" in resp.cookies
+
+    def test_callback_502_on_exchange_failure(self, client):
+        state = "valid-csrf-state-2"
+        mock_provider = AsyncMock()
+        mock_provider.config = MagicMock()
+        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
+        mock_provider.__aexit__ = AsyncMock(return_value=False)
+        mock_provider.exchange_code_for_token = AsyncMock(side_effect=ValueError("token exchange failed"))
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._pop_state", return_value=state), \
+             patch("portal.routers.sso.OktaProvider", return_value=mock_provider), \
+             patch("portal.routers.sso._get_okta_provider", return_value=mock_provider):
+            resp = client.get(
+                "/api/v1/sso/okta/callback",
+                params={"code": "bad-code", "state": state},
+            )
+        assert resp.status_code == 502
+
+
+class TestOktaRefresh:
+    def test_refresh_happy_path(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.refresh_session = AsyncMock(return_value=_make_token_pair())
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.post(
+                "/api/v1/sso/okta/refresh",
+                cookies={"sso_refresh_token": "valid-refresh-token"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["access_token"] == "test-access-token-abc123"
+        assert "sso_refresh_token" in resp.cookies
+
+    def test_refresh_401_on_invalid_token(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.refresh_session = AsyncMock(return_value=None)
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.post(
+                "/api/v1/sso/okta/refresh",
+                cookies={"sso_refresh_token": "expired-token"},
+            )
+        assert resp.status_code == 401
+
+
+class TestOktaLogout:
+    def test_logout_clears_cookie(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.jwt_service = MagicMock()
+        mock_sm.jwt_service.validate_token = MagicMock(return_value={"session_id": "sess-001"})
+        mock_sm.revoke_session = AsyncMock(return_value=True)
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.post(
+                "/api/v1/sso/okta/logout",
+                cookies={"sso_refresh_token": "valid-refresh-token"},
+            )
+        assert resp.status_code == 204
+
+
+class TestOktaMe:
+    def test_me_returns_session_info(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.validate_session = AsyncMock(return_value=_make_session_data("okta"))
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.get(
+                "/api/v1/sso/okta/me",
+                headers={"Authorization": "Bearer valid-access-token"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["provider"] == "okta"
+        assert body["email"] == "test@example.com"
+        assert body["user_id"] == "user-sub-001"
+
+    def test_me_401_on_invalid_session(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.validate_session = AsyncMock(return_value=None)
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.get(
+                "/api/v1/sso/okta/me",
+                headers={"Authorization": "Bearer invalid-token"},
+            )
+        assert resp.status_code == 401
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# AZURE ROUTES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestAzureAuthorize:
+    def test_authorize_redirects(self, client):
+        mock_provider = MagicMock()
+        mock_provider.get_authorization_url.return_value = (
+            "https://login.microsoftonline.com/tenant/oauth2/v2.0/authorize?state=abc"
+        )
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_azure_provider", return_value=mock_provider):
+            resp = client.get("/api/v1/sso/azure/authorize", follow_redirects=False)
+        assert resp.status_code == 302
+        assert "microsoftonline.com" in resp.headers["location"]
+
+    def test_authorize_503_when_not_configured(self, client):
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_azure_provider", side_effect=ValueError("missing")):
+            resp = client.get("/api/v1/sso/azure/authorize", follow_redirects=False)
+        assert resp.status_code == 503
+
+
+class TestAzureCallback:
+    def test_callback_happy_path(self, client):
+        state = "azure-csrf-state"
+        mock_provider = MagicMock()
+        mock_provider.exchange_code_for_tokens.return_value = {"access_token": "azure-at"}
+        mock_provider.get_user_info.return_value = {
+            "sub": "azure-sub-001",
+            "email": "user@contoso.com",
+            "name": "Test User",
+        }
+        mock_sm = AsyncMock()
+        mock_sm.create_session = AsyncMock(return_value=_make_token_pair())
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._pop_state", return_value=state), \
+             patch("portal.routers.sso._get_azure_provider", return_value=mock_provider), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.get(
+                "/api/v1/sso/azure/callback",
+                params={"code": "auth-code", "state": state},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["provider"] == "azure"
+        assert body["email"] == "user@contoso.com"
+
+    def test_callback_502_on_exchange_failure(self, client):
+        state = "azure-csrf-state-2"
+        mock_provider = MagicMock()
+        mock_provider.exchange_code_for_tokens.side_effect = Exception("Azure error")
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._pop_state", return_value=state), \
+             patch("portal.routers.sso._get_azure_provider", return_value=mock_provider):
+            resp = client.get(
+                "/api/v1/sso/azure/callback",
+                params={"code": "bad-code", "state": state},
+            )
+        assert resp.status_code == 502
+
+
+class TestAzureRefresh:
+    def test_refresh_happy_path(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.refresh_session = AsyncMock(return_value=_make_token_pair())
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.post(
+                "/api/v1/sso/azure/refresh",
+                cookies={"sso_refresh_token": "valid-refresh-token"},
+            )
+        assert resp.status_code == 200
+
+    def test_refresh_401_on_none(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.refresh_session = AsyncMock(return_value=None)
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.post(
+                "/api/v1/sso/azure/refresh",
+                cookies={"sso_refresh_token": "expired"},
+            )
+        assert resp.status_code == 401
+
+
+class TestAzureLogout:
+    def test_logout_204(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.jwt_service = MagicMock()
+        mock_sm.jwt_service.validate_token = MagicMock(return_value={"session_id": "sess-002"})
+        mock_sm.revoke_session = AsyncMock(return_value=True)
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.post(
+                "/api/v1/sso/azure/logout",
+                cookies={"sso_refresh_token": "valid-token"},
+            )
+        assert resp.status_code == 204
+
+
+class TestAzureMe:
+    def test_me_happy_path(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.validate_session = AsyncMock(return_value=_make_session_data("azure"))
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.get(
+                "/api/v1/sso/azure/me",
+                headers={"Authorization": "Bearer valid-access-token"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["provider"] == "azure"
+
+    def test_me_401_on_invalid(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.validate_session = AsyncMock(return_value=None)
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.get(
+                "/api/v1/sso/azure/me",
+                headers={"Authorization": "Bearer bad-token"},
+            )
+        assert resp.status_code == 401
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GOOGLE ROUTES
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestGoogleAuthorize:
+    def test_authorize_redirects(self, client):
+        mock_provider = MagicMock()
+        mock_provider.get_authorization_url.return_value = (
+            "https://accounts.google.com/o/oauth2/v2/auth?state=abc"
+        )
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_google_provider", return_value=mock_provider):
+            resp = client.get("/api/v1/sso/google/authorize", follow_redirects=False)
+        assert resp.status_code == 302
+        assert "google.com" in resp.headers["location"]
+
+    def test_authorize_503_when_not_configured(self, client):
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_google_provider", side_effect=ValueError("missing")):
+            resp = client.get("/api/v1/sso/google/authorize", follow_redirects=False)
+        assert resp.status_code == 503
+
+
+class TestGoogleCallback:
+    def test_callback_happy_path(self, client):
+        state = "google-csrf-state"
+        mock_provider = MagicMock()
+        mock_provider.exchange_code_for_tokens.return_value = {"access_token": "google-at"}
+        mock_provider.get_user_info.return_value = {
+            "sub": "google-sub-001",
+            "email": "user@gmail.com",
+            "name": "Google User",
+        }
+        mock_sm = AsyncMock()
+        mock_sm.create_session = AsyncMock(return_value=_make_token_pair())
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._pop_state", return_value=state), \
+             patch("portal.routers.sso._get_google_provider", return_value=mock_provider), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.get(
+                "/api/v1/sso/google/callback",
+                params={"code": "auth-code", "state": state},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["provider"] == "google"
+        assert body["email"] == "user@gmail.com"
+
+    def test_callback_502_on_exchange_failure(self, client):
+        state = "google-csrf-state-2"
+        mock_provider = MagicMock()
+        mock_provider.exchange_code_for_tokens.side_effect = Exception("Google error")
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._pop_state", return_value=state), \
+             patch("portal.routers.sso._get_google_provider", return_value=mock_provider):
+            resp = client.get(
+                "/api/v1/sso/google/callback",
+                params={"code": "bad-code", "state": state},
+            )
+        assert resp.status_code == 502
+
+
+class TestGoogleRefresh:
+    def test_refresh_happy_path(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.refresh_session = AsyncMock(return_value=_make_token_pair())
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.post(
+                "/api/v1/sso/google/refresh",
+                cookies={"sso_refresh_token": "valid-refresh-token"},
+            )
+        assert resp.status_code == 200
+
+    def test_refresh_401_on_none(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.refresh_session = AsyncMock(return_value=None)
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.post(
+                "/api/v1/sso/google/refresh",
+                cookies={"sso_refresh_token": "expired"},
+            )
+        assert resp.status_code == 401
+
+
+class TestGoogleLogout:
+    def test_logout_204(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.jwt_service = MagicMock()
+        mock_sm.jwt_service.validate_token = MagicMock(return_value={"session_id": "sess-003"})
+        mock_sm.revoke_session = AsyncMock(return_value=True)
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.post(
+                "/api/v1/sso/google/logout",
+                cookies={"sso_refresh_token": "valid-token"},
+            )
+        assert resp.status_code == 204
+
+
+class TestGoogleMe:
+    def test_me_happy_path(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.validate_session = AsyncMock(return_value=_make_session_data("google"))
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.get(
+                "/api/v1/sso/google/me",
+                headers={"Authorization": "Bearer valid-access-token"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["provider"] == "google"
+
+    def test_me_401_on_invalid(self, client):
+        mock_sm = AsyncMock()
+        mock_sm.validate_session = AsyncMock(return_value=None)
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.get(
+                "/api/v1/sso/google/me",
+                headers={"Authorization": "Bearer bad-token"},
+            )
+        assert resp.status_code == 401
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# COOKIE SECURITY TESTS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCookieSecurity:
+    """Verify that the refresh cookie has the correct security attributes."""
+
+    def test_okta_callback_sets_httponly_samesite_cookie(self, client):
+        state = "cookie-test-state"
+        mock_token_resp = MagicMock()
+        mock_token_resp.access_token = "okta-at"
+        mock_user_info = MagicMock()
+        mock_user_info.sub = "sub-001"
+        mock_user_info.email = "user@example.com"
+        mock_user_info.preferred_username = "user@example.com"
+        mock_provider = AsyncMock()
+        mock_provider.config = MagicMock()
+        mock_provider.__aenter__ = AsyncMock(return_value=mock_provider)
+        mock_provider.__aexit__ = AsyncMock(return_value=False)
+        mock_provider.exchange_code_for_token = AsyncMock(return_value=mock_token_resp)
+        mock_provider.get_user_info = AsyncMock(return_value=mock_user_info)
+        mock_sm = AsyncMock()
+        mock_sm.create_session = AsyncMock(return_value=_make_token_pair())
+
+        with patch("portal.routers.sso.get_settings", return_value=MOCK_SETTINGS), \
+             patch("portal.routers.sso._pop_state", return_value=state), \
+             patch("portal.routers.sso.OktaProvider", return_value=mock_provider), \
+             patch("portal.routers.sso._get_okta_provider", return_value=mock_provider), \
+             patch("portal.routers.sso._get_session_manager", return_value=mock_sm):
+            resp = client.get(
+                "/api/v1/sso/okta/callback",
+                params={"code": "auth-code", "state": state},
+            )
+
+        assert resp.status_code == 200
+        assert "sso_refresh_token" in resp.cookies
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "httponly" in set_cookie.lower(), f"HttpOnly missing from: {set_cookie}"
+        assert "samesite" in set_cookie.lower(), f"SameSite missing from: {set_cookie}"

--- a/portal/sso/providers/azure.py
+++ b/portal/sso/providers/azure.py
@@ -1,0 +1,191 @@
+import hashlib
+import base64
+import json
+import requests
+from typing import Optional, List, Dict, Any
+from dataclasses import dataclass, field
+
+@dataclass
+class AzureConfig:
+    tenant_id: str
+    client_id: str
+    client_secret: str
+    redirect_uri: str
+    scopes: List[str] = field(default_factory=lambda: ["openid", "email", "profile"])
+
+    def __post_init__(self):
+        if not all([self.tenant_id, self.client_id, self.client_secret, self.redirect_uri]):
+            raise ValueError("AzureConfig: Missing required configuration parameters.")
+
+class AzureADProvider:
+    """
+    Azure AD B2C provider for OAuth2/OpenID Connect authentication.
+    """
+    def __init__(self, config: AzureConfig):
+        self.config = config
+        self.authority = f"https://login.microsoftonline.com/{self.config.tenant_id}/v2.0"
+        self.openid_config_url = f"{self.authority}/.well-known/openid-configuration"
+        self._openid_config = None
+        self._jwks = None
+
+    def _get_openid_config(self) -> Dict[str, Any]:
+        """
+        Retrieves the OpenID Connect configuration from Azure AD B2C.
+        """
+        if not self._openid_config:
+            response = requests.get(self.openid_config_url, timeout=10)
+            response.raise_for_status()
+            self._openid_config = response.json()
+        return self._openid_config
+
+    def get_authorization_url(self, state: str) -> str:
+        """
+        Generates the authorization URL for Azure AD B2C.
+
+        Args:
+            state: A unique value to prevent cross-site request forgery attacks.
+
+        Returns:
+            The authorization URL.
+        """
+        openid_config = self._get_openid_config()
+        auth_endpoint = openid_config["authorization_endpoint"]
+
+        # PKCE (Proof Key for Code Exchange) implementation
+        code_verifier = base64.urlsafe_b64encode(hashlib.sha256(self.config.client_secret.encode()).digest()).decode().rstrip("=")
+        code_challenge = base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest()).decode().rstrip("=")
+
+        params = {
+            "client_id": self.config.client_id,
+            "response_type": "code",
+            "redirect_uri": self.config.redirect_uri,
+            "scope": " ".join(self.config.scopes),
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+        from urllib.parse import urlencode
+        return f"{auth_endpoint}?{urlencode(params)}"
+
+    def exchange_code_for_tokens(self, code: str) -> Dict[str, Any]:
+        """
+        Exchanges the authorization code for access, ID, and refresh tokens.
+
+        Args:
+            code: The authorization code received from Azure AD B2C.
+
+        Returns:
+            A dictionary containing the tokens.
+        """
+        openid_config = self._get_openid_config()
+        token_endpoint = openid_config["token_endpoint"]
+
+        # PKCE (Proof Key for Code Exchange) implementation
+        code_verifier = base64.urlsafe_b64encode(hashlib.sha256(self.config.client_secret.encode()).digest()).decode().rstrip("=")
+
+        data = {
+            "client_id": self.config.client_id,
+            "client_secret": self.config.client_secret,
+            "code": code,
+            "redirect_uri": self.config.redirect_uri,
+            "grant_type": "authorization_code",
+            "code_verifier": code_verifier,
+        }
+        response = requests.post(token_endpoint, data=data, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def get_user_info(self, access_token: str) -> Dict[str, Any]:
+        """
+        Retrieves user information from Azure AD B2C.
+
+        Args:
+            access_token: The access token obtained after code exchange.
+
+        Returns:
+            A dictionary containing user information.
+        """
+        openid_config = self._get_openid_config()
+        userinfo_endpoint = openid_config["userinfo_endpoint"]
+
+        headers = {
+            "Authorization": f"Bearer {access_token}"
+        }
+        response = requests.get(userinfo_endpoint, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def get_jwks(self) -> Dict[str, Any]:
+        """
+        Retrieves the JSON Web Key Set (JWKS) from Azure AD B2C.
+
+        Returns:
+            A dictionary containing the JWKS.
+        """
+        if not self._jwks:
+            openid_config = self._get_openid_config()
+            jwks_uri = openid_config["jwks_uri"]
+            response = requests.get(jwks_uri, timeout=10)
+            response.raise_for_status()
+            self._jwks = response.json()
+        return self._jwks
+
+    def validate_id_token(self, id_token: str) -> Dict[str, Any]:
+        """
+        Validates the ID token received from Azure AD B2C.
+
+        Args:
+            id_token: The ID token to validate.
+
+        Returns:
+            A dictionary containing the decoded and validated ID token claims.
+        
+        Raises:
+            ValueError: If the token is invalid or validation fails.
+        """
+        from jose import jwt
+        from jose.exceptions import JWTError
+
+        jwks = self.get_jwks()
+        try:
+            # Azure AD B2C tokens often have a specific issuer format, e.g., https://<tenant_id>.b2clogin.com/<tenant_id>/v2.0/
+            # We need to be flexible with the issuer check.
+            # For simplicity, we\\'ll decode without issuer validation first and then manually check.
+            # A more robust solution would involve fetching the exact issuer from the openid-configuration.
+            decoded_header = jwt.get_unverified_header(id_token)
+            kid = decoded_header["kid"]
+
+            key = None
+            for jwk in jwks["keys"]:
+                if jwk["kid"] == kid:
+                    key = jwk
+                    break
+            
+            if not key:
+                raise ValueError("No matching JWK found for the ID token.")
+
+            # Reconstruct the issuer based on the tenant_id for validation
+            # This might need adjustment based on the exact Azure B2C setup
+            expected_issuer = self._get_openid_config()["issuer"]
+
+            options = {
+                "verify_signature": True,
+                "verify_aud": True,
+                "verify_exp": True,
+                "verify_iss": True,
+            }
+
+            # The audience (aud) claim should match the client_id
+            decoded_token = jwt.decode(
+                id_token,
+                key,
+                algorithms=["RS256"], # Azure B2C typically uses RS256
+                audience=self.config.client_id,
+                issuer=expected_issuer,
+                options=options
+            )
+            return decoded_token
+        except JWTError as e:
+            raise ValueError(f"ID token validation failed: {e}")
+        except Exception as e:
+            raise ValueError(f"An unexpected error occurred during ID token validation: {e}")

--- a/portal/sso/providers/google.py
+++ b/portal/sso/providers/google.py
@@ -1,0 +1,106 @@
+
+import requests
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.backends import default_backend
+from dataclasses import dataclass, field
+from typing import List, Dict, Any
+import time
+
+@dataclass
+class GoogleConfig:
+    client_id: str
+    client_secret: str
+    redirect_uri: str
+    hosted_domain: str = None
+    scopes: List[str] = field(default_factory=lambda: ["openid", "email", "profile"])
+
+    def __post_init__(self):
+        if not self.client_id:
+            raise ValueError("GoogleConfig: client_id is required")
+        if not self.client_secret:
+            raise ValueError("GoogleConfig: client_secret is required")
+        if not self.redirect_uri:
+            raise ValueError("GoogleConfig: redirect_uri is required")
+
+class GoogleWorkspaceProvider:
+    """Google Workspace SSO Provider"""
+
+    def __init__(self, config: GoogleConfig):
+        self.config = config
+        self.authorize_url = "https://accounts.google.com/o/oauth2/v2/auth"
+        self.token_url = "https://oauth2.googleapis.com/token"  # nosec B105 - public OAuth2 endpoint, not a password
+        self.userinfo_url = "https://openidconnect.googleapis.com/v1/userinfo"
+        self.jwks_url = "https://www.googleapis.com/oauth2/v3/certs"
+
+    def get_authorization_url(self, state: str) -> str:
+        """Constructs the Google authorization URL."""
+        params = {
+            "client_id": self.config.client_id,
+            "redirect_uri": self.config.redirect_uri,
+            "response_type": "code",
+            "scope": " ".join(self.config.scopes),
+            "access_type": "offline",
+            "state": state,
+            "prompt": "select_account",
+        }
+        if self.config.hosted_domain:
+            params["hd"] = self.config.hosted_domain
+        return f"{self.authorize_url}?{requests.compat.urlencode(params)}"
+
+    def exchange_code_for_tokens(self, code: str) -> Dict[str, Any]:
+        """Exchanges authorization code for access, ID, and refresh tokens."""
+        data = {
+            "code": code,
+            "client_id": self.config.client_id,
+            "client_secret": self.config.client_secret,
+            "redirect_uri": self.config.redirect_uri,
+            "grant_type": "authorization_code",
+        }
+        response = requests.post(self.token_url, data=data, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def get_user_info(self, access_token: str) -> Dict[str, Any]:
+        """Retrieves user information using the access token."""
+        headers = {
+            "Authorization": f"Bearer {access_token}"
+        }
+        response = requests.get(self.userinfo_url, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def validate_id_token(self, id_token: str) -> Dict[str, Any]:
+        """Validates the ID token and returns its claims."""
+        jwks_client = jwt.PyJWKClient(self.jwks_url)
+        signing_key = jwks_client.get_signing_key_from_jwt(id_token)
+
+        options = {
+            "verify_signature": True,
+            "verify_aud": True,
+            "verify_exp": True,
+            "verify_iat": True,
+            "verify_nbf": True,
+            "verify_iss": True,
+            "require_aud": True,
+            "require_exp": True,
+            "require_iat": True,
+            "require_nbf": True,
+            "require_iss": True,
+        }
+
+        decoded_token = jwt.decode(
+            id_token,
+            signing_key.key,
+            algorithms=["RS256"],
+            audience=self.config.client_id,
+            issuer="https://accounts.google.com",
+            options=options
+        )
+        return decoded_token
+
+    def verify_hosted_domain(self, id_token_claims: Dict[str, Any]) -> bool:
+        """Verifies if the hosted domain in the ID token matches the configured hosted domain."""
+        if self.config.hosted_domain:
+            return id_token_claims.get("hd") == self.config.hosted_domain
+        return True

--- a/portal/sso/tests/test_azure.py
+++ b/portal/sso/tests/test_azure.py
@@ -1,0 +1,394 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import json
+import requests
+import base64
+import hashlib
+from urllib.parse import urlparse, parse_qs, quote
+
+from portal.sso.providers.azure import AzureADProvider, AzureConfig
+
+class TestAzureADProvider(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_config = AzureConfig(
+            tenant_id="test_tenant_id",
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            redirect_uri="https://test.com/redirect",
+            scopes=["openid", "email", "profile"]
+        )
+        self.provider = AzureADProvider(self.mock_config)
+        self.mock_openid_config = {
+            "authorization_endpoint": "https://login.microsoftonline.com/test_tenant_id/oauth2/v2.0/authorize",
+            "token_endpoint": "https://login.microsoftonline.com/test_tenant_id/oauth2/v2.0/token",
+            "userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+            "jwks_uri": "https://login.microsoftonline.com/test_tenant_id/discovery/v2.0/keys",
+            "issuer": "https://login.microsoftonline.com/test_tenant_id/v2.0"
+        }
+        self.mock_jwks = {
+            "keys": [
+                {
+                    "kty": "RSA",
+                    "use": "sig",
+                    "kid": "test_kid",
+                    "x5t": "test_x5t",
+                    "n": "test_n",
+                    "e": "AQAB",
+                    "x5c": ["test_x5c"],
+                    "issuer": "test_issuer"
+                }
+            ]
+        }
+
+    def test_azure_config_validation(self):
+        with self.assertRaises(ValueError):
+            AzureConfig(tenant_id="", client_id="cid", client_secret="cs", redirect_uri="ru")
+        with self.assertRaises(ValueError):
+            AzureConfig(tenant_id="tid", client_id="", client_secret="cs", redirect_uri="ru")
+        with self.assertRaises(ValueError):
+            AzureConfig(tenant_id="tid", client_id="cid", client_secret="", redirect_uri="ru")
+        with self.assertRaises(ValueError):
+            AzureConfig(tenant_id="tid", client_id="cid", client_secret="cs", redirect_uri="")
+        # Should not raise error
+        AzureConfig(tenant_id="tid", client_id="cid", client_secret="cs", redirect_uri="ru")
+
+    @patch("requests.get")
+    def test_get_openid_config(self, mock_requests_get):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = self.mock_openid_config
+        mock_requests_get.return_value = mock_response
+
+        config = self.provider._get_openid_config()
+        self.assertEqual(config, self.mock_openid_config)
+        mock_requests_get.assert_called_once_with(self.provider.openid_config_url, timeout=10)
+
+        # Test caching
+        mock_requests_get.reset_mock()
+        config = self.provider._get_openid_config()
+        self.assertEqual(config, self.mock_openid_config)
+        mock_requests_get.assert_not_called()
+
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_get_authorization_url(self, mock_get_openid_config):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        state = "test_state"
+        auth_url = self.provider.get_authorization_url(state)
+
+        self.assertIn(self.mock_openid_config["authorization_endpoint"], auth_url)
+        self.assertIn(f"client_id={self.mock_config.client_id}", auth_url)
+        self.assertIn("response_type=code", auth_url)
+        quoted_redirect_uri = quote(self.mock_config.redirect_uri, safe="")
+        quoted_scopes = quote(" ".join(self.mock_config.scopes), safe="").replace("%20", "+")
+        self.assertIn(f"redirect_uri={quoted_redirect_uri}", auth_url)
+        self.assertIn(f"scope={quoted_scopes}", auth_url)
+        self.assertIn(f"state={state}", auth_url)
+        self.assertIn("code_challenge=", auth_url)
+        self.assertIn("code_challenge_method=S256", auth_url)
+
+        parsed_url = urlparse(auth_url)
+        query_params = parse_qs(parsed_url.query)
+        self.assertIn("code_challenge", query_params)
+        self.assertEqual(query_params["code_challenge_method"][0], "S256")
+
+        code_verifier = base64.urlsafe_b64encode(hashlib.sha256(self.mock_config.client_secret.encode()).digest()).decode().rstrip("=")
+        expected_code_challenge = base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest()).decode().rstrip("=")
+        self.assertEqual(query_params["code_challenge"][0], expected_code_challenge)
+
+    @patch("requests.post")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_exchange_code_for_tokens(self, mock_get_openid_config, mock_requests_post):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"access_token": "at", "id_token": "idt", "expires_in": 3600}
+        mock_requests_post.return_value = mock_response
+
+        code = "test_code"
+        tokens = self.provider.exchange_code_for_tokens(code)
+
+        self.assertEqual(tokens["access_token"], "at")
+        mock_requests_post.assert_called_once()
+        args, kwargs = mock_requests_post.call_args
+        self.assertEqual(args[0], self.mock_openid_config["token_endpoint"])
+        self.assertIn("client_id", kwargs["data"])
+        self.assertIn("client_secret", kwargs["data"])
+        self.assertIn("code", kwargs["data"])
+        self.assertIn("redirect_uri", kwargs["data"])
+        self.assertIn("grant_type", kwargs["data"])
+        self.assertIn("code_verifier", kwargs["data"])
+
+        code_verifier = base64.urlsafe_b64encode(hashlib.sha256(self.mock_config.client_secret.encode()).digest()).decode().rstrip("=")
+        self.assertEqual(kwargs["data"]["code_verifier"], code_verifier)
+
+    @patch("requests.get")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_get_user_info(self, mock_get_openid_config, mock_requests_get):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"sub": "123", "name": "Test User"}
+        mock_requests_get.return_value = mock_response
+
+        access_token = "test_access_token"
+        user_info = self.provider.get_user_info(access_token)
+
+        self.assertEqual(user_info["name"], "Test User")
+        mock_requests_get.assert_called_once_with(
+            self.mock_openid_config["userinfo_endpoint"],
+            headers={
+                "Authorization": f"Bearer {access_token}"
+            },
+            timeout=10,
+        )
+
+    @patch("requests.get")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_get_jwks(self, mock_get_openid_config, mock_requests_get):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = self.mock_jwks
+        mock_requests_get.return_value = mock_response
+
+        jwks = self.provider.get_jwks()
+        self.assertEqual(jwks, self.mock_jwks)
+        mock_requests_get.assert_called_once_with(self.mock_openid_config["jwks_uri"], timeout=10)
+
+        # Test caching
+        mock_requests_get.reset_mock()
+        jwks = self.provider.get_jwks()
+        self.assertEqual(jwks, self.mock_jwks)
+        mock_requests_get.assert_not_called()
+
+    @patch("portal.sso.providers.azure.AzureADProvider.get_jwks")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    @patch("jose.jwt.decode")
+    @patch("jose.jwt.get_unverified_header")
+    def test_validate_id_token_success(self, mock_get_unverified_header, mock_jwt_decode, mock_get_openid_config, mock_get_jwks):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_get_jwks.return_value = self.mock_jwks
+        mock_get_unverified_header.return_value = {"kid": "test_kid"}
+        mock_jwt_decode.return_value = {"sub": "123", "aud": "test_client_id", "iss": self.mock_openid_config["issuer"]}
+
+        id_token = "mock_id_token"
+        decoded_token = self.provider.validate_id_token(id_token)
+
+        self.assertEqual(decoded_token["sub"], "123")
+        mock_get_unverified_header.assert_called_once_with(id_token)
+        mock_get_jwks.assert_called_once()
+        mock_jwt_decode.assert_called_once()
+        args, kwargs = mock_jwt_decode.call_args
+        self.assertEqual(args[0], id_token)
+        self.assertEqual(kwargs["audience"], self.mock_config.client_id)
+        self.assertEqual(kwargs["issuer"], self.mock_openid_config["issuer"])
+
+    @patch("portal.sso.providers.azure.AzureADProvider.get_jwks")
+    @patch("jose.jwt.get_unverified_header")
+    def test_validate_id_token_no_matching_jwk(self, mock_get_unverified_header, mock_get_jwks):
+        mock_get_jwks.return_value = self.mock_jwks
+        mock_get_unverified_header.return_value = {"kid": "unknown_kid"}
+
+        id_token = "mock_id_token"
+        with self.assertRaisesRegex(ValueError, "No matching JWK found for the ID token."):
+            self.provider.validate_id_token(id_token)
+
+    @patch("portal.sso.providers.azure.AzureADProvider.get_jwks")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    @patch("jose.jwt.decode")
+    @patch("jose.jwt.get_unverified_header")
+    def test_validate_id_token_jwt_error(self, mock_get_unverified_header, mock_jwt_decode, mock_get_openid_config, mock_get_jwks):
+        from jose.exceptions import JWTError
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_get_jwks.return_value = self.mock_jwks
+        mock_get_unverified_header.return_value = {"kid": "test_kid"}
+        mock_jwt_decode.side_effect = JWTError("Invalid token")
+
+        id_token = "mock_id_token"
+        with self.assertRaisesRegex(ValueError, "ID token validation failed: Invalid token"):
+            self.provider.validate_id_token(id_token)
+
+    @patch("requests.get")
+    def test_get_openid_config_http_error(self, mock_requests_get):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Not Found")
+        mock_requests_get.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self.provider._get_openid_config()
+
+    @patch("requests.post")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_exchange_code_for_tokens_http_error(self, mock_get_openid_config, mock_requests_post):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("400 Bad Request")
+        mock_requests_post.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self.provider.exchange_code_for_tokens("test_code")
+
+    @patch("requests.get")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_get_user_info_http_error(self, mock_get_openid_config, mock_requests_get):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("401 Unauthorized")
+        mock_requests_get.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self.provider.get_user_info("test_access_token")
+
+    @patch("requests.get")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_get_jwks_http_error(self, mock_get_openid_config, mock_requests_get):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("500 Internal Server Error")
+        mock_requests_get.return_value = mock_response
+
+        self.provider._jwks = None # Clear cache to force API call
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self.provider.get_jwks()
+
+    @patch("portal.sso.providers.azure.AzureADProvider.get_jwks")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    @patch("jose.jwt.decode")
+    @patch("jose.jwt.get_unverified_header")
+    def test_validate_id_token_general_exception(self, mock_get_unverified_header, mock_jwt_decode, mock_get_openid_config, mock_get_jwks):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_get_jwks.return_value = self.mock_jwks
+        mock_get_unverified_header.side_effect = Exception("Something unexpected")
+
+        id_token = "mock_id_token"
+        with self.assertRaisesRegex(ValueError, "An unexpected error occurred during ID token validation: Something unexpected"):
+            self.provider.validate_id_token(id_token)
+
+    def test_azure_config_default_scopes(self):
+        config = AzureConfig(
+            tenant_id="tid",
+            client_id="cid",
+            client_secret="cs",
+            redirect_uri="ru"
+        )
+        self.assertEqual(config.scopes, ["openid", "email", "profile"])
+
+    def test_azure_config_custom_scopes(self):
+        custom_scopes = ["profile", "offline_access"]
+        config = AzureConfig(
+            tenant_id="tid",
+            client_id="cid",
+            client_secret="cs",
+            redirect_uri="ru",
+            scopes=custom_scopes
+        )
+        self.assertEqual(config.scopes, custom_scopes)
+
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_get_authorization_url_custom_scopes(self, mock_get_openid_config):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        custom_scopes = ["profile", "offline_access"]
+        self.mock_config.scopes = custom_scopes
+        provider = AzureADProvider(self.mock_config)
+        auth_url = provider.get_authorization_url("state")
+        quoted_custom_scopes = quote(" ".join(custom_scopes), safe="").replace("%20", "+")
+        self.assertIn(f"scope={quoted_custom_scopes}", auth_url)
+
+    @patch("requests.post")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_exchange_code_for_tokens_invalid_code(self, mock_get_openid_config, mock_requests_post):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("400 Invalid Grant")
+        mock_requests_post.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self.provider.exchange_code_for_tokens("invalid_code")
+
+    @patch("portal.sso.providers.azure.AzureADProvider.get_jwks")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    @patch("jose.jwt.decode")
+    @patch("jose.jwt.get_unverified_header")
+    def test_validate_id_token_invalid_audience(self, mock_get_unverified_header, mock_jwt_decode, mock_get_openid_config, mock_get_jwks):
+        from jose.exceptions import JWTError
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_get_jwks.return_value = self.mock_jwks
+        mock_get_unverified_header.return_value = {"kid": "test_kid"}
+        mock_jwt_decode.side_effect = JWTError("Invalid audience")
+
+        id_token = "mock_id_token"
+        with self.assertRaisesRegex(ValueError, "ID token validation failed: Invalid audience"):
+            self.provider.validate_id_token(id_token)
+
+    @patch("portal.sso.providers.azure.AzureADProvider.get_jwks")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    @patch("jose.jwt.decode")
+    @patch("jose.jwt.get_unverified_header")
+    def test_validate_id_token_invalid_issuer(self, mock_get_unverified_header, mock_jwt_decode, mock_get_openid_config, mock_get_jwks):
+        from jose.exceptions import JWTError
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_get_jwks.return_value = self.mock_jwks
+        mock_get_unverified_header.return_value = {"kid": "test_kid"}
+        mock_jwt_decode.side_effect = JWTError("Invalid issuer")
+
+        id_token = "mock_id_token"
+        with self.assertRaisesRegex(ValueError, "ID token validation failed: Invalid issuer"):
+            self.provider.validate_id_token(id_token)
+
+    @patch("portal.sso.providers.azure.AzureADProvider.get_jwks")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    @patch("jose.jwt.decode")
+    @patch("jose.jwt.get_unverified_header")
+    def test_validate_id_token_expired(self, mock_get_unverified_header, mock_jwt_decode, mock_get_openid_config, mock_get_jwks):
+        from jose.exceptions import ExpiredSignatureError
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_get_jwks.return_value = self.mock_jwks
+        mock_get_unverified_header.return_value = {"kid": "test_kid"}
+        mock_jwt_decode.side_effect = ExpiredSignatureError("Token expired")
+
+        id_token = "mock_id_token"
+        with self.assertRaisesRegex(ValueError, "ID token validation failed: Token expired"):
+            self.provider.validate_id_token(id_token)
+
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_authority_url_construction(self, mock_get_openid_config):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        expected_authority = f"https://login.microsoftonline.com/{self.mock_config.tenant_id}/v2.0"
+        self.assertEqual(self.provider.authority, expected_authority)
+
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_openid_config_url_construction(self, mock_get_openid_config):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        expected_openid_config_url = f"https://login.microsoftonline.com/{self.mock_config.tenant_id}/v2.0/.well-known/openid-configuration"
+        self.assertEqual(self.provider.openid_config_url, expected_openid_config_url)
+
+    @patch("requests.get")
+    def test_get_openid_config_connection_error(self, mock_requests_get):
+        mock_requests_get.side_effect = requests.exceptions.ConnectionError("Network unreachable")
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            self.provider._get_openid_config()
+
+    @patch("requests.post")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_exchange_code_for_tokens_connection_error(self, mock_get_openid_config, mock_requests_post):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_requests_post.side_effect = requests.exceptions.ConnectionError("Network unreachable")
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            self.provider.exchange_code_for_tokens("test_code")
+
+    @patch("requests.get")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_get_user_info_connection_error(self, mock_get_openid_config, mock_requests_get):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_requests_get.side_effect = requests.exceptions.ConnectionError("Network unreachable")
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            self.provider.get_user_info("test_access_token")
+
+    @patch("requests.get")
+    @patch("portal.sso.providers.azure.AzureADProvider._get_openid_config")
+    def test_get_jwks_connection_error(self, mock_get_openid_config, mock_requests_get):
+        mock_get_openid_config.return_value = self.mock_openid_config
+        mock_requests_get.side_effect = requests.exceptions.ConnectionError("Network unreachable")
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            self.provider.get_jwks()

--- a/portal/sso/tests/test_google.py
+++ b/portal/sso/tests/test_google.py
@@ -1,0 +1,380 @@
+
+import unittest
+from unittest.mock import patch, MagicMock
+import requests
+import jwt
+import time
+from portal.sso.providers.google import GoogleWorkspaceProvider, GoogleConfig
+
+class TestGoogleWorkspaceProvider(unittest.TestCase):
+
+    def setUp(self):
+        self.config = GoogleConfig(
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            redirect_uri="https://test.com/redirect",
+            hosted_domain="test.com"
+        )
+        self.provider = GoogleWorkspaceProvider(self.config)
+
+    def test_google_config_init_success(self):
+        """Test GoogleConfig initialization with valid parameters."""
+        config = GoogleConfig(
+            client_id="valid_client_id",
+            client_secret="valid_client_secret",
+            redirect_uri="https://valid.com/redirect"
+        )
+        self.assertIsInstance(config, GoogleConfig)
+        self.assertEqual(config.client_id, "valid_client_id")
+
+    def test_google_config_init_missing_client_id(self):
+        """Test GoogleConfig initialization raises ValueError for missing client_id."""
+        with self.assertRaises(ValueError) as cm:
+            GoogleConfig(client_id="", client_secret="secret", redirect_uri="uri")
+        self.assertIn("client_id is required", str(cm.exception))
+
+    def test_google_config_init_missing_client_secret(self):
+        """Test GoogleConfig initialization raises ValueError for missing client_secret."""
+        with self.assertRaises(ValueError) as cm:
+            GoogleConfig(client_id="id", client_secret="", redirect_uri="uri")
+        self.assertIn("client_secret is required", str(cm.exception))
+
+    def test_google_config_init_missing_redirect_uri(self):
+        """Test GoogleConfig initialization raises ValueError for missing redirect_uri."""
+        with self.assertRaises(ValueError) as cm:
+            GoogleConfig(client_id="id", client_secret="secret", redirect_uri="")
+        self.assertIn("redirect_uri is required", str(cm.exception))
+
+    def test_get_authorization_url_no_hosted_domain(self):
+        """Test get_authorization_url without hosted_domain."""
+        self.config.hosted_domain = None
+        url = self.provider.get_authorization_url("test_state")
+        self.assertIn("client_id=test_client_id", url)
+        self.assertIn("redirect_uri=https%3A%2F%2Ftest.com%2Fredirect", url)
+        self.assertIn("response_type=code", url)
+        self.assertIn("scope=openid+email+profile", url)
+        self.assertIn("state=test_state", url)
+        self.assertNotIn("hd=", url)
+
+    def test_get_authorization_url_with_hosted_domain(self):
+        """Test get_authorization_url with hosted_domain."""
+        url = self.provider.get_authorization_url("test_state")
+        self.assertIn("client_id=test_client_id", url)
+        self.assertIn("redirect_uri=https%3A%2F%2Ftest.com%2Fredirect", url)
+        self.assertIn("response_type=code", url)
+        self.assertIn("scope=openid+email+profile", url)
+        self.assertIn("state=test_state", url)
+        self.assertIn("hd=test.com", url)
+
+    @patch("requests.post")
+    def test_exchange_code_for_tokens_success(self, mock_post):
+        """Test exchange_code_for_tokens successfully retrieves tokens."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "test_access_token",
+            "id_token": "test_id_token",
+            "expires_in": 3600
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        tokens = self.provider.exchange_code_for_tokens("test_code")
+        self.assertEqual(tokens["access_token"], "test_access_token")
+        mock_post.assert_called_once()
+
+    @patch("requests.post")
+    def test_exchange_code_for_tokens_http_error(self, mock_post):
+        """Test exchange_code_for_tokens handles HTTP errors."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self.provider.exchange_code_for_tokens("test_code")
+
+    @patch("requests.get")
+    def test_get_user_info_success(self, mock_get):
+        """Test get_user_info successfully retrieves user information."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"email": "test@test.com", "name": "Test User"}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        user_info = self.provider.get_user_info("test_access_token")
+        self.assertEqual(user_info["email"], "test@test.com")
+        mock_get.assert_called_once()
+
+    @patch("requests.get")
+    def test_get_user_info_http_error(self, mock_get):
+        """Test get_user_info handles HTTP errors."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError
+        mock_get.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            self.provider.get_user_info("test_access_token")
+
+    @patch("jwt.PyJWKClient")
+    @patch("jwt.decode")
+    def test_validate_id_token_success(self, mock_jwt_decode, mock_pyjwk_client):
+        """Test validate_id_token successfully validates and decodes the token."""
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = "test_key"
+        mock_pyjwk_client.return_value.get_signing_key_from_jwt.return_value = mock_signing_key
+
+        mock_jwt_decode.return_value = {
+            "iss": "https://accounts.google.com",
+            "aud": "test_client_id",
+            "exp": time.time() + 3600,
+            "iat": time.time(),
+            "nbf": time.time(),
+            "hd": "test.com"
+        }
+
+        claims = self.provider.validate_id_token("test_id_token")
+        self.assertIn("iss", claims)
+        mock_jwt_decode.assert_called_once()
+
+    @patch("jwt.PyJWKClient")
+    @patch("jwt.decode")
+    def test_validate_id_token_invalid_signature(self, mock_jwt_decode, mock_pyjwk_client):
+        """Test validate_id_token handles invalid signature."""
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = "test_key"
+        mock_pyjwk_client.return_value.get_signing_key_from_jwt.return_value = mock_signing_key
+
+        mock_jwt_decode.side_effect = jwt.exceptions.InvalidSignatureError
+
+        with self.assertRaises(jwt.exceptions.InvalidSignatureError):
+            self.provider.validate_id_token("invalid_id_token")
+
+    @patch("jwt.PyJWKClient")
+    @patch("jwt.decode")
+    def test_validate_id_token_invalid_audience(self, mock_jwt_decode, mock_pyjwk_client):
+        """Test validate_id_token handles invalid audience."""
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = "test_key"
+        mock_pyjwk_client.return_value.get_signing_key_from_jwt.return_value = mock_signing_key
+
+        mock_jwt_decode.side_effect = jwt.exceptions.InvalidAudienceError
+
+        with self.assertRaises(jwt.exceptions.InvalidAudienceError):
+            self.provider.validate_id_token("invalid_id_token")
+
+    @patch("jwt.PyJWKClient")
+    @patch("jwt.decode")
+    def test_validate_id_token_invalid_issuer(self, mock_jwt_decode, mock_pyjwk_client):
+        """Test validate_id_token handles invalid issuer."""
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = "test_key"
+        mock_pyjwk_client.return_value.get_signing_key_from_jwt.return_value = mock_signing_key
+
+        mock_jwt_decode.side_effect = jwt.exceptions.InvalidIssuerError
+
+        with self.assertRaises(jwt.exceptions.InvalidIssuerError):
+            self.provider.validate_id_token("invalid_id_token")
+
+    def test_verify_hosted_domain_match(self):
+        """Test verify_hosted_domain when hosted_domain matches."""
+        claims = {"hd": "test.com"}
+        self.assertTrue(self.provider.verify_hosted_domain(claims))
+
+    def test_verify_hosted_domain_no_match(self):
+        """Test verify_hosted_domain when hosted_domain does not match."""
+        claims = {"hd": "other.com"}
+        self.assertFalse(self.provider.verify_hosted_domain(claims))
+
+    def test_verify_hosted_domain_no_config_hosted_domain(self):
+        """Test verify_hosted_domain when no hosted_domain is configured."""
+        self.config.hosted_domain = None
+        claims = {"hd": "test.com"}
+        self.assertTrue(self.provider.verify_hosted_domain(claims))
+
+    def test_verify_hosted_domain_no_hd_claim(self):
+        """Test verify_hosted_domain when 'hd' claim is missing."""
+        claims = {}
+        self.assertFalse(self.provider.verify_hosted_domain(claims))
+
+    def test_google_config_default_scopes(self):
+        """Test that default scopes are correctly set if not provided."""
+        config = GoogleConfig(
+            client_id="id",
+            client_secret="secret",
+            redirect_uri="uri"
+        )
+        self.assertEqual(config.scopes, ["openid", "email", "profile"])
+
+    def test_google_config_custom_scopes(self):
+        """Test that custom scopes are correctly set."""
+        config = GoogleConfig(
+            client_id="id",
+            client_secret="secret",
+            redirect_uri="uri",
+            scopes=["custom_scope"]
+        )
+        self.assertEqual(config.scopes, ["custom_scope"])
+
+    @patch("requests.post")
+    def test_exchange_code_for_tokens_data_sent_correctly(self, mock_post):
+        """Test that correct data is sent in exchange_code_for_tokens request."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"access_token": "token"}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        self.provider.exchange_code_for_tokens("test_code")
+        mock_post.assert_called_with(
+            self.provider.token_url,
+            data={
+                "code": "test_code",
+                "client_id": "test_client_id",
+                "client_secret": "test_client_secret",
+                "redirect_uri": "https://test.com/redirect",
+                "grant_type": "authorization_code",
+            },
+            timeout=10,
+        )
+
+    @patch("requests.get")
+    def test_get_user_info_headers_sent_correctly(self, mock_get):
+        """Test that correct headers are sent in get_user_info request."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"email": "test@test.com"}
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        self.provider.get_user_info("test_access_token")
+        mock_get.assert_called_with(
+            self.provider.userinfo_url,
+            headers={
+                "Authorization": "Bearer test_access_token"
+            },
+            timeout=10,
+        )
+
+    @patch("jwt.PyJWKClient")
+    @patch("jwt.decode")
+    def test_validate_id_token_jwt_decode_params(self, mock_jwt_decode, mock_pyjwk_client):
+        """Test that jwt.decode is called with correct parameters."""
+        mock_signing_key = MagicMock()
+        mock_signing_key.key = "test_key"
+        mock_pyjwk_client.return_value.get_signing_key_from_jwt.return_value = mock_signing_key
+
+        mock_jwt_decode.return_value = {
+            "iss": "https://accounts.google.com",
+            "aud": "test_client_id",
+            "exp": time.time() + 3600,
+            "iat": time.time(),
+            "nbf": time.time(),
+            "hd": "test.com"
+        }
+
+        self.provider.validate_id_token("test_id_token")
+        mock_jwt_decode.assert_called_once_with(
+            "test_id_token",
+            "test_key",
+            algorithms=["RS256"],
+            audience="test_client_id",
+            issuer="https://accounts.google.com",
+            options={
+                "verify_signature": True,
+                "verify_aud": True,
+                "verify_exp": True,
+                "verify_iat": True,
+                "verify_nbf": True,
+                "verify_iss": True,
+                "require_aud": True,
+                "require_exp": True,
+                "require_iat": True,
+                "require_nbf": True,
+                "require_iss": True,
+            }
+        )
+
+    def test_google_config_scopes_default_value(self):
+        """Test that scopes default to [\'openid\', \'email\', \'profile\'] if not provided."""
+        config = GoogleConfig(
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            redirect_uri="https://test.com/redirect"
+        )
+        self.assertEqual(config.scopes, ["openid", "email", "profile"])
+
+    def test_google_config_scopes_custom_value(self):
+        """Test that scopes can be overridden with custom values."""
+        custom_scopes = ["custom_scope1", "custom_scope2"]
+        config = GoogleConfig(
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            redirect_uri="https://test.com/redirect",
+            scopes=custom_scopes
+        )
+        self.assertEqual(config.scopes, custom_scopes)
+
+    def test_google_config_hosted_domain_default_value(self):
+        """Test that hosted_domain defaults to None if not provided."""
+        config = GoogleConfig(
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            redirect_uri="https://test.com/redirect"
+        )
+        self.assertIsNone(config.hosted_domain)
+
+    def test_google_config_hosted_domain_custom_value(self):
+        """Test that hosted_domain can be overridden with a custom value."""
+        config = GoogleConfig(
+            client_id="test_client_id",
+            client_secret="test_client_secret",
+            redirect_uri="https://test.com/redirect",
+            hosted_domain="custom.com"
+        )
+        self.assertEqual(config.hosted_domain, "custom.com")
+
+    def test_verify_hosted_domain_with_none_config_hosted_domain(self):
+        """Test verify_hosted_domain returns True when config.hosted_domain is None."""
+        self.config.hosted_domain = None
+        claims = {"hd": "any.com"}
+        self.assertTrue(self.provider.verify_hosted_domain(claims))
+
+    def test_verify_hosted_domain_with_empty_config_hosted_domain(self):
+        """Test verify_hosted_domain returns True when config.hosted_domain is an empty string."""
+        self.config.hosted_domain = ""
+        claims = {"hd": "any.com"}
+        self.assertTrue(self.provider.verify_hosted_domain(claims))
+
+    def test_verify_hosted_domain_with_matching_hd_claim(self):
+        """Test verify_hosted_domain returns True when config.hosted_domain matches 'hd' claim."""
+        self.config.hosted_domain = "example.com"
+        claims = {"hd": "example.com"}
+        self.assertTrue(self.provider.verify_hosted_domain(claims))
+
+    def test_verify_hosted_domain_with_mismatching_hd_claim(self):
+        """Test verify_hosted_domain returns False when config.hosted_domain mismatches 'hd' claim."""
+        self.config.hosted_domain = "example.com"
+        claims = {"hd": "wrong.com"}
+        self.assertFalse(self.provider.verify_hosted_domain(claims))
+
+    def test_verify_hosted_domain_with_missing_hd_claim(self):
+        """Test verify_hosted_domain returns False when 'hd' claim is missing and hosted_domain is configured."""
+        self.config.hosted_domain = "example.com"
+        claims = {}
+        self.assertFalse(self.provider.verify_hosted_domain(claims))
+
+    def test_get_authorization_url_scopes_format(self):
+        """Test that scopes are correctly formatted in the authorization URL."""
+        self.config.scopes = ["scope1", "scope2"]
+        url = self.provider.get_authorization_url("test_state")
+        self.assertIn("scope=scope1+scope2", url)
+
+    def test_get_authorization_url_prompt_select_account(self):
+        """Test that 'prompt=select_account' is included in the authorization URL."""
+        url = self.provider.get_authorization_url("test_state")
+        self.assertIn("prompt=select_account", url)
+
+    def test_get_authorization_url_access_type_offline(self):
+        """Test that 'access_type=offline' is included in the authorization URL."""
+        url = self.provider.get_authorization_url("test_state")
+        self.assertIn("access_type=offline", url)
+
+
+


### PR DESCRIPTION
## Phase 21B: SSO Route Registration

### Summary
Wires the three SSO provider modules (Okta, Azure, Google) from Phase 21A into FastAPI, exposing five HTTP endpoints per provider.

### Endpoints Added (15 total)
| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/v1/sso/{provider}/authorize` | Generate CSRF state, redirect to IdP |
| GET | `/api/v1/sso/{provider}/callback` | Validate state, exchange code, create session |
| POST | `/api/v1/sso/{provider}/refresh` | Rotate refresh token via SessionManager |
| POST | `/api/v1/sso/{provider}/logout` | Revoke session, delete cookie |
| GET | `/api/v1/sso/{provider}/me` | Bearer-token session introspection |

### Security
- **CSRF protection**: State token stored in signed Starlette session cookie; validated with `hmac.compare_digest` (constant-time)
- **Secure cookie**: Refresh token delivered as `HttpOnly`, `SameSite=Lax`, `Secure` cookie
- **Bearer auth**: `/me` requires `Authorization: Bearer <access_token>`; missing/malformed → 401
- **Error codes**: Unconfigured provider → 503; IdP exchange failure → 502; bad state → 400

### Test Results
- **46/46** route tests passing (`portal/routers/tests/test_sso_routes.py`)
- **155/155** total SSO tests passing (routes + all three provider modules)
- **0 bandit issues** (B106 nosec on `token_type='refresh'` string literal)

### Files Changed
- `portal/routers/sso.py` — new SSO router (15 endpoints, ~560 LOC)
- `portal/routers/tests/test_sso_routes.py` — 46 tests covering all routes
- `portal/config.py` — added SSO settings block
- `portal/main.py` — registered SSO router at `/api/v1/sso`
- `.env.example` — added all SSO environment variable placeholders

### Head Commit
`5643a50`