### PR TITLE
fix(airlock): change CMD to airlock_server/index.mjs

### DIFF
--- a/apps/sintraprime/Dockerfile
+++ b/apps/sintraprime/Dockerfile
@@ -42,4 +42,4 @@ HEALTHCHECK --interval=15s --timeout=10s --start-period=30s --retries=3 \
 EXPOSE 3001
 
 # Try built TypeScript app first, fallback to airlock_server raw JS
-CMD ["node", "dist/index.js"]
+CMD ["node", "airlock_server/index.mjs"]


### PR DESCRIPTION
## Summary

Changes `CMD` in `apps/sintraprime/Dockerfile` from the TypeScript orchestrator runner to the actual Express HTTP server.

## Problem

The previous `CMD ["node", "dist/index.js"]` pointed to `dist/index.js` — the compiled output of `src/index.ts`, which is an orchestrator runner:
- Has **no HTTP server**
- Has **no `/health` route**
- Runs one task cycle and calls `process.exit(1)` on error

This meant two failure modes on boot:
- If `tsc` build **fails** → `dist/index.js` missing → container crashes immediately
- If `tsc` build **succeeds** → `dist/index.js` runs → no HTTP server → healthcheck fails → restart loop

## Fix

```diff
-CMD ["node", "dist/index.js"]
+CMD ["node", "airlock_server/index.mjs"]
```

`airlock_server/index.mjs` is the correct entry point:
- Express HTTP server that reads `process.env.PORT` (compose sets `PORT=3001`)
- Exposes `GET /health` → `{ status: "healthy" }`
- Already copied into the image via `COPY airlock_server/ ./airlock_server/`

## Scope

| | |
|---|---|
| **Changed files** | 1 — `apps/sintraprime/Dockerfile` |
| **Changed lines** | 1 — L45 only |
| **Workflow changes** | None |
| **pyproject.toml changes** | None |
| **F401 cleanup** | None |
| **Sigma threshold changes** | None |

## Docker Runtime Verification

> ⚠️ **Docker runtime unverified** — Docker is not available in Viktor's sandbox.
>
> Code-path proof instead:
> - `airlock_server/index.mjs` exists in repo at `apps/sintraprime/airlock_server/index.mjs`
> - `const PORT = process.env.PORT || 3000` — picks up `PORT=3001` from compose env
> - `app.get("/health", ...)` confirmed present (line 81)
> - `app.listen(PORT, ...)` confirmed present (line 248)
> - Image already runs `COPY airlock_server/ ./airlock_server/` — file available at runtime

To verify locally after merge:
```bash
docker compose build airlock-server
docker compose up -d postgres redis airlock-server
docker compose ps
curl http://localhost:3001/health
```
