### PR TITLE
CI Test Scope + Dependency Matrix

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -133,7 +133,7 @@ def _register_integrations():
     with a single-path namespace package.
     """
     current = sys.modules.get("integrations")
-    current_paths = list(getattr(current, "____path__", []))
+    current_paths = list(getattr(current, "__path__", []))
 
     # Check if both paths are already registered
     if current is not None and all(p in current_paths for p in _BOTH_PATHS):

--- a/conftest.py
+++ b/conftest.py
@@ -68,6 +68,7 @@ collect_ignore_glob = [
     # Tier 4 — Integrations (needs .[integrations])
     "integrations/*",
     # Tier 5 — Deferred (transitive imports unverified)
+    "core/*",
     "agents/*",
     "agent_protocol/*",
     "ai_compliance/*",

--- a/conftest.py
+++ b/conftest.py
@@ -68,6 +68,7 @@ collect_ignore_glob = [
     # Tier 4 — Integrations (needs .[integrations])
     "integrations/*",
     # Tier 5 — Deferred (transitive imports unverified)
+    "backend/*",
     "core/*",
     "agents/*",
     "agent_protocol/*",

--- a/conftest.py
+++ b/conftest.py
@@ -1,37 +1,47 @@
-"""Root conftest.py — pytest collection configuration.
+"""
+Root conftest.py for SintraPrime-Unified test suite.
 
-Default CI collects only Tier 1 lanes (tests/, backend/, core/tests/).
+Ensures correct import resolution when running pytest from the repo root.
+The repo has two 'integrations' directories:
+  - integrations/          (top-level: banking, case_law, airtable_crm)
+  - core/universe/integrations/  (Discord/Slack bridges)
+
+Both are registered as paths in the 'integrations' namespace package so that
+both "from integrations.banking" and "from integrations.discord_handlers"
+resolve correctly regardless of test collection order.
+
+Default CI collects Tier 1 lanes only (tests/, backend/, core/tests/).
 See docs/ci/dependency-matrix.md for the full lane classification.
 """
 import sys
 import os
-from pathlib import Path
+import sysconfig
+import types
+
+# Ensure the repo root is on sys.path, but AFTER stdlib paths to prevent
+# the local 'operator/' directory from shadowing Python's built-in operator module.
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+# Get stdlib paths to ensure they come first
+stdlib_path = sysconfig.get_paths()["stdlib"]
+stdlib_platstdlib = sysconfig.get_paths()["platstdlib"]
+
+# Remove ROOT from sys.path if already there, then re-insert after stdlib
+if ROOT in sys.path:
+    sys.path.remove(ROOT)
+
+# Find the best insertion point: after all stdlib paths
+insert_pos = 0
+for i, p in enumerate(sys.path):
+    if p.startswith(stdlib_path) or p.startswith(stdlib_platstdlib) or p == '':
+        insert_pos = i + 1
+
+sys.path.insert(insert_pos, ROOT)
 
 # ---------------------------------------------------------------------------
-# stdlib path ordering — ensure stdlib modules resolve before local shadows
+# Directories to skip during collection
 # ---------------------------------------------------------------------------
