### PR TITLE
fix: remove safe stdlib F401 imports from tests

### DIFF
--- a/tests/test_nova_agent.py
+++ b/tests/test_nova_agent.py
@@ -1,10 +1,7 @@
 """Tests for Agent Nova — Autonomous real-world execution engine."""
 
-import json
 import os
 import sys
-import tempfile
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_scheduler_core.py
+++ b/tests/test_scheduler_core.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 import sqlite3
-import time
 from datetime import UTC, datetime, timedelta
 
 import pytest

--- a/tests/test_sigma_agent.py
+++ b/tests/test_sigma_agent.py
@@ -1,9 +1,7 @@
 """Tests for Agent Sigma — Mandatory test gating guardian."""
 
-import json
 import os
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock, patch
 

--- a/tests/test_zero_agent.py
+++ b/tests/test_zero_agent.py
@@ -5,7 +5,6 @@ import os
 
 # We test in isolation by importing the modules directly
 import sys
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
PR #112 — F401 stdlib-only safe pilot

Scope:
- tests/test_nova_agent.py: removed json, tempfile, pathlib.Path
- tests/test_scheduler_core.py: removed time
- tests/test_sigma_agent.py: removed json, tempfile
- tests/test_zero_agent.py: removed tempfile

What this does not touch:
- No pyproject.toml changes
- No workflow changes
- No excluded directories
- No unittest.mock imports
- No agents.* imports
- No pytest imports
- No __init__.py files
- No pytesseract
- No portal test availability probes

Verification:
- ruff check targeted files --select F401 --isolated
- pytest targeted files
- Full CI required before merge

Sigma remains 70%; 75% ratchet held.