### PR TITLE
fix: Sigma Gate — Bandit runs with if: always() (#102)

### DIFF
--- a/.github/workflows/sigma-gate.yml
+++ b/.github/workflows/sigma-gate.yml
@@ -59,7 +59,9 @@ jobs:
 
       # P0-002: || true removed. Bandit now uses .bandit-baseline.json so only
       # NEW findings (regressions) fail the build, not the 114 pre-existing ones.
+      # P0-102: if: always() ensures bandit runs even when coverage threshold fails.
       - name: Security scan (bandit — baseline mode)
+        if: always()
         run: |
           python -m bandit -r . \
             --exclude .venv,node_modules,tests \

--- a/docs/ci/sigma-gate-policy.md
+++ b/docs/ci/sigma-gate-policy.md
@@ -1,0 +1,55 @@
+# Sigma Gate Policy — PR #102
+
+## Change
+
+Added `if: always()` to the Bandit security scan step in `.github/workflows/sigma-gate.yml`.
+
+## Why
+
+Before this change, the Sigma Gate workflow had a cascading-skip problem:
+
+```
+Step 1: Run tests with coverage     → ✅ passes
+Step 2: Enforce coverage threshold   → ❌ fails (63% < 80%)
+Step 3: Security scan (bandit)       → ⏭️ SKIPPED (because Step 2 failed)
+Step 4: Post gate status             → ✅ runs (has if: always())
+```
+
+Security scanning should run regardless of whether coverage meets its threshold.
+The bandit step is independent — it scans for new security findings, not coverage.
+
+## After
+
+```
+Step 1: Run tests with coverage     → ✅ passes
+Step 2: Enforce coverage threshold   → ❌ fails (63% < 80%)
+Step 3: Security scan (bandit)       → ✅ RUNS (if: always())
+Step 4: Post gate status             → ✅ runs (if: always())
+```
+
+## Coverage Threshold Decision (deferred)
+
+Current state: 63.0% measured, 80% threshold.
+
+| Option | Description | Trade-off |
+|--------|-------------|-----------|
+| A | Keep 80%, write tests | Sigma Gate stays red until scheduler coverage improves |
+| B | Lower to 60%, ratchet | Sigma Gate goes green now, ratchet upward over time |
+
+This PR does NOT change the threshold. That is a separate policy decision.
+
+## Coverage Baseline
+
+As of PR #101 merge:
+- agents/nova: 88%
+- agents/sigma: 74%
+- agents/zero: 73%
+- scheduler: 32%
+- TOTAL: 63%
+
+Gap to 80%: ~351 lines (primarily scheduler at 32%).
+
+## Rollback
+
+Remove `if: always()` from the bandit step. Security scan will revert to being skipped
+when coverage threshold fails.


### PR DESCRIPTION
## Sigma Gate Policy Decision — Bandit `if: always()`

Workflow commit applied at `f0162c9`. Bandit now runs with `if: always()`.

---

### Problem

After PR #101 fixed the DataError crash, Sigma Gate now fails honestly at 63% < 80% coverage threshold. However, this threshold failure **cascaded to skip the Bandit security scan step** because it lacked `if: always()`.

Security scanning is independent of coverage — it should always run.

### Fix

Added `if: always()` to the Bandit step in `sigma-gate.yml` (commit `f0162c9`).

```diff
       # P0-002: || true removed. Bandit now uses .bandit-baseline.json so only
       # NEW findings (regressions) fail the build, not the 114 pre-existing ones.
+      # P0-102: if: always() ensures bandit runs even when coverage threshold fails.
       - name: Security scan (bandit — baseline mode)
+        if: always()
         run: |
```

### Files Changed

| File | What changed |
|------|-------------|
| `.github/workflows/sigma-gate.yml` | Added `if: always()` to Bandit step (commit `f0162c9`) |
| `docs/ci/sigma-gate-policy.md` | Documents the change, coverage baseline, threshold decision |

### What this PR does NOT do

- ❌ No coverage threshold change (stays at 80%)
- ❌ No application source changes
- ❌ No test changes

### Sigma Gate Steps — Before vs After

| Step | Before (PR #101) | After (this PR) |
|------|-------------------|-----------------|
| Run tests with coverage | ✅ 146 passed | ✅ (unchanged) |
| Enforce coverage threshold | ❌ 63% < 80% | ❌ 63% < 80% (unchanged) |
| Security scan (bandit) | ⏭️ SKIPPED | ✅ RUNS — `if: always()` |
| Post gate status | ✅ | ✅ (unchanged) |

### CI Receipt (head: `f0162c9`)

**SintraPrime CI:**
```
test       ✅ success
lint       ✅ success
security   ✅ success
verify     ✅ success
```

**Sigma Gate:**
```
Run tests with coverage        ✅ 146 passed, coverage JSON produced
Enforce coverage threshold     ❌ 63.0% < 80%
Security scan (bandit)         ✅ RUNS and PASSES — 0 findings, 0 HIGH
Post gate status               ✅ success
```

### Coverage Baseline (documented, not changed)

```
agents/nova:     88%
agents/sigma:    74%
agents/zero:     73%
scheduler:       32%
TOTAL:           63%
```

Threshold decision (keep 80% vs lower to 60%) is deferred — separate PR.

### Rollback

Remove `if: always()` from the bandit step in sigma-gate.yml.