-stdlib_path = str(Path(sys.prefix) / "lib" / f"python{sys.version_info.major}.{sys.version_info.minor}")
-if stdlib_path in sys.path:
-    sys.path.remove(stdlib_path)
-    sys.path.insert(0, stdlib_path)
-
-# ---------------------------------------------------------------------------
-# namespace package registration — allow pytest to collect from sub-packages
-# ---------------------------------------------------------------------------
-for pkg in ("core", "portal", "backend"):
-    pkg_dir = Path(__file__).parent / pkg
-    if pkg_dir.is_dir() and str(pkg_dir) not in sys.path:
-        sys.path.insert(0, str(pkg_dir.parent))
-
-# ---------------------------------------------------------------------------
-# Collection scope — only Tier 1 lanes in default CI
-# All other lanes are excluded to prevent collection errors from
-# missing optional dependencies. Install extras to run them:
-#   pip install .[portal]      → portal tests
-#   pip install .[predictive]  → predictive tests
-#   pip install .[integrations] → integration tests
-#   pip install .[all]         → everything
-# ---------------------------------------------------------------------------
+# PR #94 baseline exclusions (namespace collisions / non-test dirs):
 collect_ignore_glob = [
     "apps/*",
     "deployment/*",
@@ -44,12 +54,31 @@ collect_ignore_glob = [
     "node_modules/*",
     "operator/*",
     "phase19/revenue_smoke_test/run_smoke_test.py",
-    # Tier 2-5: deferred lanes (require optional extras)
+    # -------------------------------------------------------------------
+    # Tier 2-5: deferred from default CI (PR #98 / Issue #97)
+    # These lanes require optional extras or have unverified transitive
+    # imports. Install .[portal], .[predictive], .[integrations], or
+    # .[all] and override testpaths to run them.
+    # See docs/ci/dependency-matrix.md for details.
+    # -------------------------------------------------------------------
+    # Tier 2 — Portal (needs .[portal])
     "portal/*",
-    "packages/*",
-    "agents/*",
+    # Tier 3 — Predictive (needs .[predictive])
+    "predictive/*",
+    # Tier 4 — Integrations (needs .[integrations])
     "integrations/*",
+    # Tier 5 — Deferred (transitive imports unverified)
+    "agents/*",
+    "agent_protocol/*",
+    "ai_compliance/*",
+    "app_builder/*",
+    "artifacts/*",
+    "channels/*",
+    "claude_code/*",
+    "cross_platform/*",
+    "developer_experience/*",
     "docket/*",
+    "emotional_intelligence/*",
     "esignature/*",
     "federal_agencies/*",
     "financial_mastery/*",
@@ -64,9 +93,14 @@ collect_ignore_glob = [
     "multimodal/*",
     "observability/*",
     "orchestration/*",
+    "packages/*",
     "parl/*",
     "performance/*",
-    "predictive/*",
+    "phase15/*",
+    "phase16/*",
+    "phase17/*",
+    "phase18/*",
+    "phase19/*",
     "rag/*",
     "saas/*",
     "scheduler/*",
@@ -78,24 +112,53 @@ collect_ignore_glob = [
     "twin_layer/*",
     "voice/*",
     "workflow_builder/*",
-    "phase15/*",
-    "phase16/*",
-    "phase17/*",
-    "phase18/*",
-    "phase19/*",
-    "agent_protocol/*",
-    "ai_compliance/*",
-    "app_builder/*",
-    "artifacts/*",
-    "channels/*",
-    "claude_code/*",
-    "cross_platform/*",
-    "developer_experience/*",
-    "emotional_intelligence/*",
 ]
+
+# Both integrations directories that need to be in the namespace package
+_TOP_INTEGRATIONS = os.path.join(ROOT, "integrations")
+_UNIVERSE_INTEGRATIONS = os.path.join(ROOT, "core", "universe", "integrations")
+_BOTH_PATHS = [_TOP_INTEGRATIONS, _UNIVERSE_INTEGRATIONS]
+
+
+def _register_integrations():
+    """
+    Register 'integrations' as a namespace package covering both:
+      - ROOT/integrations/          (banking, case_law, airtable_crm)
+      - ROOT/core/universe/integrations/  (discord_handlers, discord_embeds, etc.)
+
+    This is called at conftest load time AND before each file is collected,
+    to prevent pytest's import machinery from replacing our registration
+    with a single-path namespace package.
+    """
+    current = sys.modules.get("integrations")
+    current_paths = list(getattr(current, "____path__", []))
+
+    # Check if both paths are already registered
+    if current is not None and all(p in current_paths for p in _BOTH_PATHS):
+        return  # Already correctly registered
+
+    # Create or update the namespace package with both paths
+    if current is None:
+        pkg = types.ModuleType("integrations")
+    else:
+        pkg = current
+
+    pkg.__path__ = _BOTH_PATHS[:]
+    pkg.__package__ = "integrations"
+    pkg.__file__ = os.path.join(_TOP_INTEGRATIONS, "__init__.py")
+    pkg.__spec__ = None
+    sys.modules["integrations"] = pkg
+
+
+# Register immediately at conftest load time
+_register_integrations()
 
 
 def pytest_configure(config):
-    """Register custom markers."""
-    config.addinivalue_line("markers", "slow: marks tests as slow (deselect with -m 'not slow')")
-    config.addinivalue_line("markers", "integration: marks integration tests requiring external services")
+    """Re-register integrations namespace package when pytest is configured."""
+    _register_integrations()
+
+
+def pytest_collectstart(collector):
+    """Re-register integrations namespace package before each file is collected."""
+    _register_integrations()

--- a/conftest.py
+++ b/conftest.py
@@ -1,41 +1,37 @@
-"""
-Root conftest.py for SintraPrime-Unified test suite.
+"""Root conftest.py — pytest collection configuration.
 
-Ensures correct import resolution when running pytest from the repo root.
-The repo has two 'integrations' directories:
-  - integrations/          (top-level: banking, case_law, airtable_crm)
-  - core/universe/integrations/  (Discord/Slack bridges)
-
-Both are registered as paths in the 'integrations' namespace package so that
-both "from integrations.banking" and "from integrations.discord_handlers"
-resolve correctly regardless of test collection order.
+Default CI collects only Tier 1 lanes (tests/, backend/, core/tests/).
+See docs/ci/dependency-matrix.md for the full lane classification.
 """
 import sys
 import os
-import sysconfig
-import types
+from pathlib import Path
 
-# Ensure the repo root is on sys.path, but AFTER stdlib paths to prevent
-# the local 'operator/' directory from shadowing Python's built-in operator module.
-ROOT = os.path.dirname(os.path.abspath(__file__))
+# ---------------------------------------------------------------------------
+# stdlib path ordering — ensure stdlib modules resolve before local shadows
+# ---------------------------------------------------------------------------
+stdlib_path = str(Path(sys.prefix) / "lib" / f"python{sys.version_info.major}.{sys.version_info.minor}")
+if stdlib_path in sys.path:
+    sys.path.remove(stdlib_path)
+    sys.path.insert(0, stdlib_path)
 
-# Get stdlib paths to ensure they come first
-stdlib_path = sysconfig.get_paths()["stdlib"]
-stdlib_platstdlib = sysconfig.get_paths()["platstdlib"]
+# ---------------------------------------------------------------------------
+# namespace package registration — allow pytest to collect from sub-packages
+# ---------------------------------------------------------------------------
+for pkg in ("core", "portal", "backend"):
+    pkg_dir = Path(__file__).parent / pkg
+    if pkg_dir.is_dir() and str(pkg_dir) not in sys.path:
+        sys.path.insert(0, str(pkg_dir.parent))
 
-# Remove ROOT from sys.path if already there, then re-insert after stdlib
-if ROOT in sys.path:
-    sys.path.remove(ROOT)
-
-# Find the best insertion point: after all stdlib paths
-insert_pos = 0
-for i, p in enumerate(sys.path):
-    if p.startswith(stdlib_path) or p.startswith(stdlib_platstdlib) or p == '':
-        insert_pos = i + 1
-
-sys.path.insert(insert_pos, ROOT)
-
-# Directories to skip during collection (avoid namespace collisions)
+# ---------------------------------------------------------------------------
+# Collection scope — only Tier 1 lanes in default CI
+# All other lanes are excluded to prevent collection errors from
+# missing optional dependencies. Install extras to run them:
+#   pip install .[portal]      → portal tests
+#   pip install .[predictive]  → predictive tests
+#   pip install .[integrations] → integration tests
+#   pip install .[all]         → everything
+# ---------------------------------------------------------------------------
 collect_ignore_glob = [
     "apps/*",
     "deployment/*",
@@ -48,53 +44,58 @@ collect_ignore_glob = [
     "node_modules/*",
     "operator/*",
     "phase19/revenue_smoke_test/run_smoke_test.py",
+    # Tier 2-5: deferred lanes (require optional extras)
+    "portal/*",
+    "packages/*",
+    "agents/*",
+    "integrations/*",
+    "docket/*",
+    "esignature/*",
+    "federal_agencies/*",
+    "financial_mastery/*",
+    "governance/*",
+    "legal_integrations/*",
+    "legal_intelligence/*",
+    "life_governance/*",
+    "local_llm/*",
+    "local_models/*",
+    "mcp_server/*",
+    "memory/*",
+    "multimodal/*",
+    "observability/*",
+    "orchestration/*",
+    "parl/*",
+    "performance/*",
+    "predictive/*",
+    "rag/*",
+    "saas/*",
+    "scheduler/*",
+    "secure_execution/*",
+    "security/*",
+    "skill_evolution/*",
+    "superintelligence/*",
+    "trust_law/*",
+    "twin_layer/*",
+    "voice/*",
+    "workflow_builder/*",
+    "phase15/*",
+    "phase16/*",
+    "phase17/*",
+    "phase18/*",
+    "phase19/*",
+    "agent_protocol/*",
+    "ai_compliance/*",
+    "app_builder/*",
+    "artifacts/*",
+    "channels/*",
+    "claude_code/*",
+    "cross_platform/*",
+    "developer_experience/*",
+    "emotional_intelligence/*",
 ]
-
-# Both integrations directories that need to be in the namespace package
-_TOP_INTEGRATIONS = os.path.join(ROOT, "integrations")
-_UNIVERSE_INTEGRATIONS = os.path.join(ROOT, "core", "universe", "integrations")
-_BOTH_PATHS = [_TOP_INTEGRATIONS, _UNIVERSE_INTEGRATIONS]
-
-
-def _register_integrations():
-    """
-    Register 'integrations' as a namespace package covering both:
-      - ROOT/integrations/          (banking, case_law, airtable_crm)
-      - ROOT/core/universe/integrations/  (discord_handlers, discord_embeds, etc.)
-
-    This is called at conftest load time AND before each file is collected,
-    to prevent pytest's import machinery from replacing our registration
-    with a single-path namespace package.
-    """
-    current = sys.modules.get("integrations")
-    current_paths = list(getattr(current, "__path__", []))
-
-    # Check if both paths are already registered
-    if current is not None and all(p in current_paths for p in _BOTH_PATHS):
-        return  # Already correctly registered
-
-    # Create or update the namespace package with both paths
-    if current is None:
-        pkg = types.ModuleType("integrations")
-    else:
-        pkg = current
-
-    pkg.__path__ = _BOTH_PATHS[:]
-    pkg.__package__ = "integrations"
-    pkg.__file__ = os.path.join(_TOP_INTEGRATIONS, "__init__.py")
-    pkg.__spec__ = None
-    sys.modules["integrations"] = pkg
-
-
-# Register immediately at conftest load time
-_register_integrations()
 
 
 def pytest_configure(config):
-    """Re-register integrations namespace package when pytest is configured."""
-    _register_integrations()
-
-
-def pytest_collectstart(collector):
-    """Re-register integrations namespace package before each file is collected."""
-    _register_integrations()
+    """Register custom markers."""
+    config.addinivalue_line("markers", "slow: marks tests as slow (deselect with -m 'not slow')")
+    config.addinivalue_line("markers", "integration: marks integration tests requiring external services")

--- a/docs/ci/dependency-matrix.md
+++ b/docs/ci/dependency-matrix.md
@@ -92,13 +92,11 @@ Zero collection errors guaranteed. These run with `pip install .[test]`.
 | Lane | Test files | Third-party imports | Status |
 |------|-----------|---------------------|--------|
 | `tests/` | 3 | pytest | ✅ Sigma Gate: 146 pass |
-| `backend/stripe-payments/tests/` | 1 | pytest, stripe | ✅ stripe in core deps |
-| `backend/lead-router/tests/` | 1 | pytest | ✅ stdlib only |
 
 
 **Default CI command:**
 ```bash
-python -m pytest tests/ backend/lead-router/tests/ backend/stripe-payments/tests/ --tb=short -q --import-mode=importlib
+python -m pytest tests/ --tb=short -q --import-mode=importlib
 ```
 
 ### Tier 2 — Portal (requires `.[test,portal]`)
@@ -112,7 +110,7 @@ python -m pytest tests/ backend/lead-router/tests/ backend/stripe-payments/tests
 **Extended CI command:**
 ```bash
 pip install .[test,portal]
-python -m pytest tests/ backend/lead-router/tests/ backend/stripe-payments/tests/ portal/tests/ portal/routers/tests/ portal/sso/tests/ --tb=short -q --import-mode=importlib
+python -m pytest tests/ portal/tests/ portal/routers/tests/ portal/sso/tests/ --tb=short -q --import-mode=importlib
 ```
 
 ### Tier 3 — Predictive (requires `.[test,predictive]`)
@@ -135,6 +133,8 @@ their dependency requirements are verified.
 
 | Lane | Test files | Reason deferred |
 |------|-----------|----------------|
+| backend/lead-router/tests/ | 1 | imports models/ (not on sys.path from backend subdir) |
+| backend/stripe-payments/tests/ | 1 | chains to pydantic EmailStr → email-validator (undeclared) |
 | core/tests/ | 6 | test_slack_integration chains to discord (undeclared) |
 | agents/chat/tests/ | 1 | Transitive imports unverified |
 | agent_protocol/tests/ | 1 | Transitive imports unverified |

--- a/docs/ci/dependency-matrix.md
+++ b/docs/ci/dependency-matrix.md
@@ -1,0 +1,197 @@
+# CI Dependency Matrix
+
+> Generated for Issue #97. Maps every test lane to its third-party imports,
+> classifies suites into CI tiers, and documents the optional-dependency
+> groups in `pyproject.toml`.
+
+## Current state (post-PR #94 + #95)
+
+| Workflow | Status | Root cause |
+|----------|--------|------------|
+| Sigma Gate — tests | ✅ 146 passed | Runs only `tests/` |
+| Sigma Gate — coverage | ❌ | Statement/branch data mismatch |
+| SintraPrime CI — test | ❌ | Collection errors across 40+ lanes |
+| SintraPrime CI — lint | ❌ | 46K+ ruff violations (pre-existing) |
+| SintraPrime CI — security | ⬆️ | Safety policy exists (PR #95) |
+| IssueVerifier — bandit | ❌ | 9,265 findings, no baseline |
+| deploy-staging | ❌ | Pre-existing |
+
+## Dependency groups
+
+### Core (`[project.dependencies]`) — always installed
+
+| PyPI package | Import name | Used by |
+|-------------|-------------|---------|
+| fastapi>=0.104.0 | fastapi | portal, cross_platform, legal_integrations, scheduler |
+| uvicorn>=0.24.0 | uvicorn | portal |
+| sqlalchemy>=2.0.0 | sqlalchemy | portal |
+| psycopg2-binary>=2.9.9 | psycopg2 | portal |
+| pydantic>=2.5.0 | pydantic | portal, integrations |
+| pydantic-settings>=2.1.0 | pydantic_settings | portal |
+| python-jose>=3.3.0 | jose | portal |
+| passlib>=1.7.4 | passlib | portal |
+| bcrypt>=4.1.1 | bcrypt | portal |
+| python-multipart>=0.0.27 | multipart | portal |
+| httpx>=0.25.2 | httpx | portal |
+| aioredis>=2.0.1 | aioredis | core |
+| celery>=5.3.4 | celery | core |
+| redis>=5.0.1 | redis | core |
+| stripe>=7.4.0 | stripe | backend/stripe-payments |
+| python-dotenv>=1.2.2 | dotenv | portal, config |
+| openai>=1.3.0 | openai | agents, orchestration |
+| anthropic>=0.7.0 | anthropic | agents |
+| websockets>=12.0 | websockets | core |
+| pytz>=2023.3 | pytz | portal |
+| tzlocal>=5.2 | tzlocal | portal |
+| numpy>=1.24.0 | numpy | core, predictive |
+
+### `[project.optional-dependencies.test]` — CI test runner
+
+| PyPI package | Import name | Purpose |
+|-------------|-------------|---------|
+| pytest>=7.0 | pytest | Test runner |
+| pytest-cov>=4.0 | pytest_cov | Coverage reporting |
+| pytest-asyncio>=0.21 | pytest_asyncio | Async test support |
+
+### `[project.optional-dependencies.portal]` — portal SSO & auth
+
+| PyPI package | Import name | Source file |
+|-------------|-------------|------------|
+| PyJWT>=2.0 | jwt | portal/sso/providers/google.py |
+| requests>=2.31 | requests | portal/sso/providers/google.py, portal tests |
+| email-validator>=2.0 | email_validator | portal auth/validation |
+
+Note: `starlette` ships with `fastapi` and does not need separate declaration.
+
+### `[project.optional-dependencies.predictive]` — ML/analytics
+
+| PyPI package | Import name | Source file |
+|-------------|-------------|------------|
+| pandas>=2.0 | pandas | predictive/outcome_predictor.py, ml_training_pipeline.py |
+| scikit-learn>=1.3 | sklearn | predictive/outcome_predictor.py, ml_training_pipeline.py |
+
+Note: `numpy` is already in core dependencies.
+
+### `[project.optional-dependencies.integrations]` — third-party API clients
+
+| PyPI package | Import name | Source file |
+|-------------|-------------|------------|
+| aiohttp>=3.9 | aiohttp | integrations/banking, integrations/case_law |
+| plaid-python>=14.0 | plaid | integrations/banking/plaid_client.py |
+
+### `[project.optional-dependencies.all]`
+
+Installs everything: `sintraprime[test,portal,predictive,integrations]`
+
+## Test lane classification
+
+### Tier 1 — Core (default blocking CI)
+
+Zero collection errors guaranteed. These run with `pip install .[test]`.
+
+| Lane | Test files | Third-party imports | Status |
+|------|-----------|---------------------|--------|
+| `tests/` | 3 | pytest | ✅ Sigma Gate: 146 pass |
+| `backend/stripe-payments/tests/` | 1 | pytest, stripe | ✅ stripe in core deps |
+| `backend/lead-router/tests/` | 1 | pytest | ✅ stdlib only |
+| `core/tests/` | 6 | pytest, numpy | ✅ numpy in core deps |
+
+**Default CI command:**
+```bash
+python -m pytest tests/ backend/ core/tests/ --tb=short -q
+```
+
+### Tier 2 — Portal (requires `.[test,portal]`)
+
+| Lane | Test files | Extra imports needed | Status |
+|------|-----------|---------------------|--------|
+| `portal/tests/` | 12 | PyJWT, requests, email-validator | ⚠️ needs portal extras |
+| `portal/routers/tests/` | — | PyJWT, requests | ⚠️ needs portal extras |
+| `portal/sso/tests/` | 7 | PyJWT, requests | ⚠️ needs portal extras |
+
+**Extended CI command:**
+```bash
+pip install .[test,portal]
+python -m pytest tests/ backend/ core/tests/ portal/tests/ portal/routers/tests/ portal/sso/tests/ --tb=short -q
+```
+
+### Tier 3 — Predictive (requires `.[test,predictive]`)
+
+| Lane | Test files | Extra imports needed | Status |
+|------|-----------|---------------------|--------|
+| `predictive/tests/` | 1 | pandas, scikit-learn | ⚠️ needs predictive extras |
+
+### Tier 4 — Integrations (requires `.[test,integrations]`)
+
+| Lane | Test files | Extra imports needed | Status |
+|------|-----------|---------------------|--------|
+| `integrations/` | 9 | aiohttp, plaid | ⚠️ needs integrations extras |
+
+### Tier 5 — Deferred (not in default CI, tracked here)
+
+These lanes exist in `pytest.ini` testpaths but have not been fully audited
+for transitive import chains. They are excluded from default CI until
+their dependency requirements are verified.
+
+| Lane | Test files | Reason deferred |
+|------|-----------|----------------|
+| agents/chat/tests/ | 1 | Transitive imports unverified |
+| agent_protocol/tests/ | 1 | Transitive imports unverified |
+| ai_compliance/tests/ | 1 | Transitive imports unverified |
+| app_builder/tests/ | 1 | Transitive imports unverified |
+| artifacts/tests/ | 1 | Transitive imports unverified |
+| channels/tests/ | 1 | Transitive imports unverified |
+| claude_code/tests/ | 1 | Transitive imports unverified |
+| cross_platform/tests/ | 1 | Needs fastapi (declared), but transitive unverified |
+| developer_experience/tests/ | 1 | Transitive imports unverified |
+| docket/tests/ | 1 | Transitive imports unverified |
+| emotional_intelligence/tests/ | 1 | Transitive imports unverified |
+| esignature/tests/ | 1 | Transitive imports unverified |
+| federal_agencies/tests/ | 1 | Transitive imports unverified |
+| financial_mastery/tests/ | 1 | Transitive imports unverified |
+| governance/tests/ | 1 | Transitive imports unverified |
+| legal_integrations/tests/ | 1 | Transitive imports unverified |
+| legal_intelligence/tests/ | 1 | Transitive imports unverified |
+| life_governance/tests/ | 1 | Transitive imports unverified |
+| local_llm/tests/ | 1 | Transitive imports unverified |
+| local_models/tests/ | 1 | Needs requests (not in core) |
+| mcp_server/tests/ | 1 | Transitive imports unverified |
+| memory/tests/ | 1 | Transitive imports unverified |
+| multimodal/tests/ | 1 | Transitive imports unverified |
+| observability/tests/ | — | Transitive imports unverified |
+| operator/tests/ | 1 | Explicitly excluded (collect_ignore_glob) |
+| orchestration/tests/ | 1 | Needs pytest-asyncio |
+| parl/tests/ | 1 | Transitive imports unverified |
+| performance/tests/ | 1 | Transitive imports unverified |
+| phase15/ | 4 | Transitive imports unverified |
+| phase16/ | 4 | Transitive imports unverified |
+| phase17/ | 4 | Transitive imports unverified |
+| phase18/ | 5 | Transitive imports unverified |
+| phase19/ | 2 | Partially excluded already |
+| rag/tests/ | 1 | Transitive imports unverified |
+| saas/tests/ | 1 | Transitive imports unverified |
+| scheduler/tests/ | 1 | Needs fastapi (declared), but transitive unverified |
+| secure_execution/tests/ | — | Transitive imports unverified |
+| security/tests/ | — | Transitive imports unverified |
+| skill_evolution/tests/ | — | Transitive imports unverified |
+| superintelligence/tests/ | 1 | Transitive imports unverified |
+| trust_law/tests/ | 1 | Transitive imports unverified |
+| twin_layer/tests/ | 1 | Transitive imports unverified |
+| voice/tests/ | — | Transitive imports unverified |
+| workflow_builder/tests/ | 1 | Transitive imports unverified |
+
+## Rollback plan
+
+If this PR causes regressions:
+1. Revert `pytest.ini` to the previous version (all testpaths restored)
+2. Remove `[project.optional-dependencies]` sections from `pyproject.toml`
+3. Delete `docs/ci/dependency-matrix.md`
+4. All changes are additive — no source code modified
+
+## Next steps (future PRs)
+
+1. **Audit deferred lanes** — trace transitive imports for each Tier 5 lane, promote to appropriate tier
+2. **Ruff baseline** — create `ruff.toml` with `extend-ignore` for pre-existing 46K violations
+3. **Bandit baseline** — generate `.bandit-baseline.json` from current findings
+4. **Coverage config** — fix statement/branch data mismatch in Sigma Gate
+5. **CI workflow updates** — update `ci.yml` to use `pip install .[test]` and narrow testpaths (requires `workflows` permission)

--- a/docs/ci/dependency-matrix.md
+++ b/docs/ci/dependency-matrix.md
@@ -94,11 +94,11 @@ Zero collection errors guaranteed. These run with `pip install .[test]`.
 | `tests/` | 3 | pytest | ✅ Sigma Gate: 146 pass |
 | `backend/stripe-payments/tests/` | 1 | pytest, stripe | ✅ stripe in core deps |
 | `backend/lead-router/tests/` | 1 | pytest | ✅ stdlib only |
-| `core/tests/` | 6 | pytest, numpy | ✅ numpy in core deps |
+
 
 **Default CI command:**
 ```bash
-python -m pytest tests/ backend/ core/tests/ --tb=short -q
+python -m pytest tests/ backend/lead-router/tests/ backend/stripe-payments/tests/ --tb=short -q --import-mode=importlib
 ```
 
 ### Tier 2 — Portal (requires `.[test,portal]`)
@@ -112,7 +112,7 @@ python -m pytest tests/ backend/ core/tests/ --tb=short -q
 **Extended CI command:**
 ```bash
 pip install .[test,portal]
-python -m pytest tests/ backend/ core/tests/ portal/tests/ portal/routers/tests/ portal/sso/tests/ --tb=short -q
+python -m pytest tests/ backend/lead-router/tests/ backend/stripe-payments/tests/ portal/tests/ portal/routers/tests/ portal/sso/tests/ --tb=short -q --import-mode=importlib
 ```
 
 ### Tier 3 — Predictive (requires `.[test,predictive]`)
@@ -135,6 +135,7 @@ their dependency requirements are verified.
 
 | Lane | Test files | Reason deferred |
 |------|-----------|----------------|
+| core/tests/ | 6 | test_slack_integration chains to discord (undeclared) |
 | agents/chat/tests/ | 1 | Transitive imports unverified |
 | agent_protocol/tests/ | 1 | Transitive imports unverified |
 | ai_compliance/tests/ | 1 | Transitive imports unverified |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,18 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+    "pytest>=7.4.3",
+    "pytest-asyncio>=0.21.1",
+    "pytest-cov>=4.1.0",
+    "black>=23.12.0",
+    "ruff>=0.1.8",
+    "isort>=5.13.2",
+    "mypy>=1.7.1",
+    "pytest-mock>=3.12.0",
+    "responses>=0.24.1",
+    "bandit>=1.7.5",
+]
 test = [
     "pytest>=7.0",
     "pytest-cov>=4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,17 +38,26 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
-    "pytest>=7.4.3",
-    "pytest-asyncio>=0.21.1",
-    "pytest-cov>=4.1.0",
-    "black>=23.12.0",
-    "ruff>=0.1.8",
-    "isort>=5.13.2",
-    "mypy>=1.7.1",
-    "pytest-mock>=3.12.0",
-    "responses>=0.24.1",
-    "bandit>=1.7.5",
+test = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "pytest-asyncio>=0.21",
+]
+portal = [
+    "PyJWT>=2.0",
+    "requests>=2.31",
+    "email-validator>=2.0",
+]
+predictive = [
+    "pandas>=2.0",
+    "scikit-learn>=1.3",
+]
+integrations = [
+    "aiohttp>=3.9",
+    "plaid-python>=14.0",
+]
+all = [
+    "sintraprime[test,portal,predictive,integrations]",
 ]
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,16 @@ integrations = [
     "plaid-python>=14.0",
 ]
 all = [
-    "sintraprime[test,portal,predictive,integrations]",
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "pytest-asyncio>=0.21",
+    "PyJWT>=2.0",
+    "requests>=2.31",
+    "email-validator>=2.0",
+    "pandas>=2.0",
+    "scikit-learn>=1.3",
+    "aiohttp>=3.9",
+    "plaid-python>=14.0",
 ]
 
 [tool.poetry]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,9 @@
 [pytest]
-addopts = --tb=short -q
+addopts = --tb=short -q --import-mode=importlib
 testpaths =
     tests
     backend/lead-router/tests
     backend/stripe-payments/tests
-    core/tests
 norecursedirs =
     apps
     deployment

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,6 @@
 addopts = --tb=short -q --import-mode=importlib
 testpaths =
     tests
-    backend/lead-router/tests
-    backend/stripe-payments/tests
 norecursedirs =
     apps
     deployment

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,58 +2,9 @@
 addopts = --tb=short -q
 testpaths =
     tests
-    portal/tests
-    portal/routers/tests
-    packages/tests
-    agents
-    core/tests
-    integrations
-    docket/tests
-    esignature/tests
-    federal_agencies/tests
-    financial_mastery/tests
-    governance/tests
-    legal_integrations/tests
-    legal_intelligence/tests
-    life_governance/tests
-    local_llm/tests
-    local_models/tests
-    mcp_server/tests
-    memory/tests
-    multimodal/tests
-    observability/tests
-    orchestration/tests
-    performance/tests
-    predictive/tests
-    rag/tests
-    saas/tests
-    scheduler/tests
-    secure_execution/tests
-    security/tests
-    skill_evolution/tests
-    superintelligence/tests
-    trust_law/tests
-    twin_layer/tests
-    voice/tests
-    workflow_builder/tests
-    phase15
-    phase16
-    phase17
-    phase18
-    phase19
-    agent_protocol/tests
-    agents/chat/tests
-    ai_compliance/tests
-    app_builder/tests
-    artifacts/tests
     backend/lead-router/tests
     backend/stripe-payments/tests
-    channels/tests
-    claude_code/tests
-    cross_platform/tests
-    developer_experience/tests
-    emotional_intelligence/tests
-    parl/tests
+    core/tests
 norecursedirs =
     apps
     deployment


### PR DESCRIPTION
## CI Test Scope + Dependency Matrix

Implements Option C (Hybrid) from Issue #97.
Supersedes previous PR #98 body — updated to match actual verified scope.

---

### What this PR does

1. **Dependency matrix** (`docs/ci/dependency-matrix.md`) — maps every test lane → imports → PyPI package → CI tier
2. **Optional dependency groups** in `pyproject.toml`:
   - `dev` — **preserved verbatim** (pytest, black, ruff, isort, mypy, pytest-mock, responses, bandit)
   - `test` — pytest, pytest-cov, pytest-asyncio
   - `portal` — PyJWT, requests, email-validator
   - `predictive` — pandas, scikit-learn
   - `integrations` — aiohttp, plaid-python
   - `all` — direct union of test + portal + predictive + integrations (no self-reference)
3. **Narrow default CI** — `pytest.ini` testpaths = `tests/` only (Tier 1)
4. **Import-safety spine preserved** — `conftest.py` retains PR #94 structure:
   - `sysconfig`-based stdlib path ordering
   - `_register_integrations()` + immediate call
   - `pytest_configure()` re-registration
   - `pytest_collectstart()` re-registration
   - Tier 2-5 exclusions added surgically to `collect_ignore_glob`

### Tier classification (verified)

| Tier | Lane | Status | Blocker |
|------|------|--------|---------|
| **1 — Core** | `tests/` | ✅ 146 pass (Sigma Gate) | None |
| 2 — Backend | `backend/lead-router/tests/` | ⚠️ Deferred | `from models.lead import ...` — models not on sys.path |
| 2 — Backend | `backend/stripe-payments/tests/` | ⚠️ Deferred | chains to pydantic EmailStr → email-validator undeclared |
| 3 — Portal | `portal/tests/`, `portal/sso/tests/` | ⚠️ Deferred | needs `.[portal]` (PyJWT, requests, email-validator) |
| 4 — Predictive | `predictive/tests/` | ⚠️ Deferred | needs `.[predictive]` (pandas, scikit-learn) |
| 5 — Integrations | `integrations/*/tests/` | ⚠️ Deferred | needs `.[integrations]` (aiohttp, plaid-python) |
| 5 — Core engine | `core/tests/` | ⚠️ Deferred | test_slack_integration chains to discord (undeclared) |
| 5 — Specialty | 30+ lanes | ⚠️ Deferred | transitive imports unverified |

### Default CI command

```bash
python -m pytest --tb=short -q --import-mode=importlib
# testpaths = tests/ (from pytest.ini)
# Expected: 146 tests, zero collection errors
```

### CI verification receipt — commit `e9f569de`

| Workflow | Job | Result |
|----------|-----|--------|
| SintraPrime CI | test | ✅ SUCCESS — zero collection errors, `tests/` only |
| SintraPrime CI | lint | ❌ Pre-existing — 46K+ Ruff backlog (unchanged) |
| SintraPrime CI | security | ❌ Pre-existing — Bandit baseline (unchanged) |
| Sigma Gate | tests | ✅ 146 pass |
| Sigma Gate | coverage | ❌ Pre-existing — statement/branch data mismatch |

### Rollback plan

1. Revert `pytest.ini` → restore previous testpaths
2. Revert `conftest.py` → remove Tier 2-5 collect_ignore_glob entries
3. Remove `[project.optional-dependencies]` groups (keep `dev`)
4. Delete `docs/ci/dependency-matrix.md`
5. All changes are additive — no source code modified

### Files changed

| File | What changed |
|------|-------------|
| `docs/ci/dependency-matrix.md` | New — 198-line lane classification |
| `pyproject.toml` | Added test/portal/predictive/integrations/all extras; dev preserved |
| `pytest.ini` | Narrowed testpaths to `tests/` only; added `--import-mode=importlib` |
| `conftest.py` | PR #94 spine preserved; Tier 2-5 lanes added to `collect_ignore_glob` |

---

Addresses Issue #97. Does not close it — Tier 2-5 lane promotion and CI workflow updates remain.
