### PR TITLE
fix: ruff baseline config — exclude legacy dirs + per-file-ignores

### DIFF
--- a/docs/ci/ruff-baseline.md
+++ b/docs/ci/ruff-baseline.md
@@ -1,0 +1,153 @@
+# Ruff Baseline Configuration
+
+## Purpose
+
+The ruff baseline configuration uses **directory exclusions** and **per-file-ignores** to suppress pre-existing lint violations while enforcing all rules on new code. This is functionally equivalent to bandit's `--baseline` approach, implemented through ruff's native configuration.
+
+## How It Works
+
+Ruff does not have a built-in baseline file mechanism. Instead, the baseline is encoded in `pyproject.toml` through two layers:
+
+### Layer 1: Directory Exclusions (`exclude`)
+Legacy and feature-module directories are excluded from ruff scanning entirely. These directories contain **22,925 of 24,378 total violations (94%)** and are not under active development.
+
+### Layer 2: Per-File-Ignores (`per-file-ignores`)
+Active directories (`portal/`, `backend/`, `tests/`, `governance/`, root files) have specific rules suppressed at the subdirectory level. This allows:
+- ✅ New violations of *other* rules are caught in those directories
+- ✅ New files in *new* directories get full linting (not excluded)
+- ⚠️ New files in existing subdirectories inherit that subdirectory's ignores
+
+## Current Baseline Stats
+
+| Metric | Count |
+|--------|-------|
+| Generated from | main (2026-05-20) |
+| Total violations (all dirs) | 24,378 |
+| Unique rule codes | 105 |
+| Files with violations | 741 |
+| Directories excluded | 48 |
+| Per-file-ignore entries | 21 |
+| **Violations after baseline** | **0** |
+
+### Violations by Category
+
+| Category | Count | % | Strategy |
+|----------|-------|---|----------|
+| Style/whitespace (W293, W291, W292) | 6,566 | 27% | Exclude + auto-fix later |
+| Type modernization (UP006, UP035, UP045, etc.) | 10,225 | 42% | Exclude + auto-fix later |
+| Import sorting (I001) | 628 | 3% | Exclude + auto-fix later |
+| Unused imports/vars (F401, F841, F541) | 1,669 | 7% | Per-file-ignores |
+| Unused arguments (ARG*) | 710 | 3% | Per-file-ignores |
+| Datetime timezone (DTZ*) | 722 | 3% | Exclude + per-file-ignores |
+| Bugbear (B*) | 595 | 2% | Per-file-ignores |
+| Naming (N*) | 213 | 1% | Per-file-ignores |
+| Other (RET, SIM, PT, RUF, etc.) | 3,050 | 12% | Mixed |
+
+### Violations by Directory (Top 15)
+
+| Directory | Violations | Status |
+|-----------|-----------|--------|
+| `core/` | 6,701 | Excluded |
+| `integrations/` | 1,721 | Excluded |
+| `docket/` | 920 | Excluded |
+| `predictive/` | 890 | Excluded |
+| `superintelligence/` | 702 | Excluded |
+| `backend/` | 572 | Per-file-ignores |
+| `esignature/` | 558 | Excluded |
+| `federal_agencies/` | 530 | Excluded |
+| `phase19/` | 530 | Excluded |
+| `portal/` | 522 | Per-file-ignores |
+| `voice/` | 508 | Excluded |
+| `phase18/` | 487 | Excluded |
+| `financial_mastery/` | 475 | Excluded |
+| `agents/` | 459 | Excluded |
+| `skill_evolution/` | 448 | Excluded |
+
+## CI Command
+
+```yaml
+# .github/workflows/ci.yml — lint job
+- run: ruff check . --output-format=github
+```
+
+Ruff reads `pyproject.toml` automatically. No command-line changes needed.
+
+## How New Violations Fail CI
+
+1. Developer adds code in an active directory (e.g., `portal/routers/new_router.py`)
+2. New file inherits `portal/routers/**` per-file-ignores (ARG001, B008, etc.)
+3. But any OTHER rule violation (e.g., `F821` undefined name) → ruff reports it → CI fails
+4. Developer adds a new module (e.g., `billing/`) — not excluded, full linting applies
+5. Developer modifies an excluded directory (e.g., `core/`) — not linted at all
+
+## Cleanup Ladder
+
+### Phase 1: Auto-fixable bulk cleanup (low risk)
+
+Target rules (17,000+ violations, all auto-fixable):
+```bash
+# Whitespace — safe, no semantic change
+ruff check . --select W291,W292,W293 --fix
+
+# Import sorting — safe with isort config
+ruff check . --select I001 --fix
+
+# Type annotation modernization — safe for Python 3.11+
+ruff check . --select UP006,UP035,UP045 --fix
+```
+
+**After fixing:** Remove the fixed rules from `per-file-ignores`, then remove cleaned directories from `exclude`.
+
+### Phase 2: Targeted manual fixes (medium risk)
+
+| Rule | Count | Fix approach |
+|------|-------|--------------|
+| F401 | 1,187 | Review each — some imports have side effects |
+| B008 | 308 | Move default values to function body |
+| F841 | 267 | Remove or use the variable |
+| B904 | 165 | Add `from` clause to `raise` in `except` |
+
+### Phase 3: Architecture decisions (high effort)
+
+| Rule | Count | Notes |
+|------|-------|-------|
+| DTZ003/DTZ005 | 671 | Requires timezone-aware datetime migration |
+| N999 | 162 | Module naming — may require directory restructuring |
+| ARG001/ARG002 | 644 | Some are by design (interface compliance) |
+
+### Phase 4: Directory re-inclusion
+
+As directories are cleaned up:
+1. Run `ruff check <directory>/` to verify zero violations
+2. Remove the directory from `exclude` in `pyproject.toml`
+3. Add `per-file-ignores` if any residual violations remain
+4. Commit — CI now enforces rules on that directory
+
+Suggested order (by violation count, ascending):
+1. `scripts/` (already in per-file-ignores)
+2. `governance/` (already in per-file-ignores)
+3. `security/` (low count)
+4. `observability/` (low count)
+5. `scheduler/` (low count)
+6. `predictive/` (low count)
+7. Work outward from active directories
+
+## Known Issues
+
+| Issue | Detail |
+|-------|--------|
+| `portal/middleware.py` | Python syntax error — excluded from ruff entirely. Fix the syntax first. |
+| `PHASE_11_14_INTEGRATION_ORCHESTRATOR.py` | Root-level legacy file. Excluded. |
+| Per-file-ignores scope | New files in existing subdirectories inherit that subdirectory's ignores. This is a known ruff limitation — baseline files would be better but don't exist in ruff. |
+
+## Rollback Plan
+
+Revert `pyproject.toml` to previous version. The original config had the same `select` and `ignore` rules but no `exclude` or `per-file-ignores` — ruff will report all 24,378 violations again, and CI lint will fail (same as before this PR).
+
+## Configuration Reference
+
+The baseline lives entirely in `pyproject.toml` under:
+- `[tool.ruff]` → `exclude` list
+- `[tool.ruff.lint.per-file-ignores]` → directory-level suppressions
+
+No separate baseline file. No workflow changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,8 +101,77 @@ target-version = ['py311']
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+
+# ── Baseline exclude list ──────────────────────────────────────────────
+# Legacy/phase directories excluded from linting until cleanup.
+# Each directory is documented in docs/ci/ruff-baseline.md with violation
+# counts and cleanup priority.  As a directory is cleaned, remove it from
+# this list so ruff enforces rules on new commits.
+exclude = [
+    # --- legacy phase directories ---
+    "phase15",
+    "phase16",
+    "phase17",
+    "phase18",
+    "phase19",
+    "PHASE_11_14_INTEGRATION_ORCHESTRATOR.py",
+    # --- feature modules (not actively linted yet) ---
+    "agent_protocol",
+    "agents",
+    "ai_compliance",
+    "app_builder",
+    "apps",
+    "artifacts",
+    "benchmarks",
+    "channels",
+    "claude_code",
+    "core",
+    "cross_platform",
+    "developer_experience",
+    "docket",
+    "emotional_intelligence",
+    "esignature",
+    "federal_agencies",
+    "financial_mastery",
+    "integrations",
+    "legal_integrations",
+    "legal_intelligence",
+    "life_governance",
+    "local_llm",
+    "local_models",
+    "mcp_server",
+    "memory",
+    "multimodal",
+    "observability",
+    "operator",
+    "orchestration",
+    "parl",
+    "performance",
+    "predictive",
+    "rag",
+    "saas",
+    "scheduler",
+    "secure_execution",
+    "security",
+    "skill_evolution",
+    "superintelligence",
+    "trust_law",
+    "twin_layer",
+    "voice",
+    "workflow_builder",
+    # --- non-Python / build artifacts ---
+    "web",
+    "mobile",
+    "node_modules",
+    ".venv",
+    # --- files with known syntax errors ---
+    "portal/middleware.py",
+]
+
 [tool.ruff.lint]
