### PR TITLE
Mission Control: Phase 1 unified shell and verified telemetry

### DIFF
--- a/mission-control-evidence/build.txt
+++ b/mission-control-evidence/build.txt
@@ -1,0 +1,2 @@
+PASS — npm run build
+Vite 6.4.3 transformed 2,929 modules and completed the production build.

--- a/mission-control-evidence/command-audit.json
+++ b/mission-control-evidence/command-audit.json
@@ -1,0 +1,11 @@
+{
+  "mutating_commands_exposed": 0,
+  "locked_ui_commands": [
+    "Create task",
+    "Start governed run",
+    "Assign agent",
+    "Pause all",
+    "Emergency stop"
+  ],
+  "reason": "No permission-checked, audited command API is connected."
+}

--- a/mission-control-evidence/console-audit.json
+++ b/mission-control-evidence/console-audit.json
@@ -1,0 +1,5 @@
+{
+  "status": "not_run",
+  "reason": "No deployed/local authenticated Portal runtime was available in this environment.",
+  "claim": "No console-cleanliness claim is made."
+}

--- a/mission-control-evidence/implementation-summary.md
+++ b/mission-control-evidence/implementation-summary.md
@@ -1,0 +1,31 @@
+# Mission Control — Phase 1 Implementation Receipt
+
+## Scope delivered
+
+- Unified `/mission-control` shell and navigation.
+- All fourteen required sub-routes, preserved as honest empty states until
+  authoritative adapters exist.
+- Executive operating view backed by a typed Portal API read model.
+- Existing health, scheduler, evidence, recovery, and agent probes reused.
+- Permission-gated summary endpoint.
+- Commands visibly locked; no mutating behavior or success simulation.
+- Polling refresh with explicit `live`, `degraded`, and `offline` state.
+- Responsive, accessible command-center styling using existing SintraPrime
+  visual tokens.
+
+## Preservation
+
+Existing routes, dashboard pages, recovery endpoints, Operations components,
+and telemetry implementations were not removed or rewritten.
+
+## Verification
+
+- Frontend ESLint: pass
+- TypeScript type-check: pass
+- Vite production build: pass
+- Mission Control API contract test: pass
+- Python Ruff checks: pass
+- Dependency audit: zero npm vulnerabilities
+
+Baseline commit: `3d79d919749e444c0de3afc18bddaafc54bc8d3e`
+Baseline tree: `a2e7319ec5a9556b30477f9ec8d0044a18b123b4`

--- a/mission-control-evidence/known-limitations.md
+++ b/mission-control-evidence/known-limitations.md
@@ -1,0 +1,14 @@
+# Known limitations
+
+This delivery is Phase 1 of the seven-phase directive.
+
+- Commands are intentionally disabled until server-side authorization,
+  confirmation, idempotency, and audit events are implemented.
+- Runs, decisions, incidents, and cost metrics are marked `unavailable`;
+  SintraPrime does not yet expose authoritative sources for them.
+- Detail surfaces use explicit empty states rather than demo data.
+- Browser screenshots, console audit, and live responsive verification require
+  an authenticated running Portal instance. No claim is made without that
+  evidence.
+- Operations Floor integration is represented by its route in this baseline;
+  additive telemetry enhancements belong to Phase 2.

--- a/mission-control-evidence/permission-tests.json
+++ b/mission-control-evidence/permission-tests.json
@@ -1,0 +1,5 @@
+{
+  "summary_endpoint": "ADMIN_DASHBOARD permission required",
+  "test": "authenticated super-admin dependency passes",
+  "result": "pass"
+}

--- a/mission-control-evidence/responsive-audit.json
+++ b/mission-control-evidence/responsive-audit.json
@@ -1,0 +1,6 @@
+{
+  "status": "static_pass_runtime_pending",
+  "breakpoints": [1440, 1024, 768, 390],
+  "controls": ["min-width containment", "responsive grids", "horizontal subnav scroll"],
+  "runtime_browser_audit": "pending authenticated Portal runtime"
+}

