### PR TITLE
fix: scheduler datetime cleanup + dispatcher quirk fixes

### DIFF
--- a/scheduler/notification_dispatch.py
+++ b/scheduler/notification_dispatch.py
@@ -9,7 +9,7 @@ import json
 import logging
 import smtplib
 import urllib.request
-from datetime import datetime
+from datetime import datetime, timezone
 from email.mime.text import MIMEText
 from typing import Any, Dict, List, Optional
 
@@ -174,7 +174,7 @@ class NotificationDispatch:
         elif ch == "webhook":
             self._send_webhook(
                 self._config.get("webhook_url", ""),
-                payload={"message": body, "timestamp": datetime.utcnow().isoformat()},
+                payload={"message": body, "timestamp": datetime.now(timezone.utc).isoformat()},
             )
         else:
             logger.warning("Unknown notification channel: '%s'", channel)

--- a/scheduler/recurring_tasks.py
+++ b/scheduler/recurring_tasks.py
@@ -6,7 +6,7 @@ All tasks are designed for 24/7 autonomous operation.
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from .task_types import Schedule, ScheduledTask, TaskType
@@ -28,7 +28,7 @@ def daily_case_law_digest(**kwargs) -> Dict:
     logger.info("[RecurringTask] Running daily_case_law_digest")
     practice_areas = kwargs.get("practice_areas", ["civil", "criminal", "tax"])
     result = {
-        "fetched_at": datetime.utcnow().isoformat(),
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
         "practice_areas": practice_areas,
         "new_cases": [],        # populated by real API call
         "summary": "Daily case law digest completed (stub).",
@@ -45,7 +45,7 @@ def weekly_deadline_check(**kwargs) -> Dict:
     logger.info("[RecurringTask] Running weekly_deadline_check")
     warning_days = kwargs.get("warning_days", 14)
     result = {
-        "checked_at": datetime.utcnow().isoformat(),
+        "checked_at": datetime.now(timezone.utc).isoformat(),
         "warning_days": warning_days,
         "upcoming_deadlines": [],   # populated from matters DB
         "overdue": [],
@@ -59,7 +59,7 @@ def monthly_credit_report(**kwargs) -> Dict:
     """Generates a financial health summary for the firm (AR, collections, trust accounts)."""
     logger.info("[RecurringTask] Running monthly_credit_report")
     result = {
-        "period": datetime.utcnow().strftime("%Y-%m"),
+        "period": datetime.now(timezone.utc).strftime("%Y-%m"),
         "total_ar": 0.0,
         "collected": 0.0,
         "trust_balance": 0.0,
@@ -78,7 +78,7 @@ def court_docket_monitor(**kwargs) -> Dict:
     logger.info("[RecurringTask] Running court_docket_monitor")
     case_numbers = kwargs.get("case_numbers", [])
     result = {
-        "checked_at": datetime.utcnow().isoformat(),
+        "checked_at": datetime.now(timezone.utc).isoformat(),
         "case_numbers": case_numbers,
         "new_filings": [],      # populated by PACER / court API
         "summary": f"Docket monitor checked {len(case_numbers)} case(s) (stub).",
@@ -94,7 +94,7 @@ def regulatory_update_check(**kwargs) -> Dict:
     logger.info("[RecurringTask] Running regulatory_update_check")
     agencies = kwargs.get("agencies", ["IRS", "SEC", "CFPB", "DOJ"])
     result = {
-        "checked_at": datetime.utcnow().isoformat(),
+        "checked_at": datetime.now(timezone.utc).isoformat(),
         "agencies": agencies,
         "new_rules": [],        # populated by agency RSS / API
         "summary": f"Regulatory update check for {agencies} completed (stub).",
@@ -109,7 +109,7 @@ def client_followup_reminders(**kwargs) -> Dict:
     """
     logger.info("[RecurringTask] Running client_followup_reminders")
     result = {
-        "checked_at": datetime.utcnow().isoformat(),
+        "checked_at": datetime.now(timezone.utc).isoformat(),
         "reminders_sent": 0,
         "matters_reviewed": 0,
         "summary": "Client follow-up reminders completed (stub).",
@@ -129,7 +129,7 @@ def system_health_check(**kwargs) -> Dict:
     logger.info("[RecurringTask] Running system_health_check")
     disk = shutil.disk_usage("/")
     result = {
-        "checked_at": datetime.utcnow().isoformat(),
+        "checked_at": datetime.now(timezone.utc).isoformat(),
         "python_version": sys.version,
         "disk_free_gb": round(disk.free / 1e9, 2),
         "disk_used_pct": round(disk.used / disk.total * 100, 1),

--- a/scheduler/scheduler_api.py
+++ b/scheduler/scheduler_api.py
@@ -9,7 +9,7 @@ Mount in your main FastAPI app:
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 try:
@@ -214,7 +214,7 @@ def scheduler_status():
         "total_tasks": len(all_tasks),
         "by_status": by_status,
         "report": _dispatcher.status_report(),
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
 

--- a/scheduler/task_dispatcher.py
+++ b/scheduler/task_dispatcher.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, List, Optional
 
 from .task_types import Schedule, ScheduledTask, TaskStatus, TaskType
@@ -29,7 +29,7 @@ _INTERVAL_PATTERNS = [
     (re.compile(r"every\s+(\d+)\s+minute", re.I), "minutes"),
     (re.compile(r"every\s+(\d+)\s+hour", re.I), "hours"),
     (re.compile(r"every\s+(\d+)\s+day", re.I), "days"),
-    (re.compile(r"every\s+minute", re.I), "1_minute"),
+    (re.compile(r"every\s+minute", re.I), "1_minutes"),
     (re.compile(r"every\s+hour", re.I), "60_minutes"),
     (re.compile(r"every\s+day|daily", re.I), "1440_minutes"),
     (re.compile(r"every\s+week|weekly", re.I), "10080_minutes"),
@@ -38,7 +38,7 @@ _INTERVAL_PATTERNS = [
 
 _TIME_PATTERN = re.compile(r"at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?", re.I)
 _WEEKDAY_PATTERN = re.compile(
-    r"every\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tue|wed|thu|fri|sat|sun)",
+    r"every\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tue|wed|thu|fri|sat|sun)\b",
     re.I,
 )
 
@@ -195,7 +195,7 @@ class TaskDispatcher:
         if in_m:
             num = int(in_m.group(1))
             unit = in_m.group(2)
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             if unit == "minute":
                 run_at = now + timedelta(minutes=num)
             elif unit == "hour":
@@ -209,14 +209,14 @@ class TaskDispatcher:
             hour, minute = _parse_time(text)
             h = hour if hour is not None else 9
             mn = minute if minute is not None else 0
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             run_at = (now + timedelta(days=1)).replace(
                 hour=h, minute=mn, second=0, microsecond=0
             )
             return Schedule(run_at=run_at)
 
         # --- fallback: run immediately (1 second from now)
-        return Schedule(run_at=datetime.utcnow() + timedelta(seconds=1))
+        return Schedule(run_at=datetime.now(timezone.utc) + timedelta(seconds=1))
 
     def dispatch_to_agent(
         self, task: ScheduledTask, agent_type: str

--- a/scheduler/task_executor.py
+++ b/scheduler/task_executor.py
@@ -17,7 +17,7 @@ import threading
 import time
 import traceback
 from contextlib import redirect_stderr, redirect_stdout
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from .task_types import ScheduledTask, TaskResult, TaskStatus
@@ -105,7 +105,7 @@ class TaskExecutor:
 
     def _execute_once(self, task: ScheduledTask, timeout: int) -> TaskResult:
         """Run the task's callable once with timeout and output capture."""
-        start = datetime.utcnow()
+        start = datetime.now(timezone.utc)
         result_holder: Dict[str, Any] = {}
         stdout_buf = io.StringIO()
         stderr_buf = io.StringIO()
@@ -124,7 +124,7 @@ class TaskExecutor:
         thread.start()
         thread.join(timeout=timeout)
 
-        duration_ms = (datetime.utcnow() - start).total_seconds() * 1000
+        duration_ms = (datetime.now(timezone.utc) - start).total_seconds() * 1000
 
         if thread.is_alive():
             # Thread timed out — we can't forcefully kill it in CPython,

--- a/scheduler/task_scheduler.py
+++ b/scheduler/task_scheduler.py
@@ -10,7 +10,7 @@ import logging
 import sqlite3
 import threading
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Callable, Dict, List, Optional
 
 from .task_types import Schedule, ScheduledTask, TaskResult, TaskStatus, TaskType
@@ -230,7 +230,7 @@ class TaskScheduler:
         if sched is None:
             return
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         if sched.run_at:
             delay = max(0.0, (sched.run_at - now).total_seconds())
@@ -253,7 +253,7 @@ class TaskScheduler:
                 task = self._tasks.get(task_id)
             if task and task.status not in (TaskStatus.CANCELLED, TaskStatus.PAUSED):
                 self._run_task(task_id)
-                task.next_run = datetime.utcnow() + timedelta(seconds=interval_seconds)
+                task.next_run = datetime.now(timezone.utc) + timedelta(seconds=interval_seconds)
                 self._persist_task(task)
                 timer = threading.Timer(interval_seconds, _fire)
                 timer.daemon = True
@@ -282,7 +282,7 @@ class TaskScheduler:
         if not task or task.fn is None:
             return
 
-        start = datetime.utcnow()
+        start = datetime.now(timezone.utc)
         task.status = TaskStatus.RUNNING
         task.last_run = start
         task.run_count += 1
@@ -290,7 +290,7 @@ class TaskScheduler:
 
         try:
             output = task.fn(**task.payload)
-            duration_ms = (datetime.utcnow() - start).total_seconds() * 1000
+            duration_ms = (datetime.now(timezone.utc) - start).total_seconds() * 1000
             result = TaskResult(
                 task_id=task_id,
                 success=True,
@@ -308,7 +308,7 @@ class TaskScheduler:
                 except Exception:
                     pass
         except Exception as exc:  # noqa: BLE001
-            duration_ms = (datetime.utcnow() - start).total_seconds() * 1000
+            duration_ms = (datetime.now(timezone.utc) - start).total_seconds() * 1000
             import traceback
 
             result = TaskResult(
@@ -364,7 +364,7 @@ class TaskScheduler:
             with sqlite3.connect(self._db_path) as conn:
                 conn.execute(
                     "INSERT OR REPLACE INTO tasks (id, data, updated_at) VALUES (?, ?, ?)",
-                    (task.id, json.dumps(task.to_dict()), datetime.utcnow().isoformat()),
+                    (task.id, json.dumps(task.to_dict()), datetime.now(timezone.utc).isoformat()),
                 )
                 conn.commit()
         except Exception as exc:

--- a/scheduler/task_types.py
+++ b/scheduler/task_types.py
@@ -6,9 +6,21 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
+
+
+def _utcnow() -> datetime:
+    """Return current UTC time as a timezone-aware datetime."""
+    return datetime.now(timezone.utc)
+
+
+def _make_aware(dt: datetime) -> datetime:
+    """Ensure a datetime is timezone-aware (assume UTC if naive)."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 # ---------------------------------------------------------------------------
@@ -77,7 +89,7 @@ class ScheduledTask:
     payload: Dict[str, Any] = field(default_factory=dict)
     status: TaskStatus = TaskStatus.PENDING
     created_by: str = "system"
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=_utcnow)
     last_run: Optional[datetime] = None
     next_run: Optional[datetime] = None
     run_count: int = 0
@@ -135,7 +147,7 @@ class ScheduledTask:
                 cron_expr=schedule_data.get("cron_expr"),
                 interval_minutes=schedule_data.get("interval_minutes"),
                 trigger_event=schedule_data.get("trigger_event"),
-                run_at=datetime.fromisoformat(run_at) if run_at else None,
+                run_at=_make_aware(datetime.fromisoformat(run_at)) if run_at else None,
             )
         return cls(
             id=data["id"],
@@ -146,14 +158,14 @@ class ScheduledTask:
             payload=data.get("payload", {}),
             status=TaskStatus(data.get("status", "pending")),
             created_by=data.get("created_by", "system"),
-            created_at=datetime.fromisoformat(data["created_at"]),
+            created_at=_make_aware(datetime.fromisoformat(data["created_at"])),
             last_run=(
-                datetime.fromisoformat(data["last_run"])
+                _make_aware(datetime.fromisoformat(data["last_run"]))
                 if data.get("last_run")
                 else None
             ),
             next_run=(
-                datetime.fromisoformat(data["next_run"])
+                _make_aware(datetime.fromisoformat(data["next_run"]))
                 if data.get("next_run")
                 else None
             ),
@@ -173,7 +185,7 @@ class TaskResult:
     output: Any = None
     error: Optional[str] = None
     duration_ms: float = 0.0
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=_utcnow)
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/tests/test_scheduler_core.py
+++ b/tests/test_scheduler_core.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import time
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -52,7 +52,7 @@ def _make_task(name="task", fn=None, **overrides):
         "name": name,
         "description": f"Test task: {name}",
         "task_type": TaskType.ONE_TIME,
-        "schedule": Schedule(run_at=datetime.utcnow() + timedelta(hours=1)),  # noqa: DTZ003
+        "schedule": Schedule(run_at=datetime.now(timezone.utc) + timedelta(hours=1)),
         "payload": {},
         "fn": fn or _noop,
     }
@@ -123,7 +123,7 @@ class TestSchedulingAPI:
         assert found.name == "find_me"
 
     def test_schedule_once(self, scheduler):
-        run_at = datetime.utcnow() + timedelta(hours=2) # noqa: DTZ003
+        run_at = datetime.now(timezone.utc) + timedelta(hours=2)
         task_id = scheduler.schedule_once("once", _noop, run_at, payload={"x": 1})
         assert isinstance(task_id, str)
         task = scheduler.get_task(task_id)
@@ -218,7 +218,7 @@ class TestQueryAPI:
         assert scheduler.get_task("nonexistent") is None
 
     def test_next_run_time(self, scheduler):
-        run_at = datetime.utcnow() + timedelta(hours=5) # noqa: DTZ003
+        run_at = datetime.now(timezone.utc) + timedelta(hours=5)
         task = _make_task(schedule=Schedule(run_at=run_at))
         task.next_run = run_at
         scheduler.schedule(task)
@@ -399,7 +399,7 @@ class TestPersistence:
 
 class TestArming:
     def test_arm_threading_run_at(self, scheduler):
-        run_at = datetime.utcnow() + timedelta(hours=1) # noqa: DTZ003
+        run_at = datetime.now(timezone.utc) + timedelta(hours=1)
         task = _make_task(schedule=Schedule(run_at=run_at), fn=_noop)
         scheduler.start()
         scheduler.schedule(task)
@@ -445,7 +445,7 @@ class TestArming:
 
     def test_disarm_removes_timer(self, scheduler):
         task = _make_task(
-            schedule=Schedule(run_at=datetime.utcnow() + timedelta(hours=1)), # noqa: DTZ003
+            schedule=Schedule(run_at=datetime.now(timezone.utc) + timedelta(hours=1)),
             fn=_noop,
         )
         scheduler.start()

--- a/tests/test_scheduler_core.py
+++ b/tests/test_scheduler_core.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -52,7 +52,7 @@ def _make_task(name="task", fn=None, **overrides):
         "name": name,
         "description": f"Test task: {name}",
         "task_type": TaskType.ONE_TIME,
-        "schedule": Schedule(run_at=datetime.now(timezone.utc) + timedelta(hours=1)),
+        "schedule": Schedule(run_at=datetime.now(UTC) + timedelta(hours=1)),
         "payload": {},
         "fn": fn or _noop,
     }
@@ -123,7 +123,7 @@ class TestSchedulingAPI:
         assert found.name == "find_me"
 
     def test_schedule_once(self, scheduler):
-        run_at = datetime.now(timezone.utc) + timedelta(hours=2)
+        run_at = datetime.now(UTC) + timedelta(hours=2)
         task_id = scheduler.schedule_once("once", _noop, run_at, payload={"x": 1})
         assert isinstance(task_id, str)
         task = scheduler.get_task(task_id)
@@ -218,7 +218,7 @@ class TestQueryAPI:
         assert scheduler.get_task("nonexistent") is None
 
     def test_next_run_time(self, scheduler):
-        run_at = datetime.now(timezone.utc) + timedelta(hours=5)
+        run_at = datetime.now(UTC) + timedelta(hours=5)
         task = _make_task(schedule=Schedule(run_at=run_at))
         task.next_run = run_at
         scheduler.schedule(task)
@@ -399,7 +399,7 @@ class TestPersistence:
 
 class TestArming:
     def test_arm_threading_run_at(self, scheduler):
-        run_at = datetime.now(timezone.utc) + timedelta(hours=1)
+        run_at = datetime.now(UTC) + timedelta(hours=1)
         task = _make_task(schedule=Schedule(run_at=run_at), fn=_noop)
         scheduler.start()
         scheduler.schedule(task)
@@ -445,7 +445,7 @@ class TestArming:
 
     def test_disarm_removes_timer(self, scheduler):
         task = _make_task(
-            schedule=Schedule(run_at=datetime.now(timezone.utc) + timedelta(hours=1)),
+            schedule=Schedule(run_at=datetime.now(UTC) + timedelta(hours=1)),
             fn=_noop,
         )
         scheduler.start()

--- a/tests/test_scheduler_dispatcher.py
+++ b/tests/test_scheduler_dispatcher.py
@@ -4,7 +4,7 @@ Tests for scheduler/task_dispatcher.py — NL parsing, dispatch, agents, status.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -140,11 +140,16 @@ class TestScheduleParsing:
         assert "1 * *" in s.cron_expr
 
     def test_monthly_at_2pm(self, dispatcher):
-        # Note: "every month at 2pm" triggers the weekday pattern because
-        # "mon" in "month" matches the "mon" abbreviation in _WEEKDAY_PATTERN.
-        # This is a known parser quirk. Use "monthly at 2pm" for actual monthly.
         s = dispatcher.parse_schedule_from_text("monthly at 2pm")
         assert s.cron_expr is not None
+        assert "14" in s.cron_expr
+
+    def test_every_month_at_2pm_regression(self, dispatcher):
+        """Regression: 'every month at 2pm' must NOT match 'mon' as Monday."""
+        s = dispatcher.parse_schedule_from_text("every month at 2pm")
+        assert s.cron_expr is not None
+        # Must be a monthly cron (day-of-month = 1), not a weekday cron
+        assert "1 * *" in s.cron_expr
         assert "14" in s.cron_expr
 
     def test_every_30_minutes(self, dispatcher):
@@ -160,9 +165,12 @@ class TestScheduleParsing:
         assert s.interval_minutes == 2880
 
     def test_every_1_minute(self, dispatcher):
-        # "every minute" (without digit) hits a parser bug (_INTERVAL_PATTERNS
-        # unit "1_minute" doesn't end with "_minutes"). Use "every 1 minute".
         s = dispatcher.parse_schedule_from_text("every 1 minute")
+        assert s.interval_minutes == 1
+
+    def test_every_minute_no_digit_regression(self, dispatcher):
+        """Regression: 'every minute' (no digit) must parse as 1-min interval, not IndexError."""
+        s = dispatcher.parse_schedule_from_text("every minute")
         assert s.interval_minutes == 1
 
     def test_every_1_hour(self, dispatcher):
@@ -172,25 +180,25 @@ class TestScheduleParsing:
     def test_in_2_hours(self, dispatcher):
         s = dispatcher.parse_schedule_from_text("run in 2 hours")
         assert s.run_at is not None
-        expected = datetime.utcnow() + timedelta(hours=2)  # noqa: DTZ003
+        expected = datetime.now(timezone.utc) + timedelta(hours=2)
         assert abs((s.run_at - expected).total_seconds()) < 5
 
     def test_in_30_minutes(self, dispatcher):
         s = dispatcher.parse_schedule_from_text("in 30 minutes")
         assert s.run_at is not None
-        expected = datetime.utcnow() + timedelta(minutes=30)  # noqa: DTZ003
+        expected = datetime.now(timezone.utc) + timedelta(minutes=30)
         assert abs((s.run_at - expected).total_seconds()) < 5
 
     def test_in_1_day(self, dispatcher):
         s = dispatcher.parse_schedule_from_text("in 1 day")
         assert s.run_at is not None
-        expected = datetime.utcnow() + timedelta(days=1)  # noqa: DTZ003
+        expected = datetime.now(timezone.utc) + timedelta(days=1)
         assert abs((s.run_at - expected).total_seconds()) < 5
 
     def test_tomorrow_at_3pm(self, dispatcher):
         s = dispatcher.parse_schedule_from_text("run tomorrow at 3pm")
         assert s.run_at is not None
-        tomorrow = datetime.utcnow() + timedelta(days=1)  # noqa: DTZ003
+        tomorrow = datetime.now(timezone.utc) + timedelta(days=1)
         assert s.run_at.date() == tomorrow.date()
         assert s.run_at.hour == 15
 
@@ -202,7 +210,7 @@ class TestScheduleParsing:
     def test_fallback_immediate(self, dispatcher):
         s = dispatcher.parse_schedule_from_text("do something unclear")
         assert s.run_at is not None
-        diff = abs((s.run_at - datetime.utcnow()).total_seconds())  # noqa: DTZ003
+        diff = abs((s.run_at - datetime.now(timezone.utc)).total_seconds())
         assert diff < 5  # runs almost immediately
 
     def test_weekday_abbrev_wed(self, dispatcher):
@@ -239,7 +247,7 @@ class TestDispatch:
         assert task.payload == {"env": "test"}
 
     def test_dispatch_with_deadline(self, dispatcher, scheduler):
-        deadline = datetime.utcnow() + timedelta(days=1)  # noqa: DTZ003
+        deadline = datetime.now(timezone.utc) + timedelta(days=1)
         tid = dispatcher.dispatch("run now", fn=_noop, deadline=deadline)
         task = scheduler.get_task(tid)
         # Deadline is passed as next_run to ScheduledTask, but _arm_threading

--- a/tests/test_scheduler_dispatcher.py
+++ b/tests/test_scheduler_dispatcher.py
@@ -4,7 +4,7 @@ Tests for scheduler/task_dispatcher.py — NL parsing, dispatch, agents, status.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -180,25 +180,25 @@ class TestScheduleParsing:
     def test_in_2_hours(self, dispatcher):
         s = dispatcher.parse_schedule_from_text("run in 2 hours")
         assert s.run_at is not None
-        expected = datetime.now(timezone.utc) + timedelta(hours=2)
+        expected = datetime.now(UTC) + timedelta(hours=2)
         assert abs((s.run_at - expected).total_seconds()) < 5
 
     def test_in_30_minutes(self, dispatcher):
         s = dispatcher.parse_schedule_from_text("in 30 minutes")
         assert s.run_at is not None
-        expected = datetime.now(timezone.utc) + timedelta(minutes=30)
+        expected = datetime.now(UTC) + timedelta(minutes=30)
         assert abs((s.run_at - expected).total_seconds()) < 5
 
     def test_in_1_day(self, dispatcher):
         s = dispatcher.parse_schedule_from_text("in 1 day")
         assert s.run_at is not None
-        expected = datetime.now(timezone.utc) + timedelta(days=1)
+        expected = datetime.now(UTC) + timedelta(days=1)
         assert abs((s.run_at - expected).total_seconds()) < 5
 
     def test_tomorrow_at_3pm(self, dispatcher):
         s = dispatcher.parse_schedule_from_text("run tomorrow at 3pm")
         assert s.run_at is not None
-        tomorrow = datetime.now(timezone.utc) + timedelta(days=1)
+        tomorrow = datetime.now(UTC) + timedelta(days=1)
         assert s.run_at.date() == tomorrow.date()
         assert s.run_at.hour == 15
 
@@ -210,7 +210,7 @@ class TestScheduleParsing:
     def test_fallback_immediate(self, dispatcher):
         s = dispatcher.parse_schedule_from_text("do something unclear")
         assert s.run_at is not None
-        diff = abs((s.run_at - datetime.now(timezone.utc)).total_seconds())
+        diff = abs((s.run_at - datetime.now(UTC)).total_seconds())
         assert diff < 5  # runs almost immediately
 
     def test_weekday_abbrev_wed(self, dispatcher):
@@ -247,7 +247,7 @@ class TestDispatch:
         assert task.payload == {"env": "test"}
 
     def test_dispatch_with_deadline(self, dispatcher, scheduler):
-        deadline = datetime.now(timezone.utc) + timedelta(days=1)
+        deadline = datetime.now(UTC) + timedelta(days=1)
         tid = dispatcher.dispatch("run now", fn=_noop, deadline=deadline)
         task = scheduler.get_task(tid)
         # Deadline is passed as next_run to ScheduledTask, but _arm_threading

--- a/tests/test_scheduler_executor.py
+++ b/tests/test_scheduler_executor.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import os
 import time
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -47,7 +47,7 @@ def _make_task(fn=None, name="exec_task", max_retries=0, timeout_seconds=5):
     task = ScheduledTask(
         name=name,
         task_type=TaskType.ONE_TIME,
-        schedule=Schedule(run_at=datetime.utcnow() + timedelta(hours=1)), # noqa: DTZ003
+        schedule=Schedule(run_at=datetime.now(timezone.utc) + timedelta(hours=1)),
         fn=fn or _noop,
         max_retries=max_retries,
     )

--- a/tests/test_scheduler_executor.py
+++ b/tests/test_scheduler_executor.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import os
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -47,7 +47,7 @@ def _make_task(fn=None, name="exec_task", max_retries=0, timeout_seconds=5):
     task = ScheduledTask(
         name=name,
         task_type=TaskType.ONE_TIME,
-        schedule=Schedule(run_at=datetime.now(timezone.utc) + timedelta(hours=1)),
+        schedule=Schedule(run_at=datetime.now(UTC) + timedelta(hours=1)),
         fn=fn or _noop,
         max_retries=max_retries,
     )

--- a/tests/test_scheduler_queue.py
+++ b/tests/test_scheduler_queue.py
@@ -5,7 +5,7 @@ Tests for scheduler/task_queue.py — priority queue, thread safety, async bridg
 from __future__ import annotations
 
 import threading
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -22,7 +22,7 @@ def _make_task(name="task"):
     return ScheduledTask(
         name=name,
         task_type=TaskType.ONE_TIME,
-        schedule=Schedule(run_at=datetime.utcnow() + timedelta(hours=1)), # noqa: DTZ003
+        schedule=Schedule(run_at=datetime.now(timezone.utc) + timedelta(hours=1)),
     )
 
 

--- a/tests/test_scheduler_queue.py
+++ b/tests/test_scheduler_queue.py
@@ -5,7 +5,7 @@ Tests for scheduler/task_queue.py — priority queue, thread safety, async bridg
 from __future__ import annotations
 
 import threading
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -22,7 +22,7 @@ def _make_task(name="task"):
     return ScheduledTask(
         name=name,
         task_type=TaskType.ONE_TIME,
-        schedule=Schedule(run_at=datetime.now(timezone.utc) + timedelta(hours=1)),
+        schedule=Schedule(run_at=datetime.now(UTC) + timedelta(hours=1)),
     )
 
 

--- a/tests/test_scheduler_task_types.py
+++ b/tests/test_scheduler_task_types.py
@@ -6,7 +6,7 @@ TaskResult.to_dict, TaskPipeline operations.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -35,7 +35,7 @@ class TestSchedule:
         assert s.describe() == "every 30 minute(s)"
 
     def test_describe_run_at(self):
-        dt = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        dt = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
         s = Schedule(run_at=dt)
         assert "once at" in s.describe()
         assert "2026-06-01" in s.describe()
@@ -75,7 +75,7 @@ class TestScheduledTaskSerialization:
         assert d["schedule"]["interval_minutes"] is None
 
     def test_to_dict_with_schedule_run_at(self):
-        run_at = datetime(2026, 7, 1, 10, 0, 0, tzinfo=timezone.utc)
+        run_at = datetime(2026, 7, 1, 10, 0, 0, tzinfo=UTC)
         task = ScheduledTask(
             name="once_task",
             schedule=Schedule(run_at=run_at),
@@ -84,7 +84,7 @@ class TestScheduledTaskSerialization:
         assert d["schedule"]["run_at"] == "2026-07-01T10:00:00+00:00"
 
     def test_to_dict_with_last_run_and_next_run(self):
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         task = ScheduledTask(name="ran", last_run=now, next_run=now + timedelta(hours=1))
         d = task.to_dict()
         assert d["last_run"] is not None
@@ -137,7 +137,7 @@ class TestScheduledTaskSerialization:
             },
         }
         task = ScheduledTask.from_dict(d)
-        assert task.schedule.run_at == datetime(2026, 7, 1, 10, 0, 0, tzinfo=timezone.utc)
+        assert task.schedule.run_at == datetime(2026, 7, 1, 10, 0, 0, tzinfo=UTC)
 
     def test_from_dict_with_last_run_and_next_run(self):
         d = {
@@ -148,8 +148,8 @@ class TestScheduledTaskSerialization:
             "next_run": "2026-06-02T12:00:00",
         }
         task = ScheduledTask.from_dict(d)
-        assert task.last_run == datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
-        assert task.next_run == datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
+        assert task.last_run == datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+        assert task.next_run == datetime(2026, 6, 2, 12, 0, 0, tzinfo=UTC)
 
     def test_roundtrip(self):
         original = ScheduledTask(

--- a/tests/test_scheduler_task_types.py
+++ b/tests/test_scheduler_task_types.py
@@ -6,7 +6,7 @@ TaskResult.to_dict, TaskPipeline operations.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -35,7 +35,7 @@ class TestSchedule:
         assert s.describe() == "every 30 minute(s)"
 
     def test_describe_run_at(self):
-        dt = datetime(2026, 6, 1, 12, 0, 0)  # noqa: DTZ001
+        dt = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
         s = Schedule(run_at=dt)
         assert "once at" in s.describe()
         assert "2026-06-01" in s.describe()
@@ -75,16 +75,16 @@ class TestScheduledTaskSerialization:
         assert d["schedule"]["interval_minutes"] is None
 
     def test_to_dict_with_schedule_run_at(self):
-        run_at = datetime(2026, 7, 1, 10, 0, 0)  # noqa: DTZ001
+        run_at = datetime(2026, 7, 1, 10, 0, 0, tzinfo=timezone.utc)
         task = ScheduledTask(
             name="once_task",
             schedule=Schedule(run_at=run_at),
         )
         d = task.to_dict()
-        assert d["schedule"]["run_at"] == "2026-07-01T10:00:00"
+        assert d["schedule"]["run_at"] == "2026-07-01T10:00:00+00:00"
 
     def test_to_dict_with_last_run_and_next_run(self):
-        now = datetime.utcnow()  # noqa: DTZ003
+        now = datetime.now(timezone.utc)
         task = ScheduledTask(name="ran", last_run=now, next_run=now + timedelta(hours=1))
         d = task.to_dict()
         assert d["last_run"] is not None
@@ -137,7 +137,7 @@ class TestScheduledTaskSerialization:
             },
         }
         task = ScheduledTask.from_dict(d)
-        assert task.schedule.run_at == datetime(2026, 7, 1, 10, 0, 0)  # noqa: DTZ001
+        assert task.schedule.run_at == datetime(2026, 7, 1, 10, 0, 0, tzinfo=timezone.utc)
 
     def test_from_dict_with_last_run_and_next_run(self):
         d = {
@@ -148,8 +148,8 @@ class TestScheduledTaskSerialization:
             "next_run": "2026-06-02T12:00:00",
         }
         task = ScheduledTask.from_dict(d)
-        assert task.last_run == datetime(2026, 6, 1, 12, 0, 0)  # noqa: DTZ001
-        assert task.next_run == datetime(2026, 6, 2, 12, 0, 0)  # noqa: DTZ001
+        assert task.last_run == datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        assert task.next_run == datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
 
     def test_roundtrip(self):
         original = ScheduledTask(


### PR DESCRIPTION
## PR #106 — Scheduler Datetime Cleanup + Dispatcher Quirk Fixes

### What
Replaces deprecated `datetime.utcnow()` with timezone-aware `datetime.now(timezone.utc)` across all scheduler modules, and fixes two dispatcher parsing bugs.

### Why
1. `datetime.utcnow()` is deprecated in Python 3.12+ (DeprecationWarning in every CI run)
2. `"every month at 2pm"` was incorrectly parsed as Monday (weekday regex matched "mon" in "month")
3. `"every minute"` (no digit) raised IndexError (unit string `"1_minute"` didn't match `endswith("_minutes")` check)

### Changes

#### Source files (7 files, app logic changes)

| File | Change |
|------|--------|
| `scheduler/task_types.py` | Added `_utcnow()` helper, `_make_aware()` for tz-safe deserialization, replaced 2× `datetime.utcnow` |
| `scheduler/task_dispatcher.py` | Fixed `_WEEKDAY_PATTERN` (added `\b`), fixed `_INTERVAL_PATTERNS` (`"1_minute"` → `"1_minutes"`), replaced 3× `datetime.utcnow()` |
| `scheduler/task_executor.py` | Replaced 2× `datetime.utcnow()` |
| `scheduler/task_scheduler.py` | Replaced 6× `datetime.utcnow()` |
| `scheduler/recurring_tasks.py` | Replaced 7× `datetime.utcnow()` |
| `scheduler/notification_dispatch.py` | Replaced 1× `datetime.utcnow()` (consistency) |
| `scheduler/scheduler_api.py` | Replaced 1× `datetime.utcnow()` (consistency) |

**Total: 22 `datetime.utcnow()` → `datetime.now(timezone.utc)` replacements**

#### Test files (5 files, test improvements)

| File | Change |
|------|--------|
| `tests/test_scheduler_dispatcher.py` | Added 2 regression tests, removed quirk workaround comments, tz-aware datetimes |
| `tests/test_scheduler_core.py` | tz-aware datetimes, removed `# noqa: DTZ` |
| `tests/test_scheduler_executor.py` | tz-aware datetimes, removed `# noqa: DTZ` |
| `tests/test_scheduler_queue.py` | tz-aware datetimes, removed `# noqa: DTZ` |
| `tests/test_scheduler_task_types.py` | tz-aware datetimes, updated ISO format assertion (+00:00 suffix) |

### Dispatcher Quirk Fixes

#### Fix 1: "every month" matching "mon" as Monday
- **Root cause:** `_WEEKDAY_PATTERN` regex `every\s+(mon|tue|...)` matched "mon" in "month" before the month handler ran
- **Fix:** Added `\b` (word boundary) after the alternation group → `every\s+(mon|tue|...)\b`
- **Regression test:** `test_every_month_at_2pm_regression` — asserts `"every month at 2pm"` produces monthly cron (`1 * *`), not Monday cron

#### Fix 2: "every minute" (no digit) IndexError
- **Root cause:** `_INTERVAL_PATTERNS` unit `"1_minute"` (singular) didn't match `endswith("_minutes")` check → fell through to fallback → IndexError on some paths
- **Fix:** Changed unit string to `"1_minutes"` (plural) → matches the endswith check
- **Regression test:** `test_every_minute_no_digit_regression` — asserts `"every minute"` produces `interval_minutes=1`

### Timezone Migration Strategy

All scheduler modules now use `datetime.now(timezone.utc)` which produces timezone-aware datetimes (`+00:00` suffix in ISO format). To handle existing serialized data (naive datetimes without timezone), `task_types.py` includes:

- `_utcnow()` — single source of truth for "now in UTC"
- `_make_aware(dt)` — ensures deserialized datetimes get `tzinfo=timezone.utc` if naive

This means old serialized data (without `+00:00`) deserializes correctly as UTC.

### What This Does NOT Change
- ❌ No `sigma-gate.yml` changes
- ❌ No threshold changes
- ❌ No Bandit baseline changes
- ❌ No unrelated source cleanup

### Test Count
- Before: 328 passed
- After: 330 passed (+2 regression tests)
- Pre-existing: 1 async test requires pytest-asyncio (not installed in CI — skipped)

### Rollback
Revert this commit. All changes are in `scheduler/` source and `tests/` files.

### Next Step
PR #107 — ratchet Sigma threshold 65% → 70%.
