### PR TITLE
chore(web): enable @typescript-eslint/no-explicit-any as warn and fix all 9 occurrences

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -18,7 +18,7 @@ module.exports = {
       'warn',
       { allowConstantExport: true },
     ],
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-unused-vars': 'off',
     'no-unused-vars': 'off',
   },

--- a/web/src/components/financial/AccountSummary.tsx
+++ b/web/src/components/financial/AccountSummary.tsx
@@ -1,5 +1,5 @@
 import { Building2, TrendingUp, TrendingDown } from 'lucide-react';
-import Badge from '../ui/Badge';
+import Badge, { type BadgeVariant } from '../ui/Badge';
 
 interface Account {
   id: string;
@@ -62,7 +62,7 @@ export default function AccountSummary() {
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-1.5">
                 <p className="text-xs font-medium text-slate-200 truncate">{account.name}</p>
-                <Badge variant={typeColors[account.type] as any} size="sm" className="capitalize hidden sm:inline-flex">{account.type}</Badge>
+                <Badge variant={typeColors[account.type] as BadgeVariant} size="sm" className="capitalize hidden sm:inline-flex">{account.type}</Badge>
               </div>
               <p className="text-[10px] text-slate-500">{account.institution} ...{account.last4}</p>
             </div>

--- a/web/src/components/financial/BudgetTracker.tsx
+++ b/web/src/components/financial/BudgetTracker.tsx
@@ -1,4 +1,4 @@
-import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, type TooltipProps } from 'recharts';
 
 const expenses = [
   { name: 'Housing', value: 3200, color: '#3B82F6' },
@@ -14,12 +14,12 @@ const totalExpenses = expenses.reduce((s, e) => s + e.value, 0);
 const savings = totalIncome - totalExpenses;
 const savingsRate = ((savings / totalIncome) * 100).toFixed(1);
 
-const CustomTooltip = ({ active, payload }: any) => {
+const CustomTooltip = ({ active, payload }: TooltipProps<number, string>) => {
   if (active && payload && payload.length) {
     return (
       <div className="bg-slate-900 border border-slate-700/50 rounded-xl p-3 shadow-xl">
         <p className="text-xs text-slate-400 mb-1">{payload[0].name}</p>
-        <p className="text-sm font-bold text-white">${payload[0].value.toLocaleString()}</p>
+        <p className="text-sm font-bold text-white">${payload[0].value!.toLocaleString()}</p>
       </div>
     );
   }

--- a/web/src/components/financial/FundingOpportunities.tsx
+++ b/web/src/components/financial/FundingOpportunities.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { DollarSign, ExternalLink, Filter, Star } from 'lucide-react';
-import Badge from '../ui/Badge';
+import Badge, { type BadgeVariant } from '../ui/Badge';
 import Button from '../ui/Button';
 import { clsx } from 'clsx';
 
@@ -104,7 +104,7 @@ export default function FundingOpportunities({ opportunities }: { opportunities:
                 </div>
 
                 <div className="flex items-center gap-2 mt-2 flex-wrap">
-                  <Badge variant={typeColors[opp.type] as any} size="sm" className="capitalize">{opp.type}</Badge>
+                  <Badge variant={typeColors[opp.type] as BadgeVariant}size="sm" className="capitalize">{opp.type}</Badge>
                   <div className="flex items-center gap-1">
                     <div className="h-1 w-16 bg-slate-700 rounded-full overflow-hidden">
                       <div className="h-full bg-gold rounded-full" style={{ width: `${opp.match}%` }} />

--- a/web/src/components/financial/NetWorthChart.tsx
+++ b/web/src/components/financial/NetWorthChart.tsx
@@ -6,6 +6,7 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  type TooltipProps,
 } from 'recharts';
 
 const data = [
@@ -29,12 +30,12 @@ function formatDollars(v: number) {
   return `$${v}`;
 }
 
-const CustomTooltip = ({ active, payload, label }: any) => {
+const CustomTooltip = ({ active, payload, label }: TooltipProps<number, string>) => {
   if (active && payload && payload.length) {
     return (
       <div className="bg-slate-900 border border-slate-700/50 rounded-xl p-3 shadow-xl">
         <p className="text-xs text-slate-400 mb-1">{label}</p>
-        <p className="text-base font-bold text-gold">{formatDollars(payload[0].value)}</p>
+        <p className="text-base font-bold text-gold">{formatDollars(payload[0].value!)}</p>
       </div>
     );
   }

--- a/web/src/components/legal/CaseCard.tsx
+++ b/web/src/components/legal/CaseCard.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'framer-motion';
 import { Scale, Calendar, ChevronRight, AlertCircle } from 'lucide-react';
-import Badge from '../ui/Badge';
+import Badge, { type BadgeVariant } from '../ui/Badge';
 import type { Case } from '../../types/legal';
 import { clsx } from 'clsx';
 
@@ -44,7 +44,7 @@ export default function CaseCard({ case_, onClick, compact }: CaseCardProps) {
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
               <span className="text-[10px] font-mono text-slate-500">{case_.caseNumber}</span>
-              <Badge variant={statusColors[case_.status] as any} size="sm" className="capitalize">{case_.status}</Badge>
+              <Badge variant={statusColors[case_.status] as BadgeVariant}size="sm" className="capitalize">{case_.status}</Badge>
               {urgencyDays !== null && urgencyDays <= 7 && (
                 <div className="flex items-center gap-1 text-amber-400 text-[10px]">
                   <AlertCircle className="w-3 h-3" />

--- a/web/src/components/legal/TrustLawExplorer.tsx
+++ b/web/src/components/legal/TrustLawExplorer.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Search, BookOpen, ChevronRight } from 'lucide-react';
 import { clsx } from 'clsx';
-import Badge from '../ui/Badge';
+import Badge, { type BadgeVariant } from '../ui/Badge';
 
 const trustDoctrines = [
   { name: 'Express Trust', category: 'Formation', description: 'Trust created by explicit declaration of intent. Requires settlor, trustee, beneficiary, and corpus.' },
@@ -115,7 +115,7 @@ export default function TrustLawExplorer({ compact }: TrustLawExplorerProps) {
                 <span className="text-xs font-semibold text-slate-200">{doctrine.name}</span>
               </div>
               <div className="flex items-center gap-1.5">
-                <Badge variant={categoryColors[doctrine.category] as any} size="sm">{doctrine.category}</Badge>
+                <Badge variant={categoryColors[doctrine.category] as BadgeVariant} size="sm">{doctrine.category}</Badge>
                 <ChevronRight className={clsx('w-3.5 h-3.5 text-slate-600 transition-transform', selectedDoctrine === doctrine.name && 'rotate-90')} />
               </div>
             </div>

--- a/web/src/pages/LiveCaseManagement.tsx
+++ b/web/src/pages/LiveCaseManagement.tsx
@@ -11,10 +11,26 @@ import {
 } from 'lucide-react';
 import recoveryApi, { RecoveryCase, DashboardStats } from '../api/recovery';
 
+interface EvidenceItem {
+  evidence_id: string;
+  title: string;
+  evidence_type: string;
+}
+
+interface Receipt {
+  receipt_id: string;
+  action: string;
+}
+
+interface CasePacket {
+  evidence?: EvidenceItem[];
+  receipts?: Receipt[];
+}
+
 export default function LiveCaseManagement() {
   const [cases, setCases] = useState<RecoveryCase[]>([]);
   const [selectedCase, setSelectedCase] = useState<RecoveryCase | null>(null);
-  const [casePacket, setCasePacket] = useState<any>(null);
+  const [casePacket, setCasePacket] = useState<CasePacket | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
@@ -122,7 +138,7 @@ export default function LiveCaseManagement() {
               <h2 className="text-lg font-semibold text-white mb-4">Case Packet</h2>
               {casePacket.evidence && casePacket.evidence.length > 0 ? (
                 <div className="space-y-2">
-                  {casePacket.evidence.map((ev: any) => (
+                  {casePacket.evidence.map((ev) => (
                     <div key={ev.evidence_id} className="flex items-center justify-between p-3 rounded-lg bg-slate-800/50">
                       <div>
                         <div className="text-sm text-white">{ev.title}</div>
@@ -140,7 +156,7 @@ export default function LiveCaseManagement() {
                 <div className="mt-4">
                   <h3 className="text-sm font-semibold text-slate-300 mb-2">Receipts</h3>
                   <div className="space-y-1">
-                    {casePacket.receipts.map((r: any) => (
+                    {casePacket.receipts.map((r) => (
                       <div key={r.receipt_id} className="text-xs text-slate-400 p-2 rounded bg-slate-800/30">
                         <span className="font-mono">{r.receipt_id}</span>: {r.action}
                       </div>

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -5,7 +5,7 @@ import { Lock, Mail, Scale } from 'lucide-react';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import { login, type LoginResponse } from '../api/auth';
-import { useAppStore } from '../store/appStore';
+import { useAppStore, type User } from '../store/appStore';
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -40,7 +40,7 @@ export default function LoginPage() {
         id: response.user_id,
         name: email.split('@')[0],
         email,
-        role: response.role as any,
+        role: response.role as User['role'],
         preferences: {
           theme: 'dark',
           sidebarCollapsed: false,


### PR DESCRIPTION
## Summary

Re-enable `@typescript-eslint/no-explicit-any` in the web package as a **warning** (not error) and eliminate the existing 9 `any` occurrences.

This increment improves type safety without breaking the build; CI still uses `--max-warnings 0`, so the rule will be promoted to error once warnings are resolved.

## Changes

- `web/.eslintrc.cjs`: switch `@typescript-eslint/no-explicit-any` from `off` to `warn`.
- Replace cast-to-any Badge variant usage with typed `BadgeVariant` imports in:
  - `AccountSummary.tsx`
  - `CaseCard.tsx`
  - `FundingOpportunities.tsx`
  - `TrustLawExplorer.tsx`
- Type recharts `CustomTooltip` props via `TooltipProps<number, string>` in:
  - `BudgetTracker.tsx`
  - `NetWorthChart.tsx`
- Add typed `CasePacket` interfaces and remove `any` from `LiveCaseManagement.tsx`.
- Type `Login.tsx` role assignment using `User['role']`.

## Verification

- `cd web && npm run lint` ✅
- `cd web && npm run type-check` ✅
- `cd web && npm run build` ✅

## Scope

Web package only. No runtime behavior changes.