--- a/mission-control-evidence/route-matrix.json
+++ b/mission-control-evidence/route-matrix.json
@@ -1,0 +1,17 @@
+{
+  "/mission-control": "telemetry-backed executive view",
+  "/mission-control/operations": "preserved route; adapter pending",
+  "/mission-control/agents": "preserved route; adapter pending",
+  "/mission-control/tasks": "preserved route; adapter pending",
+  "/mission-control/decisions": "preserved route; adapter pending",
+  "/mission-control/runs": "preserved route; adapter pending",
+  "/mission-control/activity": "preserved route; adapter pending",
+  "/mission-control/schedules": "preserved route; adapter pending",
+  "/mission-control/evidence": "preserved route; adapter pending",
+  "/mission-control/governance": "preserved route; adapter pending",
+  "/mission-control/memory": "preserved route; adapter pending",
+  "/mission-control/costs": "preserved route; adapter pending",
+  "/mission-control/incidents": "preserved route; adapter pending",
+  "/mission-control/integrations": "preserved route; adapter pending",
+  "/mission-control/settings": "preserved route; adapter pending"
+}

--- a/mission-control-evidence/test-results.json
+++ b/mission-control-evidence/test-results.json
@@ -1,0 +1,8 @@
+{
+  "frontend_lint": "pass",
+  "frontend_typecheck": "pass",
+  "frontend_build": "pass",
+  "api_contract": "pass",
+  "python_ruff": "pass",
+  "npm_audit_vulnerabilities": 0
+}

--- a/mission-control-evidence/typecheck.txt
+++ b/mission-control-evidence/typecheck.txt
@@ -1,0 +1,2 @@
+PASS — npm run type-check
+TypeScript completed with zero errors.

