### PR TITLE
docs/ci: reconcile dependency and command claims for supported lanes

### DIFF
--- a/.github/workflows/issue-verifier-ci.yml
+++ b/.github/workflows/issue-verifier-ci.yml
@@ -24,7 +24,7 @@ jobs:
           pip install bandit safety email-validator
 
       - name: Run unit tests (scoped)
-        run: pytest -q tests/
+        run: python -m pytest --tb=short -q
 
       # P0-002: bandit now uses .bandit-baseline.json to suppress pre-existing
       # findings. Only NEW issues (regressions) will fail the build.

--- a/.github/workflows/sigma-gate.yml
+++ b/.github/workflows/sigma-gate.yml
@@ -33,12 +33,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-cov bandit mypy
+          pip install ruff==0.15.20 pytest pytest-cov bandit mypy
 
       - name: Run tests with coverage
         run: |
-          python -m pytest tests/ \
+          python -m pytest \
             --tb=short \
+            -q \
             --cov=. \
             --cov-report=json:/tmp/coverage.json \
             --cov-report=term-missing \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## 🚀 Proof in 10 Minutes
 
-**Start here.** Clone, run one command, see a working example in < 10 minutes.
+**Start here.** Clone, install the verified dependencies, and run the supported verification commands.
 
 ### Quick Start
 
@@ -33,21 +33,34 @@ cd SintraPrime-Unified
 # Setup (1 min)
 python -m venv venv
 source venv/bin/activate  # or: venv\Scripts\activate on Windows
-pip install -e ".[dev]"
+pip install -r requirements.txt
+```
 
-# Run demo (2 min)
-docker-compose up -d
-# Nginx: http://localhost  |  API: http://localhost:8080  |  Airlock: http://localhost:3001
+### Verified commands
 
-# See it work (5 min)
-# 1. Login with demo credentials (see README_DEMO.md)
-# 2. Intake a sample trust (Jane Smith, $2.3M)
-# 3. Watch AI generate trust memo
-# 4. See payment processing (Stripe test mode)
-# 5. Download audit receipt
+These commands define the currently supported local verification lane:
 
-# Run tests (2 min)
-pytest tests/ -v --cov=src --cov-report=term-missing
+```bash
+# Python supported test lane
+python -m pytest --tb=short -q
+
+# Web verification
+cd web && npm install
+cd web && npm run lint
+cd web && npm run type-check
+cd web && npm run build
+```
+
+### Full-stack Docker boot
+
+The repository contains `docker-compose.yml` and `Dockerfile` files for a complete deployment (PostgreSQL, Redis, Elasticsearch, MinIO, Prometheus, Grafana, Nginx, API, Airlock, Twin display). Running this stack requires configured environment variables and external services. It is **not** part of the supported quick-start until it is independently verified on your environment. See `docs/DEPLOYMENT.md` for setup details.
+
+### Known limitations / deferred work
+
+- Scheduler arming tests (`tests/test_scheduler_core.py::TestArming`) are currently re-scoped as experimental because they expose an APScheduler trigger adapter bug. The real bug is tracked in Issue #164.
+- Optional integrations (Plaid, predictive analytics, advanced LLM providers) are documented in `docs/ci/DEPENDENCY_MATRIX.md` but are not installed or tested in the default supported CI lane.
+
+**See [docs/CLAIMS.md](docs/CLAIMS.md) for detailed claims with test references.
 ```
 
 **Expected output:**

