### PR TITLE
chore: add .nova/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ dist/
 .DS_Store
 .idea/
 .vscode/
+.nova/
 *.swp
 *.swo
 Thumbs.db


### PR DESCRIPTION
## Summary\n\nAdds `.nova/` (Nova IDE runtime state) to `.gitignore` to prevent local tooling scratch files from being tracked.\n\n## Change\n\n- Added `.nova/` to the Editors/OS section of `.gitignore`