### PR TITLE
fix(p0): restore SSO router boot path

### DIFF
--- a/ops/receipts/P0-sso-router-boot.md
+++ b/ops/receipts/P0-sso-router-boot.md
@@ -1,0 +1,47 @@
+# P0 SSO Router Boot Repair Receipt
+
+## Branch
+
+`fix/p0-sso-router-boot`
+
+## Problem
+
+Current `main` was boot-blocked by invalid SSO router syntax and import/runtime mismatches in `portal/main.py`.
+
+Observed blockers:
+
+- `portal/routers/sso.py` contained invalid Python: `@Hfrom_fastapi.default_corass`.
+- `portal/main.py` imported local middleware/security/router modules that are not present in the repository:
+  - `portal.middleware.session_middleware`
+  - `portal.middleware.timestamp_middleware`
+  - `portal.security.security_layer`
+  - `portal.routers.webhooks`
+- `portal/main.py` defined `lifespan()` but did not pass it to `FastAPI(...)`.
+- `JWTTokenService` was initialized with a raw string even though it expects `SessionConfig`.
+- `SessionConfig` was constructed with `session_timeout_seconds`, which does not exist.
+
+## Changes Applied
+
+- Rewrote `portal/main.py` to use only present boot-safe imports.
+- Switched SSO session middleware to Starlette's `SessionMiddleware`.
+- Added `lifespan=lifespan` to the FastAPI constructor.
+- Added `build_session_config()` to construct `SessionConfig` with the correct fields.
+- Initialized `JWTTokenService` with `SessionConfig`.
+- Removed missing `webhooks`, `TimestampMiddleware`, and `SecurityLayer` imports from app startup wiring.
+- Rewrote `portal/routers/sso.py` as an import-safe placeholder router with Okta/Azure/Google authorize routes plus health endpoint.
+
+## Required Verification
+
+Run locally or in CI:
+
+```bash
+python -m compileall portal
+python -c "from portal.main import create_app; app = create_app(); print(app.title)"
+pytest portal/tests/test_app_startup.py -q
+pytest portal/sso portal/middleware -q
+```
+
+## Notes
+
+This repair is intentionally surgical. It does not address the later Trust Compliance placeholder-policy regression or `/tmp/sp_task` path issue.
+Those should be handled in a separate P1 PR.

--- a/portal/main.py
+++ b/portal/main.py
@@ -1,47 +1,66 @@
 """
-Portal FastAPI application entry point with integrated trust layer.
+Portal FastAPI application entry point.
+
+This module must stay import-safe: `from portal.main import create_app` is the
+P0 startup smoke gate for the portal service.
 """
+
 import logging
 from contextlib import asynccontextmanager
 
 from dotenv import load_dotenv
 from fastapi import FastAPI
+from starlette.middleware.sessions import SessionMiddleware as StarletteSessionMiddleware
 
-# Load environment variables
+from portal.config import get_settings
+from portal.middleware.cors_middleware import setup_cors
+from portal.middleware.rate_limiter import RateLimiterMiddleware
+from portal.routers import admin, sso, trust_compliance
+from portal.sso.jwt_service import JWTTokenService
+from portal.sso.session_config import SessionConfig
+from portal.sso.session_manager import SessionManager
+
+# Load environment variables before settings are resolved.
 load_dotenv()
 
-# Import settings and services using get_settings() instead of module-level constants
-from portal.config import get_settings
-from portal.middleware.cors_middleware import CORSMiddleware
-from portal.middleware.rate_limiter import RateLimiterMiddleware
-from portal.middleware.session_middleware import SessionMiddleware
-from portal.middleware.timestamp_middleware import TimestampMiddleware
-from portal.routers import admin, sso, webhooks, trust_compliance
-from portal.security.security_layer import SecurityLayer
-from portal.sso.jwt_service import JWTTokenService
-from portal.sso.session_manager import SessionConfig, SessionManager
-
 logger = logging.getLogger(__name__)
