### PR TITLE
fix(tests): remove unused Schedule import (F401) — Phase 4 Group A

### DIFF
--- a/tests/test_scheduler_dispatcher.py
+++ b/tests/test_scheduler_dispatcher.py
@@ -10,7 +10,7 @@ import pytest
 
 from scheduler.task_dispatcher import TaskDispatcher, _parse_time
 from scheduler.task_scheduler import TaskScheduler
-from scheduler.task_types import Schedule, ScheduledTask, TaskType
+from scheduler.task_types import ScheduledTask, TaskType
 
 # ---------------------------------------------------------------------------
 # Fixtures


### PR DESCRIPTION
## Summary

Remove unused `Schedule` from `tests/test_scheduler_dispatcher.py`.

## Change

**File:** `tests/test_scheduler_dispatcher.py`
- Line 13: `from scheduler.task_types import Schedule, ScheduledTask, TaskType`
- Becomes: `from scheduler.task_types import ScheduledTask, TaskType`
- Net: 0 lines delta (inline removal within existing import line)

## Verification

`Schedule` as a standalone token appears exactly twice in the file:
1. The import line itself (line 13)
2. A comment `# Schedule parsing` (line 84)

No usage in test bodies, fixtures, or assertions.

## Scope

Single file · single import symbol · no logic changes

Refs: `docs/ci/ruff-f401-phase-4-audit.md` — Group A (test fixtures)