### PR TITLE
Fix root Jest configuration

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    "/apps/",
+    "/mobile/",
+    "/web/",
+    "/.venv/",
+  ],
+
+  modulePathIgnorePatterns: [
+    "<rootDir>/apps/",
+    "<rootDir>/mobile/",
+    "<rootDir>/web/",
+    "<rootDir>/.venv/",
+  ],
+};


### PR DESCRIPTION
Adds a root Jest config so npm test does not scan nested app folders or TypeScript smoke files outside the root test scope.