### PR TITLE
fix(airlock): add MANUS_SHARED_SECRET, AIRLOCK_SHARED_SECRET, MAKE_WEBHOOK_URL to compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,9 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
       DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      MANUS_SHARED_SECRET: ${MANUS_SHARED_SECRET:-sintra_local_manus_secret}
+      AIRLOCK_SHARED_SECRET: ${AIRLOCK_SHARED_SECRET:-sintra_local_airlock_secret}
+      MAKE_WEBHOOK_URL: ${MAKE_WEBHOOK_URL:-http://host.docker.internal:9999/mock}
     ports:
       - "3001:3001"
     depends_on:


### PR DESCRIPTION
## Summary

`docker-compose.yml` — airlock-server `environment:` block only.

PR #120 fixed the Airlock packages and writable tmp dir, but a clean `main` restart still fails because `airlock_server/index.mjs` reads three env vars that were not wired into the compose service. This PR wires them in with safe local defaults via shell variable expansion.

---

## Change

**File:** `docker-compose.yml`

Three vars appended after `DISCORD_BOT_TOKEN` in the `airlock-server.environment:` block:

```yaml
      MANUS_SHARED_SECRET: ${MANUS_SHARED_SECRET:-sintra_local_manus_secret}
      AIRLOCK_SHARED_SECRET: ${AIRLOCK_SHARED_SECRET:-sintra_local_airlock_secret}
      MAKE_WEBHOOK_URL: ${MAKE_WEBHOOK_URL:-http://host.docker.internal:9999/mock}
```

Pattern: `${VAR:-default}` — reads from `.env` / shell env if set, otherwise falls back to the safe local default. No secrets hardcoded. No host-port workaround included.

---

## Scope

| | |
|---|---|
| **Changed files** | 1 — `docker-compose.yml` |
| **package.json / lock file** | Not touched |
| **Dockerfile** | Not touched |
| **Workflow changes** | None |
| **pyproject.toml changes** | None |
| **F401 cleanup** | None |
| **Sigma threshold changes** | None |
| **Hardcoded 5433 workaround** | Not included |
