### PR TITLE
fix(stripe): repair local import path and model exports clean

### DIFF
--- a/backend/stripe-payments/README.md
+++ b/backend/stripe-payments/README.md
@@ -35,6 +35,34 @@ Complete payment processing and subscription management system using Stripe.
 
 ## Quick Start
 
+### Local Launch
+
+Run the Stripe payments module locally:
+
+```bash
+cd backend/stripe-payments
+python main.py
+```
+
+The API will be available at `http://localhost:8000`.
+
+- Health check: `GET /health`
+- API docs: `GET /api/docs`
+- Payments endpoints: `/api/*`
+- Webhooks endpoint: `POST /webhooks/stripe`
+
+### Test Credentials
+
+This module requires Stripe test credentials to run functional tests or create checkout sessions. Do **not** commit real keys. Copy `.env.example` to `.env` and add your test keys from the [Stripe Dashboard](https://dashboard.stripe.com/test/apikeys):
+
+```env
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_PUBLISHABLE_KEY=pk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+```
+
+Tests that call the Stripe API will be skipped or fail until valid test credentials are provided.
+
 ### 1. Install Dependencies
 
 ```bash

--- a/backend/stripe-payments/api/__init__.py
+++ b/backend/stripe-payments/api/__init__.py
@@ -1,5 +1,5 @@
 """API routes for Stripe payment system"""
 
-from .routes import router
+from api.routes import router
 
 __all__ = ["router"]

--- a/backend/stripe-payments/api/routes.py
+++ b/backend/stripe-payments/api/routes.py
@@ -5,10 +5,9 @@ FastAPI routes for Stripe payment processing
 import logging
 from typing import Optional
 
+from config import TIER_AMOUNTS
 from fastapi import APIRouter, Depends, HTTPException, status
-
-from ..config import TIER_AMOUNTS
-from ..models import (
+from models import (
     CancelResponse,
     CheckoutRequest,
     CheckoutResponse,
@@ -18,8 +17,8 @@ from ..models import (
     UpgradeRequest,
     UpgradeResponse,
 )
-from ..services.subscription_service import subscription_service
-from ..stripe_client import stripe_client
+from services.subscription_service import subscription_service
+from stripe_client import stripe_client
 
 logger = logging.getLogger(__name__)
 

--- a/backend/stripe-payments/main.py
+++ b/backend/stripe-payments/main.py
@@ -3,6 +3,13 @@ Main FastAPI application for Stripe payments module
 """
 
 import logging
+import sys
+from pathlib import Path
+
+# Ensure package imports work when running main.py directly
+if __package__ is None:
+    module_dir = Path(__file__).parent
+    sys.path.insert(0, str(module_dir))
 
 from api.routes import router as payment_router
 from fastapi import FastAPI

--- a/backend/stripe-payments/models/__init__.py
+++ b/backend/stripe-payments/models/__init__.py
@@ -1,13 +1,20 @@
 """Models for Stripe payment system"""
 
 from .subscription import (
+    CancelResponse,
     CheckoutRequest,
+    CheckoutResponse,
     Customer,
     Payment,
+    PaymentStatus,
     RefundRequest,
     Subscription,
     SubscriptionRequest,
+    SubscriptionResponse,
+    SubscriptionStatus,
+    Tier,
     UpgradeRequest,
+    UpgradeResponse,
     WebhookEvent,
 )
 
@@ -15,9 +22,16 @@ __all__ = [
     "Subscription",
     "Customer",
     "Payment",
+    "PaymentStatus",
     "CheckoutRequest",
+    "CheckoutResponse",
     "SubscriptionRequest",
+    "SubscriptionResponse",
     "UpgradeRequest",
+    "UpgradeResponse",
     "RefundRequest",
-    "WebhookEvent"
+    "WebhookEvent",
+    "SubscriptionStatus",
+    "Tier",
+    "CancelResponse",
 ]

--- a/backend/stripe-payments/services/__init__.py
+++ b/backend/stripe-payments/services/__init__.py
@@ -1,6 +1,6 @@
 """Services for Stripe payment system"""
 
-from .airtable_sync import AirtableSyncService
-from .subscription_service import SubscriptionService
+from services.airtable_sync import AirtableSyncService
+from services.subscription_service import SubscriptionService
 
 __all__ = ["SubscriptionService", "AirtableSyncService"]

--- a/backend/stripe-payments/services/airtable_sync.py
+++ b/backend/stripe-payments/services/airtable_sync.py
@@ -12,8 +12,8 @@ from typing import Any, Dict, Optional
 # Add parent directory to path to import airtable_client
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
 
-from ..config import AIRTABLE_PAYMENTS_TABLE
-from ..models import Subscription
+from config import AIRTABLE_PAYMENTS_TABLE
+from models import Subscription
 
 logger = logging.getLogger(__name__)
 

--- a/backend/stripe-payments/services/subscription_service.py
+++ b/backend/stripe-payments/services/subscription_service.py
@@ -7,8 +7,8 @@ import logging
 from datetime import datetime, timedelta
 from typing import Optional
 
-from ..config import REFUND_PERCENTAGE, REFUND_WINDOW_DAYS, TIER_AMOUNTS, TRIAL_DAYS
-from ..models import (
+from config import REFUND_PERCENTAGE, REFUND_WINDOW_DAYS, TIER_AMOUNTS, TRIAL_DAYS
+from models import (
     Customer,
     RefundRequest,
     Subscription,
@@ -16,7 +16,8 @@ from ..models import (
     SubscriptionStatus,
     UpgradeRequest,
 )
-from ..stripe_client import stripe_client
+from stripe_client import stripe_client
+
 from .airtable_sync import AirtableSyncService
 
 logger = logging.getLogger(__name__)
@@ -211,7 +212,7 @@ class SubscriptionService:
                 amount = self._calculate_refund_amount(subscription_id, subscription.tier)
 
             # Process refund via Stripe
-            from ..stripe_client import stripe_client as client
+            from stripe_client import stripe_client as client
             refund_result = await client.refund_payment(
                 payment_intent_id=payment_intent_id,
                 amount=amount,

--- a/backend/stripe-payments/stripe_client.py
+++ b/backend/stripe-payments/stripe_client.py
@@ -8,8 +8,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 import stripe
-
-from .config import (
+from config import (
     API_BASE_URL,
     DEFAULT_PAYMENT_BEHAVIOR,
     IS_PRODUCTION,
@@ -19,7 +18,7 @@ from .config import (
     TIER_PRICE_IDS,
     TRIAL_DAYS,
 )
-from .models import Customer, Payment, PaymentStatus, Subscription, SubscriptionStatus
+from models import Customer, Payment, PaymentStatus, Subscription, SubscriptionStatus
 
 # Initialize Stripe
 stripe.api_key = STRIPE_SECRET_KEY

--- a/backend/stripe-payments/utils/__init__.py
+++ b/backend/stripe-payments/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility functions for Stripe payment system"""
 
-from .pricing import PricingCalculator
+from utils.pricing import PricingCalculator
 
 __all__ = ["PricingCalculator"]

--- a/backend/stripe-payments/utils/pricing.py
+++ b/backend/stripe-payments/utils/pricing.py
@@ -7,7 +7,7 @@ import logging
 from datetime import datetime
 from typing import Dict, Tuple
 
-from ..config import TIER_AMOUNTS
+from config import TIER_AMOUNTS
 
 logger = logging.getLogger(__name__)
 

--- a/backend/stripe-payments/webhooks/__init__.py
+++ b/backend/stripe-payments/webhooks/__init__.py
@@ -1,5 +1,5 @@
 """Webhook handlers for Stripe events"""
 
-from .webhook_handler import handle_webhook, router
+from webhooks.webhook_handler import handle_webhook, router
 
 __all__ = ["router", "handle_webhook"]

--- a/backend/stripe-payments/webhooks/webhook_handler.py
+++ b/backend/stripe-payments/webhooks/webhook_handler.py
@@ -7,11 +7,10 @@ import json
 import logging
 
 import stripe
+from config import STRIPE_WEBHOOK_SECRET
 from fastapi import APIRouter, HTTPException, Request
-
-from ..config import STRIPE_WEBHOOK_SECRET
-from ..services.airtable_sync import airtable_sync_service
-from ..stripe_client import stripe_client
+from services.airtable_sync import airtable_sync_service
+from stripe_client import stripe_client
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

This PR supersedes the mislabeled PR #183.

## What happened with PR #183

- PR #183 was titled `fix(stripe): repair local import path and model exports`.
- GitHub patch for PR #183 actually contained Agent Mesh files only:
  - `.mesh/ledger/2026-07.jsonl`
  - `.mesh/ledger/README.md`
  - `ops/IKE_AGENT_MESH.md`
- The Stripe repair commit `02913c02` was clean and Stripe-only, but it was not safely merged through PR #183.
- This PR cherry-picks the clean Stripe commit onto current `main`.

## This PR is Stripe-only

Changed files (all under `backend/stripe-payments/`):

- `backend/stripe-payments/main.py` — fixes direct-run import path.
- `backend/stripe-payments/models/__init__.py` — exports missing enums and response models.
- `backend/stripe-payments/api/*.py`, `services/*.py`, `webhooks/*.py`, `utils/*.py`, `stripe_client.py` — convert relative imports to module-root imports so tests and `python main.py` use the same layout.
- `backend/stripe-payments/README.md` — adds Local Launch and Test Credentials sections.

## Verification commands and results

```bash
# Module compilation passes
python -m compileall backend/stripe-payments

# FastAPI app imports and starts locally
cd backend/stripe-payments
../../.venv/Scripts/python main.py

# Tests collect (18 pass, 1 pre-existing pricing-logic failure unrelated to imports)
../../.venv/Scripts/python -m pytest tests/test_stripe.py --collect-only  # 19 tests collected
../../.venv/Scripts/python -m pytest tests/test_stripe.py --tb=short -q    # 18 passed, 1 failed
```

The one failing test, `TestPricingCalculator.test_calculate_annual_savings`, is a pre-existing pricing-logic mismatch (expects 10800, function returns 9900) and is outside the import/export scope of this PR.

## Safety confirmations

- No live Stripe charges or checkout sessions were created.
- No test Stripe API calls were made.
- No secret keys were committed; `.env.example` remains placeholder-only.
- No production Stripe dashboard settings were modified.
- No `.mesh/`, `ops/`, root docs, or unrelated files were changed.

Do not merge until owner review.
