### PR TITLE
fix(tests): remove unused import pytest (F401) — Phase 4 Group A target

### DIFF
--- a/tests/test_scheduler_task_types.py
+++ b/tests/test_scheduler_task_types.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
-import pytest
-
 from scheduler.task_types import (
     Schedule,
     ScheduledTask,


### PR DESCRIPTION
## Summary

Remove unused  from .

## Change

**File:** 
- Remove line 11:  (F401 — unused import)
- Collapse resulting blank line gap (I001 compliance)
- Net: 2 lines removed, 243 lines total

## Verification

Pytest is not used directly in this file:
- No  decorators
- No  calls
- No  references
- Tests use only stdlib -style assertions via the imported fixtures

## Scope

Single file · single import · execution-only · no logic changes

Refs:  — Group A (test fixtures), first of 25 remaining
