### PR TITLE
fix: ratchet Sigma coverage threshold 60% → 65%

### DIFF
--- a/.github/workflows/sigma-gate.yml
+++ b/.github/workflows/sigma-gate.yml
@@ -51,10 +51,10 @@ jobs:
           data = json.load(open('/tmp/coverage.json'))
           pct = data['totals']['percent_covered']
           print(f'Coverage: {pct:.1f}%')
-          if pct < 60:
-              print(f'FAIL: Coverage {pct:.1f}% < 60% (baseline threshold — target: 80%)')
+          if pct < 65:
+              print(f'FAIL: Coverage {pct:.1f}% < 65% (Stage 1 ratchet — target: 80%)')
               sys.exit(1)
-          print(f'PASS: Coverage {pct:.1f}% meets baseline threshold (60%, target: 80%)')
+          print(f'PASS: Coverage {pct:.1f}% meets Stage 1 threshold (65%, target: 80%)')
           "
 
       # P0-002: || true removed. Bandit now uses .bandit-baseline.json so only

--- a/docs/ci/sigma-gate-coverage.md
+++ b/docs/ci/sigma-gate-coverage.md
@@ -91,6 +91,18 @@ This gives an honest 63% coverage for the tested modules.
 | scheduler/ (all) | 738 | 234 | 32% |
 | **TOTAL** | **2,068** | **1,303** | **63%** |
 
+*After PR #104 (scheduler coverage expansion):*
+
+| Module | Before | After |
+|--------|--------|-------|
+| scheduler/task_types.py | 75% | **100%** |
+| scheduler/task_executor.py | 52% | **100%** |
+| scheduler/task_queue.py | 26% | **99%** |
+| scheduler/task_dispatcher.py | 17% | **98%** |
+| scheduler/recurring_tasks.py | 31% | **98%** |
+| scheduler/task_scheduler.py | 15% | **80%** |
+| **TOTAL** | **63%** | **85%** |
+
 ### By component
 
 | Component | Stmts | Covered | Coverage | Notes |
@@ -98,7 +110,7 @@ This gives an honest 63% coverage for the tested modules.
 | agents/nova | 632 | 556 | 88% | Above 80% |
 | agents/sigma | 282 | 210 | 74% | Close to 80% |
 | agents/zero | 416 | 303 | 73% | Close to 80% |
-| scheduler | 738 | 234 | 32% | Needs test investment |
+| scheduler | 738 | ~700 | ~95% | PR #104 expansion |
 
 ## What's needed to reach 80%
 
@@ -111,8 +123,18 @@ Priority path to 80%:
 3. **agents/sigma/sigma_agent.py** (211 stmts, 69% covered) — close to 80%
 4. **agents/zero/zero_agent.py** (246 stmts, 66% covered) — close to 80%
 
-Alternative: adjust the 80% threshold in `.github/workflows/sigma-gate.yml`
-to 60% initially, with a roadmap to raise it as test coverage improves.
+## Threshold Ratchet Schedule
+
+| Stage | Threshold | Trigger | Status |
+|-------|-----------|---------|--------|
+| Baseline (PR #103) | 60% | Initial policy decision | ✅ Done |
+| Stage 1 (PR #105) | 65% | PR #104 raised coverage to 85% | ✅ Done |
+| Stage 2 | 70% | Next coverage expansion PR | Planned |
+| Stage 3 | 75% | — | Planned |
+| Stage 4 (target) | 80% | Long-term quality target | Planned |
+
+The threshold is ratcheted upward only after coverage demonstrably exceeds the next stage.
+It should never be lowered to pass — only raised after real tests bring coverage above the threshold.
 
 ## Sigma Gate Step-by-Step After Fix
 


### PR DESCRIPTION
## PR #105 — Sigma Threshold Ratchet: 60% → 65%

### What
Ratchets the Sigma Gate coverage threshold from 60% (baseline) to 65% (Stage 1).

### Why
PR #104 raised total coverage from 63% to 85% by adding 182 scheduler tests. Coverage now well exceeds the next ratchet stage (65%).

### Before
- Threshold: 60% (baseline, set in PR #103)
- Coverage: 85% (after PR #104)

### After
- Threshold: 65% (Stage 1 ratchet)
- Coverage: ~85% (unchanged — no test changes in this PR)
- Long-term target: 80%

### Ratchet Schedule
| Stage | Threshold | Status |
|-------|-----------|--------|
| Baseline (PR #103) | 60% | ✅ Done |
| **Stage 1 (this PR)** | **65%** | **Current** |
| Stage 2 | 70% | Planned |
| Stage 3 | 75% | Planned |
| Stage 4 (target) | 80% | Planned |

### Next Planned Ratchet
70% — after the next coverage expansion PR brings coverage above 70% threshold with confidence margin.

### Files Changed
- `.github/workflows/sigma-gate.yml` — threshold `60` → `65`, message updated to say "Stage 1 ratchet"
- `docs/ci/sigma-gate-coverage.md` — added ratchet schedule table, updated coverage breakdown with PR #104 numbers

### What This Does NOT Change
- ❌ No application source code changes
- ❌ No test changes
- ❌ No Bandit behavior changes
- ❌ 80% remains documented as the long-term target

### Workflow Commit
Commit `cbd7484` — `fix: ratchet sigma coverage threshold to 65 percent` (applied by @ihoward40).

### CI Receipt — head `cbd7484`

- SintraPrime CI test ✅ success (1m43s)
- SintraPrime CI lint ✅ success (8s)
- SintraPrime CI security ✅ success (36s)
- IssueVerifier ✅ success (2m16s)
- Sigma Gate ✅ success (4m16s)
- Sigma coverage ✅ 328 passed, ~85% coverage ≥ 65%
- Sigma Bandit ✅ 0 findings, 0 HIGH

### Rollback
Revert threshold in `sigma-gate.yml` from `65` back to `60`.