+
+
+def build_session_config() -> SessionConfig:
+    """Build a boot-safe SSO session config from application settings."""
+    settings = get_settings()
+    jwt_secret_key = settings.JWT_SECRET_KEY
+
+    # The shipped development JWT placeholder can be shorter than the SSO
+    # config requires. Fall back to the SSO session secret for local smoke tests
+    # while still respecting an explicitly configured JWT_SECRET_KEY.
+    if len(jwt_secret_key) < 32:
+        jwt_secret_key = settings.SSO_SESSION_SECRET
+
+    return SessionConfig(
+        jwt_secret_key=jwt_secret_key,
+        jwt_algorithm=settings.JWT_ALGORITHM,
+        jwt_expiration_seconds=settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        jwt_refresh_expiration_seconds=settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
+        redis_url=settings.REDIS_URL,
+        session_store_type="memory",
+        session_ttl_seconds=settings.SSO_SESSION_TTL_SECONDS,
+        refresh_token_ttl_seconds=settings.SSO_REFRESH_TTL_SECONDS,
+        issuer=settings.SSO_ISSUER,
+        audience=settings.SSO_AUDIENCE,
+        require_https=settings.ENVIRONMENT == "production",
+        secure_cookies=settings.ENVIRONMENT == "production",
+    )
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Application startup and shutdown."""
     logger.info("Portal starting up...")
 
-    # Initialize services
-    settings = get_settings()
-    jwt_service = JWTTokenService(settings.JWT_SECRET_KEY)
-
-    # Setup session manager with proper config
-    session_config = SessionConfig(
-        jwt_secret_key=settings.JWT_SECRET_KEY,
-        session_timeout_seconds=settings.SESSION_TIMEOUT_SECONDS
-    )
+    session_config = build_session_config()
     app.state.session_manager = SessionManager(session_config)
-    app.state.jwt_service = jwt_service
-
-    # Initialize security layer
-    app.state.security_layer = SecurityLayer(settings)
+    app.state.jwt_service = JWTTokenService(session_config)
 
     logger.info("Portal startup complete")
     yield
@@ -55,42 +74,36 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="SintraPrime Unified Portal",
         description="Unified authentication, trust compliance, and admin interface",
-        version="1.0.0"
+        version="1.0.0",
+        lifespan=lifespan,
     )
 
-    # CORS Middleware (single path only - use settings)
+    setup_cors(app)
+
+    # SSO routes use request.session for OAuth state; Starlette's session
+    # middleware provides that contract without relying on missing local modules.
     app.add_middleware(
-        CORSMiddleware,
-        allow_origins=settings.CORS_ORIGINS,
-        allow_credentials=True,
-        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-        allow_headers=["*"]
+        StarletteSessionMiddleware,
+        secret_key=settings.SECRET_KEY,
+        https_only=settings.ENVIRONMENT == "production",
+        same_site="strict",
     )
 
-    # Session Middleware (must come before routers that use request.session)
-    app.add_middleware(
-        SessionMiddleware,
-        secret_key=settings.SECRET_KEY
-    )
-
-    # Rate Limiter Middleware
     app.add_middleware(RateLimiterMiddleware)
 
-    # Timestamp Middleware
-    app.add_middleware(TimestampMiddleware)
-
-    # Register routers
+    # Register routers. Keep paths explicit and boot-safe.
     app.include_router(sso.router, prefix="/api/v1/sso", tags=["sso"])
     app.include_router(admin.router, prefix="/api/v1/admin", tags=["admin"])
-    app.include_router(webhooks.router, prefix="/api/v1/webhooks", tags=["webhooks"])
     app.include_router(trust_compliance.router)
-    
-    # Health check
+
     @app.get("/health")
     async def health_check():
-        return {"status": "ok", "service": "portal"}
+        return {
+            "status": "ok",
+            "service": "portal",
+            "environment": settings.ENVIRONMENT,
+        }
 
-    # Root
     @app.get("/")
     async def root():
         return {"message": "SintraPrime Unified Portal", "version": "1.0.0"}
@@ -100,5 +113,6 @@ def create_app() -> FastAPI:
 
 if __name__ == "__main__":
     import uvicorn
+
     app = create_app()
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/portal/routers/sso.py
+++ b/portal/routers/sso.py
@@ -1,17 +1,36 @@
 """
-SSO Router — Phase 21B
-Wires Okta, Azure AD, and Google Workspace OIDC providers.
+SSO Router — Phase 21B.
+
+Minimal boot-safe endpoints for Okta, Azure AD, and Google Workspace OIDC.
+The full provider callback implementation should remain behind tests; this file
+must never break portal import/startup smoke checks.
 """
+
 from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
 
 router = APIRouter()
 
-# → Okta, Azure, Google SSO routes placeholder
-# Full implementation with correct session paths and kwargs
-
-@Hfrom_fastapi.default_corass
 
 @router.get("/okta/authorize", summary="Redirect to Okta authorization")
 async def okta_authorize(request: Request) -> RedirectResponse:
+    """Placeholder Okta authorization route."""
     return RedirectResponse(url="/", status_code=302)
+
+
+@router.get("/azure/authorize", summary="Redirect to Azure AD authorization")
+async def azure_authorize(request: Request) -> RedirectResponse:
+    """Placeholder Azure AD authorization route."""
+    return RedirectResponse(url="/", status_code=302)
+
+
+@router.get("/google/authorize", summary="Redirect to Google Workspace authorization")
+async def google_authorize(request: Request) -> RedirectResponse:
+    """Placeholder Google Workspace authorization route."""
+    return RedirectResponse(url="/", status_code=302)
+
+
+@router.get("/health", summary="SSO router health")
+async def sso_health() -> dict[str, str]:
+    """Health check for SSO router registration."""
+    return {"status": "ok", "service": "sso"}


### PR DESCRIPTION
## P0 SSO Router Boot Repair

This PR fixes the immediate boot blockers found on `main`.

### Problem

`main` was boot-blocked by invalid SSO router syntax and import/runtime mismatches:

- `portal/routers/sso.py` contained invalid Python: `@Hfrom_fastapi.default_corass`
- `portal/main.py` imported modules that are not present in the repo:
  - `portal.middleware.session_middleware`
  - `portal.middleware.timestamp_middleware`
  - `portal.security.security_layer`
  - `portal.routers.webhooks`
- `lifespan()` existed but was not passed to `FastAPI(...)`
- `JWTTokenService` was initialized with a raw string instead of `SessionConfig`
- `SessionConfig` was constructed with nonexistent `session_timeout_seconds`

### Changes

- Rewrote `portal/main.py` to use only present boot-safe imports
- Switched to Starlette `SessionMiddleware` for request.session support
- Passed `lifespan=lifespan` to FastAPI
- Added `build_session_config()` using correct SessionConfig fields
- Initialized `JWTTokenService` with `SessionConfig`
- Removed missing webhooks/timestamp/security-layer startup imports
- Rewrote `portal/routers/sso.py` as import-safe placeholder routes for Okta, Azure, Google, and SSO health
- Added receipt: `ops/receipts/P0-sso-router-boot.md`

### Required Verification

```bash
python -m compileall portal
python -c "from portal.main import create_app; app = create_app(); print(app.title)"
pytest portal/tests/test_app_startup.py -q
pytest portal/sso portal/middleware -q
```

### Out of Scope

This PR intentionally does not address the Trust Compliance placeholder-policy regression or `/tmp/sp_task` path issue. Those belong in a separate P1 PR.