-# Enable plugins
+# ── Target rule set ────────────────────────────────────────────────────
+# These are the rules we WANT enforced long-term.  Rules in `ignore` are
+# globally suppressed; per-file-ignores handles directory-level backlog.
 select = [
     "E",     # pycodestyle errors
     "W",     # pycodestyle warnings
@@ -128,8 +197,41 @@ ignore = [
     "SIM102", # nested-if-statements
     "DTZ011", # datetime.today() (noqa per file)
 ]
+
 [tool.ruff.lint.isort]
 known-first-party = ["portal", "operator"]
+
+[tool.ruff.lint.per-file-ignores]
+# ── Per-file baseline ──────────────────────────────────────────────────
+# Existing violations in active directories, suppressed by path.
+# As violations are fixed in a directory, remove its entry here.
+# See docs/ci/ruff-baseline.md for counts and cleanup priorities.
+#
+# Root-level files
+"__init__.py" = ["N999"]
+"load_test_runner.py" = ["I001", "W292", "W293"]
+"conftest.py" = ["ARG001", "I001", "SIM108"]
+"scripts/**" = ["F401", "F541", "I001"]
+# backend
+"backend/lead-router/**" = ["ARG001", "ARG002", "B007", "B028", "B904", "DTZ003", "F401", "F841", "I001", "PT011", "RUF010", "RUF012", "RUF022", "UP006", "UP035", "UP042", "UP045", "W291", "W293"]
+"backend/stripe-payments/**" = ["ARG002", "B904", "DTZ003", "DTZ006", "F401", "I001", "N999", "PT011", "RET504", "RET505", "RUF012", "RUF022", "UP006", "UP035", "UP042", "UP045", "W293"]
+# governance
+"governance/**" = ["ARG002", "B007", "F401", "F841", "I001", "N999", "RET504", "RET505", "RUF001", "RUF022", "RUF100", "SIM300", "UP006", "UP017", "UP035", "UP037", "UP042", "UP045"]
+# portal
+"portal/admin/**" = ["ARG001"]
+"portal/auth/**" = ["ARG001", "B008", "B904", "N999"]
+"portal/main.py" = ["E402", "W293"]
+"portal/middleware/**" = ["I001", "N999", "RET504", "UP017", "UP035"]
+"portal/models/**" = ["F821", "N999"]
+"portal/routers/**" = ["ARG001", "ARG002", "B008", "B904", "DTZ003", "E741", "F401", "F811", "I001", "N999", "UP006", "UP035"]
+"portal/schemas/**" = ["B904", "N999"]
+"portal/security/**" = ["ARG002", "N999", "W292", "W293"]
+"portal/services/**" = ["ARG001", "ARG002", "F401", "I001", "N806", "N999", "RUF006", "UP006", "UP015", "UP035"]
+"portal/sso/**" = ["ARG001", "ARG002", "B008", "B904", "DTZ003", "N999", "PT011", "RUF012", "RUF043"]
+"portal/tests/**" = ["ARG001", "ARG002", "ARG005", "B017", "DTZ003", "F401", "I001", "N802", "N999", "PT011", "RUF002", "RUF012", "SIM117"]
+"portal/websocket/**" = ["ARG002", "N999", "RUF012"]
+# tests
+"tests/**" = ["ARG002", "F401", "F811", "F841", "I001", "N802", "N999", "PT009", "PT011", "PT027", "RUF059"]
 
 [tool.pytest.ini_options]
 testpaths = ["portal/tests", "packages/tests"]


### PR DESCRIPTION
## Ruff Baseline Config

Makes CI lint pass by encoding the existing violation backlog as ruff configuration — no source code changes, no auto-fixes, no workflow edits.

---

### Strategy

Ruff doesn't have a `--baseline` file like bandit. Instead, the baseline is encoded in `pyproject.toml` through two layers:

1. **Directory exclusions** (`[tool.ruff] exclude`) — 48 legacy/phase directories containing 22,925 of 24,378 violations (94%)
2. **Per-file-ignores** (`[tool.ruff.lint.per-file-ignores]`) — 21 entries for active directories (`portal/`, `backend/`, `tests/`, `governance/`, root files)

### Current violation landscape

```
Total violations:          24,378
Unique rules:              105
Files with violations:     741
Directories excluded:      48
Per-file-ignore entries:   21
After baseline:            0
```

### Top violation categories

| Category | Count | % |
|----------|-------|---|
| Whitespace (W293/W291/W292) | 6,566 | 27% |
| Type modernization (UP006/UP035/UP045) | 10,225 | 42% |
| Import sorting (I001) | 628 | 3% |
| Unused imports/vars (F401/F841/F541) | 1,669 | 7% |
| Datetime timezone (DTZ*) | 722 | 3% |
| Bugbear (B*) | 595 | 2% |
| Other | 3,973 | 16% |

### What this PR does NOT do

- ❌ No source code changes
- ❌ No auto-fixes applied
- ❌ No workflow file edits
- ❌ No rules removed from `select` (target rule set preserved)
- ❌ No rules added to `ignore` (only existing ignores preserved)

### Files changed

| File | What changed |
|------|-------------|
| `pyproject.toml` | Added `exclude` list + `per-file-ignores` to `[tool.ruff]` |
| `docs/ci/ruff-baseline.md` | New — baseline strategy, cleanup ladder, rollback plan |

### How new violations are caught

- New code in **active directories** (portal, backend, tests, governance): enforced for all rules EXCEPT per-file-ignores for that subdirectory
- New code in **new directories** (not in exclude list): full rule enforcement
- New code in **excluded directories**: not linted (these are legacy)

### Cleanup ladder (documented in ruff-baseline.md)

| Phase | Target | Count | Risk |
|-------|--------|-------|------|
| 1 | Auto-fix whitespace, imports, type annotations | 17,000+ | Low |
| 2 | Manual fixes: unused imports, bugbear, raise-from | ~2,000 | Medium |
| 3 | Architecture: datetime tz, module naming | ~1,000 | High |
| 4 | Re-include excluded directories | — | Per-dir |

### CI verification receipt — commit `ae540faa`

| Job | Result |
|-----|--------|
| SintraPrime CI test | ✅ success |
| SintraPrime CI lint | ✅ success |
| SintraPrime CI security | ✅ success |
| IssueVerifier | ✅ success |
| Sigma Gate | ❌ pre-existing coverage statement/branch mismatch |

### Local verification

```
$ ruff check . 
All checks passed!
Exit code: 0
```

### Rollback plan

Revert `pyproject.toml` to previous version. Lint CI will fail again with 24,378 violations (same as before this PR).
