### PR TITLE
ci: ratchet Sigma threshold 65% → 70%

### DIFF
--- a/.github/workflows/sigma-gate.yml
+++ b/.github/workflows/sigma-gate.yml
@@ -51,10 +51,10 @@ jobs:
           data = json.load(open('/tmp/coverage.json'))
           pct = data['totals']['percent_covered']
           print(f'Coverage: {pct:.1f}%')
-          if pct < 65:
-              print(f'FAIL: Coverage {pct:.1f}% < 65% (Stage 1 ratchet — target: 80%)')
+          if pct < 70:
+              print(f'FAIL: Coverage {pct:.1f}% < 70% (Stage 2 ratchet — target: 80%)')
               sys.exit(1)
-          print(f'PASS: Coverage {pct:.1f}% meets Stage 1 threshold (65%, target: 80%)')
+          print(f'PASS: Coverage {pct:.1f}% meets Stage 2 threshold (70%, target: 80%)')
           "
 
       # P0-002: || true removed. Bandit now uses .bandit-baseline.json so only

--- a/docs/ci/sigma-gate-coverage.md
+++ b/docs/ci/sigma-gate-coverage.md
@@ -129,7 +129,7 @@ Priority path to 80%:
 |-------|-----------|---------|--------|
 | Baseline (PR #103) | 60% | Initial policy decision | ✅ Done |
 | Stage 1 (PR #105) | 65% | PR #104 raised coverage to 85% | ✅ Done |
-| Stage 2 | 70% | Next coverage expansion PR | Planned |
+| Stage 2 (PR #107) | 70% | Coverage at 85%+, dispatcher fixes landed (PR #106) | ✅ Done |
 | Stage 3 | 75% | — | Planned |
 | Stage 4 (target) | 80% | Long-term quality target | Planned |
 


### PR DESCRIPTION
## PR #107 — Ratchet Sigma Threshold 65% → 70%

### What
Ratchets the Sigma Gate coverage threshold from 65% to 70%.

### Why
Coverage currently sits at ~85% (PR #104 scheduler expansion + PR #106 datetime cleanup). The threshold has been sitting at 65% since PR #105 — well below actual coverage. Time to tighten the ratchet per our schedule.

### Changes

| File | Change |
|------|--------|
| `docs/ci/sigma-gate-coverage.md` | Updated ratchet table — Stage 2 marked ✅ Done |
| `.github/workflows/sigma-gate.yml` | Threshold 65% → 70%, Stage 1 → Stage 2 labels (commit `13c748e`) |

### Commits

| Commit | Author | Change |
|--------|--------|--------|
| `168e3c3` | Viktor AI | Docs: ratchet schedule table update |
| `13c748e` | Isiah Howard | Workflow: threshold 65→70, Stage 1→Stage 2 labels |

### CI Receipt — commit `13c748e` ✅

```
lint             ✅  10s
test             ✅  1m38s
security         ✅  35s
verify           ✅  2m19s
Sigma Gate       ✅  4m27s  (70% threshold enforced)
```

All checks pass on the new 70% threshold.

### Ratchet Schedule

| Stage | Threshold | Status |
|-------|-----------|--------|
| Baseline (PR #103) | 60% | ✅ Done |
| Stage 1 (PR #105) | 65% | ✅ Done |
| *Stage 2 (this PR)* | *70%* | *✅ Done* |
| Stage 3 | 75% | Planned |
| Stage 4 (target) | 80% | Long-term target |

### Coverage Headroom
- Current coverage: ~85%
- New threshold: 70%
- Headroom: ~15 percentage points

### What This Does NOT Change
- ❌ No source code changes
- ❌ No test changes
- ❌ No Bandit baseline changes
- ❌ No unrelated cleanup

### Rollback
Revert sigma-gate.yml changes (70 → 65 in 3 places).

### Next Step
Ruff cleanup ladder or Stage 3 ratchet (75%) after next coverage expansion.
