### PR TITLE
fix(tests): remove unused TaskResult import (F401) — Phase 4 Group A

### DIFF
--- a/tests/test_scheduler_core.py
+++ b/tests/test_scheduler_core.py
@@ -15,7 +15,6 @@ from scheduler.task_scheduler import TaskScheduler
 from scheduler.task_types import (
     Schedule,
     ScheduledTask,
-    TaskResult,
     TaskStatus,
     TaskType,
 )


### PR DESCRIPTION
## Summary

Remove unused `TaskResult` from `tests/test_scheduler_core.py`.

## Change

**File:** `tests/test_scheduler_core.py`
- Remove `    TaskResult,` (line 18) from multi-line import block
- Net: 1 line removed, 452 lines total

## Verification

`TaskResult` appears exactly once in the file — the import line only. No references in test bodies, fixtures, or assertions.

## Scope

Single file · single import entry · no logic changes

Refs: `docs/ci/ruff-f401-phase-4-audit.md` — Group A (test fixtures), second of 24 remaining