--- a/docs/ci/DEPENDENCY_MATRIX.md
+++ b/docs/ci/DEPENDENCY_MATRIX.md
@@ -1,0 +1,63 @@
+# Dependency Matrix
+
+This document reconciles the declared dependencies in SintraPrime-Unified.
+
+## Source of truth status
+
+- **`requirements.txt` is the current operational install source** for verified local commands and CI workflows.
+- **`pyproject.toml` remains the intended package metadata source** for a future clean packaging install (`pip install -e .[...]`). It should be reconciled with `requirements.txt` in a later packaging cleanup issue, not in the default supported CI lane.
+- **`requirements-py313-windows.txt`** is a pinned Windows-specific export. It has been updated to pin `ruff==0.15.20` to match the CI lint gate.
+
+## Core / default supported lane
+
+These dependencies are installed by `pip install -r requirements.txt` and exercised by `python -m pytest --tb=short -q`:
+
+| Category | Key packages |
+|---|---|
+| Web framework | fastapi, uvicorn[standard], gunicorn, starlette |
+| Data validation | pydantic, pydantic-settings |
+| Database | sqlalchemy, psycopg2-binary, asyncpg, alembic |
+| Auth/security | python-jose[cryptography], passlib[bcrypt], bcrypt, PyJWT, pyotp, qrcode |
+| HTTP clients | httpx, requests, aiohttp |
+| Async/cache/jobs | aioredis, celery, redis |
+| Payments | stripe |
+| LLM APIs | openai, anthropic |
+| Config/utilities | python-dotenv, pyyaml, click, typer, rich, python-dateutil, pytz, tzlocal |
+| Logging/metrics | python-json-logger, prometheus-client, structlog |
+| Test/quality (installed from requirements.txt) | pytest, pytest-asyncio, pytest-cov, black, ruff, mypy |
+
+## CI lint pin
+
+The required `ruff` version for the default lint gate is:
+
+- **ruff==0.15.20**
+
+CI (`ci.yml` and `sigma-gate.yml`) installs `ruff==0.15.20` explicitly. `requirements-py313-windows.txt` now matches this pin. `requirements.txt` does not pin `ruff` because it is installed separately by CI; future reconciliation may add the pin.
+
+## Optional integration groups
+
+These groups are documented but **not installed or tested in the default supported CI lane** unless explicitly installed and tested:
+
+| Group | File | Packages | Status |
+|---|---|---|---|
+| portal | `pyproject.toml` `[project.optional-dependencies] portal` | PyJWT, requests, email-validator | Partially present in `requirements.txt`; not a separate install target today. |
+| predictive | `pyproject.toml` | pandas, scikit-learn | Not installed by default. |
+| integrations | `pyproject.toml` | aiohttp, plaid-python | `aiohttp` is present in `requirements.txt`; Plaid integration is not wired or tested in the default lane. |
+| all | `pyproject.toml` | Union of the above | Not used by CI. |
+
+## Deferred work
+
+- **Dependency reconciliation between `pyproject.toml` and `requirements.txt`** — future packaging cleanup; not in scope for the default CI lane.
+- **Optional integration activation** — each integration needs its own verified issue, env vars, and tests before it can be promoted to the supported lane.
+- **Scheduler APScheduler trigger adapter repair** — Issue #164. `scheduler/task_scheduler.py` passes a `datetime` object where APScheduler expects a trigger instance or string. This bug is explicitly deferred and is not fixed by this dependency reconciliation.
+
+## Verified commands
+
+```bash
+pip install -r requirements.txt
+python -m pytest --tb=short -q
+cd web && npm install
+cd web && npm run lint
+cd web && npm run type-check
+cd web && npm run build
+```

--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
-    "lint": "eslint . --ext .ts,.tsx",
-    "format": "prettier --write \"**/*.{ts,tsx,json,md}\"",
-    "test": "jest",
-    "test:watch": "jest --watch"
+    "dev": "cd web && npm run dev",
+    "build": "cd web && npm run build",
+    "preview": "cd web && npm run preview",
+    "lint": "cd web && npm run lint",
+    "type-check": "cd web && npm run type-check",
+    "format": "cd web && npm run format",
+    "test": "python -m pytest --tb=short -q",
+    "test:watch": "cd web && npm run test:watch"
   },
   "dependencies": {
     "axios": "^1.6.0",

--- a/requirements-py313-windows.txt
+++ b/requirements-py313-windows.txt
@@ -72,7 +72,7 @@ pytest-cov==5.0.0
 
 # Code quality
 black==24.8.0
-ruff==0.6.9
+ruff==0.15.20
 mypy==1.11.2
 
 # QR codes & email validation


### PR DESCRIPTION
## Summary

Reconciles dependency, install, and command claims with the verified supported lanes.

## Changes

- `README.md`
  - Documents verified install path: `pip install -r requirements.txt`.
  - Documents verified commands: `python -m pytest --tb=short -q`; `cd web && npm run lint/type-check/build`.
  - Replaces one-command Docker/full-stack boot claims with an env-vars/external-services note.
  - Notes scheduler arming bug (#164) and optional integrations as deferred.

- `package.json` (root)
  - Scripts now delegate to the `web/` workspace: `cd web && npm run ...`.
  - `test` script runs `python -m pytest --tb=short -q`.

- `requirements-py313-windows.txt`
  - Pinned `ruff==0.15.20` to match CI lint gate.

- `.github/workflows/sigma-gate.yml` and `.github/workflows/issue-verifier-ci.yml`
  - Aligned pytest commands to `python -m pytest --tb=short -q` (no explicit `tests/` path).
  - `sigma-gate.yml` now installs the CI ruff pin explicitly.

- `docs/ci/DEPENDENCY_MATRIX.md` (new)
  - Documents current operational install source (`requirements.txt`) vs intended metadata source (`pyproject.toml`).
  - Lists core/default lane dependencies and optional integration groups.
  - States CI ruff pin and deferred #164 scheduler bug.

## Verification

- `python -m pytest --tb=short -q` passes
- `cd web && npm run lint` passes
- `cd web && npm run type-check` passes
- `cd web && npm run build` passes

## Deferred work

- Scheduler APScheduler trigger adapter repair → Issue #164.
- Full pyproject.toml/requirements.txt reconciliation → future packaging cleanup issue.

Closes #88
