### PR TITLE
ci: ratchet Sigma threshold 70% → 75%

### DIFF
--- a/.github/workflows/sigma-gate.yml
+++ b/.github/workflows/sigma-gate.yml
@@ -51,10 +51,10 @@ jobs:
           data = json.load(open('/tmp/coverage.json'))
           pct = data['totals']['percent_covered']
           print(f'Coverage: {pct:.1f}%')
-          if pct < 70:
-              print(f'FAIL: Coverage {pct:.1f}% < 70% (Stage 2 ratchet — target: 80%)')
+          if pct < 75:
+              print(f'FAIL: Coverage {pct:.1f}% < 75% (Stage 3 ratchet — target: 80%)')
               sys.exit(1)
-          print(f'PASS: Coverage {pct:.1f}% meets Stage 2 threshold (70%, target: 80%)')
+          print(f'PASS: Coverage {pct:.1f}% meets Stage 3 threshold (75%, target: 80%)')
           "
 
       # P0-002: || true removed. Bandit now uses .bandit-baseline.json so only


### PR DESCRIPTION
## Summary

Ratchet Sigma Gate coverage threshold from 70% to 75%.

## Scope

Changed only `.github/workflows/sigma-gate.yml`.

## Change

- Coverage fail threshold: `70` → `75`
- Stage message: Stage 2 → Stage 3
- Target remains 80%
- Preserved Bandit `if: always()` behavior

## What this does not touch

- No F401 cleanup
- No test file changes
- No pyproject.toml changes
- No excluded-directory changes
- No unrelated workflow edits

## Verification

Full CI required before merge.