### PR TITLE
chore(security): bump requests to >=2.33.0 and document remaining transitive alerts

### DIFF
--- a/docs/security/VULN-ASSESSMENT-ECDSA-RSA-2026-07-06.md
+++ b/docs/security/VULN-ASSESSMENT-ECDSA-RSA-2026-07-06.md
@@ -1,0 +1,29 @@
+# Vulnerability Assessment — ecdsa and rsa (transitive deps of python-jose)
+
+**Repository:** SintraPrime-Unified  
+**Date:** 2026-07-06  
+**Affected transitive packages:** `ecdsa`, `rsa`  
+**Root direct dependency:** `python-jose>=3.4.0`  
+
+## Findings
+
+1. **No direct dependency declared.** Neither `ecdsa` nor `rsa` is listed in `pyproject.toml`, `requirements.txt`, or `requirements-py313-windows.txt`.
+2. **Both come from `python-jose`.** The installed version `python-jose 3.5.0` requires `ecdsa`, `pyasn1`, and `rsa`.
+3. **`rsa` alert GHSA-xrx6-fmxq-rjj2 (CVE-2020-25658).** Patched in `rsa>=4.7`. The currently resolved version in this environment is `rsa 4.9.1`, which is **already patched**. Dependabot is flagging a transitive relationship but has not refreshed against the resolved version.
+4. **`ecdsa` alert GHSA-wj6h-64fc-37mp (CVE-2024-23342).** The `python-ecdsa` maintainers state: *"The python-ecdsa project considers side channel attacks out of scope for the project and there is no planned fix."* Therefore there is **no patched version available**. The alert is informational and cannot be remediated by a version bump.
+
+## Recommended actions
+
+1. **For `rsa`:** Wait for GitHub Dependabot to re-scan `main` after the `requests>=2.33.0` update is merged. The resolved `rsa 4.9.1` should clear this alert.
+2. **For `ecdsa`:** Because no fix exists and the package is only used transitively via `python-jose`, either:
+   - Accept the risk and document it (this file), or
+   - Replace `python-jose` with a library that does not depend on `python-ecdsa` (e.g., `joserfc` or direct `PyJWT`/`cryptography` usage). This would be a larger refactor requiring ADR and migration of JWT/JWS/JWE code.
+
+## Current mitigation
+
+- `python-jose` is already at the latest version (3.5.0) and uses `ecdsa` only for ECDSA signing/verification, which is not in the hot path of the SintraPrime portal JWT handling (portal uses `PyJWT` for JWT and `python-jose` only where JWS/JWE broader support is needed).
+- No code in this repository calls `ecdsa.SigningKey.sign_digest()` or `rsa.decrypt()` directly.
+
+## Decision
+
+Document and defer `ecdsa`. Re-assess after Dependabot re-scan confirms whether the `rsa` alert clears.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "bcrypt>=4.1.1",
     "python-multipart>=0.0.31",
     "httpx>=0.25.2",
+    "requests>=2.33.0",
     "aioredis>=2.0.1",
     "celery>=5.3.4",
     "redis>=5.0.1",
@@ -58,7 +59,7 @@ test = [
 ]
 portal = [
     "PyJWT>=2.13.0",
-    "requests>=2.32.4",
+    "requests>=2.33.0",
     "email-validator>=2.0",
 ]
 predictive = [
@@ -74,7 +75,7 @@ all = [
     "pytest-cov>=4.0",
     "pytest-asyncio>=0.21",
     "PyJWT>=2.13.0",
-    "requests>=2.32.4",
+    "requests>=2.33.0",
     "email-validator>=2.0",
     "pandas>=2.0",
     "scikit-learn>=1.3",

--- a/requirements-py313-windows.txt
+++ b/requirements-py313-windows.txt
@@ -50,7 +50,7 @@ bcrypt==5.0.0
 pyotp==2.9.0
 
 # HTTP clients
-requests==2.32.4
+requests==2.33.0
 httpx==0.27.0
 
 # Configuration & utilities

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ passlib[bcrypt]>=1.7.4
 bcrypt>=4.1.1
 python-multipart>=0.0.31
 httpx>=0.25.2
+requests>=2.33.0
 aioredis>=2.0.1
 celery>=5.3.4
 redis>=5.0.1


### PR DESCRIPTION
## Summary

Follow-up security patch to PR #172. Bumps `requests` from `>=2.32.4` to `>=2.33.0` across `pyproject.toml`, `requirements.txt`, and `requirements-py313-windows.txt` to resolve GHSA-gc5v-m9x4-r6x2. Also documents the two remaining transitive alerts (`ecdsa`, `rsa`) that cannot be remediated by version bumps.

## Files changed

- `pyproject.toml` — add `requests>=2.33.0` to main deps; bump optional-deps floors.
- `requirements.txt` — add `requests>=2.33.0`.
- `requirements-py313-windows.txt` — pin `requests==2.33.0`.
- `docs/security/VULN-ASSESSMENT-ECDSA-RSA-2026-07-06.md` — assessment of transitive ecdsa/rsa alerts.

## Verification

- `python -m pytest --tb=short -q` ✅ pass
- `ruff check .` ✅ pass
- `cd web && npm run lint` ✅ pass
- `cd web && npm run type-check` ✅ pass
- `cd web && npm run build` ✅ pass

## Remaining open alerts after merge

- `rsa` GHSA-xrx6-fmxq-rjj2 — should clear after Dependabot re-scan; resolved version 4.9.1 is already installed.
- `ecdsa` GHSA-wj6h-64fc-37mp — no patched version exists; maintained by `python-jose` transitive dependency. Documented and deferred pending library replacement ADR.