--- a/portal/main.py
+++ b/portal/main.py
@@ -25,6 +25,7 @@ from portal.routers import (
     clients,
     documents,
     messages,
+    mission_control,
     notifications,
     recovery,
     sso,
@@ -127,6 +128,7 @@ def create_app() -> FastAPI:
     app.include_router(clients.router, prefix="/api/v1/clients", tags=["clients"])
     app.include_router(billing.router, prefix="/api/v1/billing", tags=["billing"])
     app.include_router(messages.router, prefix="/api/v1/messages", tags=["messages"])
+    app.include_router(mission_control.router)
     app.include_router(notifications.router, prefix="/api/v1/notifications", tags=["notifications"])
     app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
 

--- a/portal/routers/mission_control.py
+++ b/portal/routers/mission_control.py
@@ -1,0 +1,87 @@
+"""Mission Control read model.
+
+This router intentionally exposes observation only. Command endpoints belong to
+the governed execution layer and must not be simulated by the UI.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from ..auth.rbac import CurrentUser, Permission, require_permissions
+from .system_health import (
+    _check_agents,
+    _check_database,
+    _check_evidence_platform,
+    _check_recovery_api,
+    _check_scheduler,
+)
+
+router = APIRouter(prefix="/api/v1/mission-control", tags=["mission-control"])
+
+
+class Metric(BaseModel):
+    value: int | float | str | None
+    status: Literal["verified", "unknown", "unavailable"] = "verified"
+
+
+class MissionControlSummary(BaseModel):
+    environment: str
+    health: Literal["healthy", "degraded", "offline"]
+    telemetry_updated_at: datetime
+    telemetry_source: str = "portal.system_health"
+    active_agents: Metric
+    active_runs: Metric
+    pending_decisions: Metric
+    open_incidents: Metric
+    daily_spend_usd: Metric
+    kill_switch: Metric
+    evidence_items: Metric
+    scheduled_jobs: Metric
+    subsystems: dict[str, dict] = Field(default_factory=dict)
+
+
+@router.get("/summary", response_model=MissionControlSummary)
+async def get_summary(
+    _: CurrentUser = Depends(require_permissions(Permission.ADMIN_DASHBOARD)),
+) -> MissionControlSummary:
+    """Return a telemetry-backed executive summary.
+
+    Values for which SintraPrime has no authoritative source are explicitly
+    marked unavailable rather than inferred or fabricated.
+    """
+    database = _check_database()
+    recovery = _check_recovery_api()
+    evidence = _check_evidence_platform()
+    scheduler = _check_scheduler()
+    agents = _check_agents()
+    subsystems = {
+        "database": database,
+        "recovery": recovery,
+        "evidence": evidence,
+        "scheduler": scheduler,
+        "agents": agents,
+    }
+    degraded = any(item.get("status") not in {"healthy"} for item in subsystems.values())
+
+    evidence_count = sum(
+        int(case.get("evidence_items", 0)) for case in evidence.get("cases", [])
+    )
+    return MissionControlSummary(
+        environment="production" if database.get("type") != "sqlite" else "local",
+        health="degraded" if degraded else "healthy",
+        telemetry_updated_at=datetime.now(UTC),
+        active_agents=Metric(value=agents.get("running"), status="verified"),
+        active_runs=Metric(value=None, status="unavailable"),
+        pending_decisions=Metric(value=None, status="unavailable"),
+        open_incidents=Metric(value=None, status="unavailable"),
+        daily_spend_usd=Metric(value=None, status="unavailable"),
+        kill_switch=Metric(value=recovery.get("external_action", "unknown"), status="verified"),
+        evidence_items=Metric(value=evidence_count, status="verified"),
+        scheduled_jobs=Metric(value=scheduler.get("jobs"), status="verified"),
+        subsystems=subsystems,
+    )

--- a/portal/tests/test_mission_control.py
+++ b/portal/tests/test_mission_control.py
@@ -1,0 +1,39 @@
+"""Mission Control API contract tests."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from portal.auth.rbac import CurrentUser, Permission, get_current_user
+from portal.routers import mission_control
+
+
+def _admin() -> CurrentUser:
+    return CurrentUser(
+        {
+            "sub": "00000000-0000-0000-0000-000000000001",
+            "tenant_id": "00000000-0000-0000-0000-000000000002",
+            "role": "SUPER_ADMIN",
+            "permissions": [Permission.ADMIN_DASHBOARD],
+        }
+    )
+
+
+def test_summary_marks_missing_sources_unavailable(monkeypatch):
+    app = FastAPI()
+    app.include_router(mission_control.router)
+    app.dependency_overrides[get_current_user] = _admin
+
+    monkeypatch.setattr(mission_control, "_check_database", lambda: {"status": "healthy", "type": "sqlite"})
+    monkeypatch.setattr(mission_control, "_check_recovery_api", lambda: {"status": "healthy", "external_action": "locked"})
+    monkeypatch.setattr(mission_control, "_check_evidence_platform", lambda: {"status": "healthy", "cases": [{"evidence_items": 3}]})
+    monkeypatch.setattr(mission_control, "_check_scheduler", lambda: {"status": "healthy", "jobs": 4})
+    monkeypatch.setattr(mission_control, "_check_agents", lambda: {"status": "healthy", "running": 2})
+
+    response = TestClient(app).get("/api/v1/mission-control/summary")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["active_agents"] == {"value": 2, "status": "verified"}
+    assert body["evidence_items"] == {"value": 3, "status": "verified"}
+    assert body["active_runs"]["status"] == "unavailable"
+    assert body["pending_decisions"]["value"] is None
+    assert body["kill_switch"]["value"] == "locked"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,9 @@ import AIParliament from './pages/AIParliament';
 import CaseLawSearch from './pages/CaseLawSearch';
 import Settings from './pages/Settings';
 import Login from './pages/Login';
+import MissionControlLayout from './pages/mission-control/MissionControlLayout';
+import MissionControlHome from './pages/mission-control/MissionControlHome';
+import MissionControlSurface from './pages/mission-control/MissionControlSurface';
 import { useTheme } from './hooks/useTheme';
 
 function AppContent() {
@@ -34,6 +37,10 @@ function AppContent() {
           <Route path="ai-parliament" element={<AIParliament />} />
           <Route path="caselaw" element={<CaseLawSearch />} />
           <Route path="settings" element={<Settings />} />
+          <Route path="mission-control" element={<MissionControlLayout />}>
+            <Route index element={<MissionControlHome />} />
+            <Route path=":surface" element={<MissionControlSurface />} />
+          </Route>
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Route>
       </Routes>

--- a/web/src/api/missionControl.ts
+++ b/web/src/api/missionControl.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+
+export type EvidenceStatus = 'verified' | 'unknown' | 'unavailable';
+
+export interface MissionMetric {
+  value: string | number | null;
+  status: EvidenceStatus;
+}
+
+export interface MissionControlSummary {
+  environment: string;
+  health: 'healthy' | 'degraded' | 'offline';
+  telemetry_updated_at: string;
+  telemetry_source: string;
+  active_agents: MissionMetric;
+  active_runs: MissionMetric;
+  pending_decisions: MissionMetric;
+  open_incidents: MissionMetric;
+  daily_spend_usd: MissionMetric;
+  kill_switch: MissionMetric;
+  evidence_items: MissionMetric;
+  scheduled_jobs: MissionMetric;
+  subsystems: Record<string, { status: string; [key: string]: unknown }>;
+}
+
+export async function getMissionControlSummary(): Promise<MissionControlSummary> {
+  const token = localStorage.getItem('sintraprime_token');
+  const { data } = await axios.get<MissionControlSummary>(
+    `${API_BASE}/api/v1/mission-control/summary`,
+    { headers: token ? { Authorization: `Bearer ${token}` } : undefined, timeout: 15_000 },
+  );
+  return data;
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Gavel,
   Shield,
   Star,
+  RadioTower,
 } from 'lucide-react';
 import { useAppStore } from '../../store/appStore';
 import { clsx } from 'clsx';
@@ -29,6 +30,7 @@ interface NavItem {
 }
 
 const navItems: NavItem[] = [
+  { path: '/mission-control', label: 'Mission Control', icon: RadioTower, badge: 'LIVE', badgeColor: 'green' },
   { path: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { path: '/legal', label: 'Legal Hub', icon: Scale, badge: '5', badgeColor: 'gold' },
   { path: '/financial', label: 'Financial Empire', icon: TrendingUp },

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -190,3 +190,65 @@
     background-size: 24px 24px;
   }
 }
+
+@layer components {
+  .mc-shell { @apply space-y-5 min-w-0; font-variant-numeric: tabular-nums; }
+  .mc-masthead { @apply flex flex-col lg:flex-row lg:items-end justify-between gap-5 border-b border-gold/20 pb-5; }
+  .mc-masthead h1 { @apply text-3xl md:text-4xl font-black tracking-tight text-white; }
+  .mc-masthead p:not(.mc-eyebrow) { @apply text-slate-400 mt-1; }
+  .mc-eyebrow { @apply text-[10px] font-bold tracking-[0.22em] text-gold uppercase mb-1; }
+  .mc-doctrine { @apply flex flex-wrap gap-2; }
+  .mc-doctrine span { @apply text-[10px] tracking-widest border border-gold/30 text-gold px-2 py-1 bg-gold/5; }
+  .mc-subnav { @apply flex gap-1 overflow-x-auto pb-2; scrollbar-width: thin; }
+  .mc-subnav a { @apply shrink-0 px-3 py-2 text-xs text-slate-400 border-b-2 border-transparent hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold; }
+  .mc-subnav a.active { @apply text-gold border-gold bg-gold/5; }
+  .mc-home { @apply space-y-6; }
+  .mc-statusbar { @apply grid grid-cols-2 lg:flex lg:items-center gap-3 lg:gap-6 bg-slate-950/80 border border-slate-800 px-4 py-3 text-xs text-slate-500; }
+  .mc-statusbar > div { @apply flex items-center gap-2; }
+  .mc-statusbar strong { @apply text-slate-200 uppercase; }
+  .mc-statusbar svg { @apply w-3.5 h-3.5; }
+  .mc-statusbar svg.live { @apply text-teal-400; }
+  .mc-statusbar svg.degraded { @apply text-amber-400; }
+  .mc-statusbar svg.offline { @apply text-rose-400; }
+  .mc-statusbar button { @apply lg:ml-auto flex items-center gap-2 text-slate-300 hover:text-gold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold; }
+  .mc-warning { @apply flex items-center gap-3 border border-amber-500/30 bg-amber-500/5 text-amber-300 px-4 py-3 text-sm; }
+  .mc-warning svg { @apply w-4 h-4 shrink-0; }
+  .mc-command-strip { @apply grid lg:grid-cols-[1fr_1.4fr] gap-6 p-5 md:p-6 border border-gold/25 bg-gradient-to-br from-slate-900 to-slate-950; }
+  .mc-command-strip h2, .mc-section-title h2, .mc-surface h2 { @apply text-xl font-bold text-white; }
+  .mc-command-strip p:not(.mc-eyebrow) { @apply text-sm text-slate-400 mt-2 max-w-xl; }
+  .mc-command-actions { @apply grid grid-cols-2 md:grid-cols-3 gap-2; }
+  .mc-command-actions button, .mc-command-actions a { @apply min-h-11 flex items-center justify-center gap-2 border border-slate-700 bg-slate-900 px-3 py-2 text-xs text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gold; }
+  .mc-command-actions button:disabled { @apply opacity-45 cursor-not-allowed; }
+  .mc-command-actions a { @apply border-gold/40 text-gold hover:bg-gold/10; }
+  .mc-command-actions svg { @apply w-3.5 h-3.5; }
+  .mc-section-title { @apply flex items-end justify-between gap-4 mb-3; }
+  .mc-section-title > span { @apply text-[10px] text-slate-600 font-mono break-all text-right; }
+  .mc-metrics { @apply grid grid-cols-2 lg:grid-cols-4 gap-px bg-slate-800 border border-slate-800; }
+  .mc-metric { @apply bg-slate-950 p-4 min-w-0; }
+  .mc-metric-label { @apply text-[10px] tracking-wider uppercase text-slate-500; }
+  .mc-metric-value { @apply text-2xl md:text-3xl text-white font-black my-2 truncate; }
+  .mc-source { @apply flex items-center gap-1 text-[10px] uppercase tracking-wider; }
+  .mc-source svg { @apply w-3 h-3; }
+  .mc-source.verified { @apply text-teal-400; }
+  .mc-source.unknown, .mc-source.unavailable { @apply text-slate-600; }
+  .mc-systems { @apply border border-slate-800 p-4; }
+  .mc-system-row { @apply grid grid-cols-[auto_1fr_auto] items-center gap-3 py-3 border-t border-slate-800 text-sm; }
+  .mc-system-row strong { @apply capitalize text-slate-200; }
+  .mc-system-row > span:last-child { @apply uppercase text-[10px] text-slate-500; }
+  .mc-health-dot { @apply w-2 h-2 rounded-full bg-slate-600; }
+  .mc-health-dot.healthy { @apply bg-teal-400 shadow-[0_0_8px_rgba(45,212,191,.7)]; }
+  .mc-health-dot.degraded { @apply bg-amber-400; }
+  .mc-empty { @apply text-sm text-slate-500 py-8 text-center; }
+  .mc-surface { @apply space-y-8 py-2; }
+  .mc-surface > div:first-child > p:not(.mc-eyebrow) { @apply text-slate-400 mt-2; }
+  .mc-empty-state { @apply min-h-[320px] border border-dashed border-slate-700 flex flex-col items-center justify-center text-center p-8; }
+  .mc-empty-state > svg { @apply w-8 h-8 text-slate-600 mb-4; }
+  .mc-empty-state h3 { @apply text-lg text-white font-semibold; }
+  .mc-empty-state p { @apply text-sm text-slate-500 max-w-lg mt-2; }
+  .mc-empty-state span { @apply flex items-center gap-2 text-xs text-amber-400/80 mt-5; }
+  .mc-empty-state span svg { @apply w-3.5 h-3.5; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { scroll-behavior: auto !important; animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+}

--- a/web/src/pages/mission-control/MissionControlHome.tsx
+++ b/web/src/pages/mission-control/MissionControlHome.tsx
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Activity, AlertTriangle, CheckCircle2, LockKeyhole, Radio, RefreshCw, ShieldAlert } from 'lucide-react';
+import { getMissionControlSummary, MissionControlSummary, MissionMetric } from '../../api/missionControl';
+
+const unavailable: MissionMetric = { value: null, status: 'unavailable' };
+
+function MetricCard({ label, metric, format }: { label: string; metric: MissionMetric; format?: (value: string | number) => string }) {
+  const display = metric.value === null ? '—' : format ? format(metric.value) : String(metric.value);
+  return (
+    <article className="mc-metric">
+      <div className="mc-metric-label">{label}</div>
+      <div className="mc-metric-value">{display}</div>
+      <div className={`mc-source ${metric.status}`}>
+        {metric.status === 'verified' ? <CheckCircle2 /> : <AlertTriangle />}
+        {metric.status}
+      </div>
+    </article>
+  );
+}
+
+export default function MissionControlHome() {
+  const [summary, setSummary] = useState<MissionControlSummary | null>(null);
+  const [connection, setConnection] = useState<'live' | 'degraded' | 'offline'>('offline');
+  const [error, setError] = useState('');
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await getMissionControlSummary();
+      setSummary(next);
+      setConnection(next.health === 'healthy' ? 'live' : 'degraded');
+      setError('');
+    } catch {
+      setConnection('offline');
+      setError('Telemetry endpoint is unavailable. No operational values are being inferred.');
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const timer = window.setInterval(refresh, 30_000);
+    return () => window.clearInterval(timer);
+  }, [refresh]);
+
+  const metrics = summary ?? {
+    active_agents: unavailable, active_runs: unavailable, pending_decisions: unavailable,
+    open_incidents: unavailable, daily_spend_usd: unavailable, kill_switch: unavailable,
+    evidence_items: unavailable, scheduled_jobs: unavailable,
+  };
+
+  return (
+    <div className="mc-home">
+      <div className="mc-statusbar" role="status" aria-live="polite">
+        <div><Radio className={connection} /> Telemetry <strong>{connection}</strong></div>
+        <div>Environment <strong>{summary?.environment ?? 'unknown'}</strong></div>
+        <div>Updated <strong>{summary ? new Date(summary.telemetry_updated_at).toLocaleTimeString() : 'not connected'}</strong></div>
+        <button onClick={refresh} aria-label="Refresh telemetry"><RefreshCw /> Refresh</button>
+      </div>
+      {error && <div className="mc-warning"><ShieldAlert /> {error}</div>}
+
+      <section className="mc-command-strip" aria-label="Command controls">
+        <div>
+          <p className="mc-eyebrow">COMMAND AUTHORITY</p>
+          <h2>Human control remains active</h2>
+          <p>Mutating controls stay locked until their permission-checked APIs and audit receipts are connected.</p>
+        </div>
+        <div className="mc-command-actions">
+          {['Create task', 'Start governed run', 'Assign agent', 'Pause all', 'Emergency stop'].map((command) => (
+            <button key={command} disabled title="Governed command API not connected">
+              <LockKeyhole /> {command}
+            </button>
+          ))}
+          <a href="/mission-control/operations"><Activity /> Open Operations</a>
+        </div>
+      </section>
+
+      <section>
+        <div className="mc-section-title"><div><p className="mc-eyebrow">VERIFIED READ MODEL</p><h2>Operational posture</h2></div><span>Source: {summary?.telemetry_source ?? 'unavailable'}</span></div>
+        <div className="mc-metrics">
+          <MetricCard label="Active agents" metric={metrics.active_agents} />
+          <MetricCard label="Active runs" metric={metrics.active_runs} />
+          <MetricCard label="Pending decisions" metric={metrics.pending_decisions} />
+          <MetricCard label="Open incidents" metric={metrics.open_incidents} />
+          <MetricCard label="Evidence items" metric={metrics.evidence_items} />
+          <MetricCard label="Scheduled jobs" metric={metrics.scheduled_jobs} />
+          <MetricCard label="Daily spend" metric={metrics.daily_spend_usd} format={(v) => `$${v}`} />
+          <MetricCard label="Kill switch" metric={metrics.kill_switch} />
+        </div>
+      </section>
+
+      <section className="mc-systems">
+        <div className="mc-section-title"><div><p className="mc-eyebrow">OBSERVATION</p><h2>Subsystem health</h2></div></div>
+        {summary ? Object.entries(summary.subsystems).map(([name, state]) => (
+          <div className="mc-system-row" key={name}>
+            <span className={`mc-health-dot ${state.status}`} />
+            <strong>{name.replace('_', ' ')}</strong>
+            <span>{state.status}</span>
+          </div>
+        )) : <div className="mc-empty">Connect the Portal API to inspect subsystem telemetry.</div>}
+      </section>
+    </div>
+  );
+}

--- a/web/src/pages/mission-control/MissionControlLayout.tsx
+++ b/web/src/pages/mission-control/MissionControlLayout.tsx
@@ -1,0 +1,30 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import { clsx } from 'clsx';
+import { missionControlSections } from './sections';
+
+export default function MissionControlLayout() {
+  return (
+    <section className="mc-shell" aria-label="Mission Control">
+      <header className="mc-masthead">
+        <div>
+          <p className="mc-eyebrow">SINTRAPRIME / CONTROL PLANE</p>
+          <h1>Mission Control</h1>
+          <p>Authorized work. Verifiable outcomes.</p>
+        </div>
+        <div className="mc-doctrine">
+          <span>GOVERNANCE FIRST</span>
+          <span>EVIDENCE REQUIRED</span>
+        </div>
+      </header>
+      <nav className="mc-subnav" aria-label="Mission Control sections">
+        <NavLink end to="/mission-control" className={({ isActive }) => clsx(isActive && 'active')}>Overview</NavLink>
+        {missionControlSections.map(([path, label]) => (
+          <NavLink key={path} to={`/mission-control/${path}`} className={({ isActive }) => clsx(isActive && 'active')}>
+            {label}
+          </NavLink>
+        ))}
+      </nav>
+      <Outlet />
+    </section>
+  );
+}

--- a/web/src/pages/mission-control/MissionControlSurface.tsx
+++ b/web/src/pages/mission-control/MissionControlSurface.tsx
@@ -1,0 +1,23 @@
+import { useParams } from 'react-router-dom';
+import { LockKeyhole, Radio } from 'lucide-react';
+import { missionControlSections } from './sections';
+
+export default function MissionControlSurface() {
+  const { surface = '' } = useParams();
+  const label = missionControlSections.find(([path]) => path === surface)?.[1] ?? 'Control Surface';
+  return (
+    <div className="mc-surface">
+      <div>
+        <p className="mc-eyebrow">MISSION CONTROL / {label.toUpperCase()}</p>
+        <h2>{label}</h2>
+        <p>This route is preserved in the unified shell. Its authoritative data adapter is not connected yet.</p>
+      </div>
+      <div className="mc-empty-state">
+        <Radio />
+        <h3>No fabricated operational data</h3>
+        <p>Mission Control will populate this surface only from typed telemetry, governance, and evidence APIs.</p>
+        <span><LockKeyhole /> Commands unavailable until server-side authorization and audit events are active.</span>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/mission-control/sections.ts
+++ b/web/src/pages/mission-control/sections.ts
@@ -1,0 +1,16 @@
+export const missionControlSections = [
+  ['operations', 'Operations'],
+  ['agents', 'Agents'],
+  ['tasks', 'Tasks'],
+  ['decisions', 'Decisions'],
+  ['runs', 'Runs'],
+  ['activity', 'Activity'],
+  ['schedules', 'Schedules'],
+  ['evidence', 'Evidence'],
+  ['governance', 'Governance'],
+  ['memory', 'Memory'],
+  ['costs', 'Costs'],
+  ['incidents', 'Incidents'],
+  ['integrations', 'Integrations'],
+  ['settings', 'Settings'],
+] as const;


### PR DESCRIPTION
## Summary
- adds the unified Mission Control shell and all required routes
- adds a permission-gated, telemetry-backed executive summary
- reuses existing system probes instead of duplicating infrastructure
- keeps mutating controls locked until governed command APIs exist
- includes the requested implementation evidence package

## Verification
- frontend lint: pass
- TypeScript type-check: pass
- Vite production build: pass
- API contract test: pass
- Python Ruff: pass
- npm audit: zero vulnerabilities

## Boundary
This PR implements Phase 1 of the seven-phase directive. It does not fabricate live data or claim browser/runtime evidence that was not produced.