### PR TITLE
Mission Control Phase Two Increment One command ledger

### DIFF
--- a/docs/mission-control/phase-2-increment-1-evidence.md
+++ b/docs/mission-control/phase-2-increment-1-evidence.md
@@ -1,0 +1,218 @@
+# Mission Control Phase Two Increment One Evidence
+
+## Scope
+
+Authorized increment: command ledger + guard + idempotency + refusal-only endpoint.
+
+No command in this increment mutates run, task, scheduler, agent, mission, or assignment state. The Mission Control UI remains read-only and no frontend files were changed.
+
+## Baseline
+
+- Frozen tag: `mission-control-phase-1`
+- Baseline commit: `bedccf2ff92291b9fbc51c72146255dd83d26663`
+- Baseline tree: `eeb8886fae074d1c20f9aa18ed65272c40cf0ca8`
+- Working branch: `feat/mission-control-phase-2-command-ledger`
+- Parent for implementation branch: `bedccf2ff92291b9fbc51c72146255dd83d26663`
+- Final commit/tree: recorded in PR metadata and completion response. A commit cannot contain its own hash without changing that hash.
+
+## Changed Files
+
+- `portal/auth/rbac.py`
+- `portal/main.py`
+- `portal/migrations/add_mission_control_command_ledger.sql`
+- `portal/models/__init__.py`
+- `portal/models/audit.py`
+- `portal/models/mission_control_command.py`
+- `portal/routers/mission_control_commands.py`
+- `portal/services/audit_service.py`
+- `portal/services/mission_control_command_guard.py`
+- `portal/services/mission_control_command_service.py`
+- `portal/tests/test_mission_control_commands.py`
+- `portal/tests/test_service_units.py`
+- `docs/mission-control/phase-2-increment-1-evidence.md`
+
+## Migration
+
+- File: `portal/migrations/add_mission_control_command_ledger.sql`
+- SHA256: `8898E116F75261C57185C2232803137085FCF6B2F4DE2896B49CFE4CEBD2BD71`
+
+Migration creates only:
+
+- `mission_control_commands`
+- `mission_control_command_events`
+- `mission_control_command_receipts`
+
+It does not create run-state, scheduler-state, mission-state, agent-state, or assignment-state tables.
+
+## Permission Matrix
+
+| Permission | Super Admin | Firm Admin | Attorney | Paralegal | Accountant | Viewer | Client |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `mission_control:command_read` | yes | yes | yes | no | no | no | no |
+| `mission_control:command_create` | yes | yes | yes | no | no | no | no |
+| `mission_control:run_start` | yes | yes | yes | no | no | no | no |
+| `mission_control:run_pause` | yes | yes | yes | no | no | no | no |
+| `mission_control:run_resume` | yes | yes | yes | no | no | no | no |
+| `mission_control:run_cancel` | yes | yes | no | no | no | no | no |
+| `mission_control:agent_assign` | yes | yes | yes | no | no | no | no |
+| `mission_control:agent_reassign` | yes | yes | no | no | no | no | no |
+| `mission_control:command_admin` | yes | no | no | no | no | no | no |
+
+Super Admin receives all permissions through the existing `frozenset(Permission)` behavior.
+
+## Endpoint
+
+`POST /api/v1/mission-control/commands`
+
+No direct mutation endpoints were added.
+
+## Request Example
+
+```json
+{
+  "command_type": "PAUSE_RUN",
+  "target_type": "run",
+  "target_id": "run-123",
+  "idempotency_key": "client-generated-key",
+  "reason": "operator requested hold",
+  "payload": {},
+  "metadata": {
+    "source": "mission-control-ui"
+  }
+}
+```
+
+## Refusal Response Example
+
+```json
+{
+  "command_id": "uuid",
+  "command_type": "PAUSE_RUN",
+  "target_type": "run",
+  "target_id": "run-123",
+  "state": "REFUSED",
+  "reason_code": "COMMAND_EXECUTION_NOT_ENABLED",
+  "reason": "operator requested hold",
+  "duplicate": false,
+  "idempotency_key": "client-generated-key",
+  "request_hash": "sha256",
+  "audit_log_id": "uuid",
+  "event_ids": ["uuid", "uuid", "uuid"],
+  "receipt_id": "uuid",
+  "created_at": "timestamp",
+  "completed_at": "timestamp"
+}
+```
+
+## Idempotency Replay Example
+
+Same tenant + requester + idempotency key + identical canonical request hash returns the original command response with:
+
+```json
+{
+  "duplicate": true,
+  "state": "REFUSED",
+  "reason_code": "COMMAND_EXECUTION_NOT_ENABLED"
+}
+```
+
+No second command row or receipt row is created.
+
+## Duplicate Conflict Example
+
+Same tenant + requester + idempotency key + changed canonical request hash returns HTTP 409:
+
+```json
+{
+  "detail": {
+    "state": "DUPLICATE_CONFLICT",
+    "reason_code": "IDEMPOTENCY_KEY_CONFLICT",
+    "command_id": "original-command-id"
+  }
+}
+```
+
+No second command row is created.
+
+## Audit And Receipt Behavior
+
+For an accepted non-duplicate command request, the service:
+
+1. creates a `mission_control_commands` row;
+2. appends `RECEIVED`, `VALIDATING`, and `REFUSED` command events;
+3. writes the existing hash-chained `audit_logs` record;
+4. creates a `REFUSAL` receipt with a deterministic receipt hash;
+5. publishes requester-scoped realtime status on a best-effort basis.
+
+Atomic behavior: audit failure rolls back the command transaction and raises. It does not leave an apparently successful command record.
+
+## Command Event Hash Verification
+
+Focused tests recompute each event hash from:
+
+- command ID;
+- sequence;
+- event type;
+- state;
+- payload;
+- previous hash.
+
+The test asserts the stored `previous_hash` and `event_hash` chain is deterministic.
+
+## Realtime Behavior
+
+The implementation reuses `ws_manager.send_to_user` for requester-scoped command status events only.
+
+No unauthenticated or tenant-wide Mission Control command broadcasts were added. Realtime delivery failure is logged and does not change the terminal `REFUSED` outcome.
+
+## Proof No Mutation Path Was Enabled
+
+- No frontend files changed.
+- Mission Control command buttons remain disabled.
+- No direct `/runs/{id}/pause`, `/runs/{id}/resume`, `/runs/{id}/cancel`, `/agents/{id}/assign`, or `/agents/{id}/reassign` endpoints were added.
+- Code search for direct scheduler mutation calls in touched portal/web areas returned no matches.
+- The command guard always returns `COMMAND_EXECUTION_NOT_ENABLED`.
+- Tests assert supported commands persist and end in `REFUSED`.
+
+## Phase One Visual Evidence
+
+No files under these Phase One evidence paths were changed:
+
+- `docs/ui-audit/screenshots/preservation-main-20260718`
+- `docs/ui-audit/preservation-main-20260718-results.json`
+
+`git diff -- docs/ui-audit/screenshots/preservation-main-20260718 docs/ui-audit/preservation-main-20260718-results.json` returned no output.
+
+## Verification Results
+
+Passed:
+
+- `python -m py_compile portal\tests\test_mission_control_commands.py portal\models\mission_control_command.py portal\models\audit.py portal\services\audit_service.py portal\services\mission_control_command_service.py portal\routers\mission_control_commands.py`
+- `python -m pytest portal\tests\test_mission_control_commands.py -q` -> 20 passed
+- `python -m pytest portal\tests\test_mission_control.py portal\tests\test_rbac.py -q` -> 35 passed
+- `python -m pytest portal\tests\test_service_units.py -q` -> 70 passed
+- `python -m pytest portal\tests\test_mission_control_commands.py portal\tests\test_mission_control.py portal\tests\test_rbac.py portal\tests\test_service_units.py -q` -> 125 passed
+- `python -m ruff check` on touched Python files -> all checks passed
+- `git diff --check` -> clean
+- SQLAlchemy model smoke check confirmed `mission_control_commands`, `mission_control_command_events`, and `mission_control_command_receipts` are registered in metadata.
+
+Full repository Python test command:
+
+- `python -m pytest --tb=short -q` completed with 4 failures in `tests/test_scheduler_executor.py`.
+- Failures are Windows shell environment failures while spawning Unix-like shell commands `echo`, `sleep`, and `false` from `scheduler/task_executor.py` tests.
+- These failures are unrelated to the Mission Control command ledger and do not indicate a command mutation path.
+
+Frontend checks:
+
+- Not run because no frontend or shared frontend types were touched.
+
+## Known Limitations
+
+- Increment One records and refuses commands only.
+- No confirmation flow exists.
+- No approval consumption exists.
+- No runner pause/resume/cancel integration exists.
+- No scheduler mutation exists.
+- No assignment mutation exists.
+- No command history UI is enabled.
+- Command rows are a projection; command events and receipts are the immutable history.

--- a/docs/mission-control/phase-2-increment-1-evidence.md
+++ b/docs/mission-control/phase-2-increment-1-evidence.md
@@ -13,7 +13,7 @@ No command in this increment mutates run, task, scheduler, agent, mission, or as
 - Baseline tree: `eeb8886fae074d1c20f9aa18ed65272c40cf0ca8`
 - Working branch: `feat/mission-control-phase-2-command-ledger`
 - Parent for implementation branch: `bedccf2ff92291b9fbc51c72146255dd83d26663`
-- Final commit/tree: recorded in PR metadata and completion response. A commit cannot contain its own hash without changing that hash.
+- Final commit/tree: recorded in PR metadata, PR comments, and completion response. A commit cannot contain its own hash without changing that hash.
 
 ## Changed Files
 
@@ -73,7 +73,7 @@ No direct mutation endpoints were added.
   "command_type": "PAUSE_RUN",
   "target_type": "run",
   "target_id": "run-123",
-  "idempotency_key": "client-generated-key",
+  "idempotency_key": "client-generated-key-0001",
   "reason": "operator requested hold",
   "payload": {},
   "metadata": {
@@ -94,7 +94,7 @@ No direct mutation endpoints were added.
   "reason_code": "COMMAND_EXECUTION_NOT_ENABLED",
   "reason": "operator requested hold",
   "duplicate": false,
-  "idempotency_key": "client-generated-key",
+  "idempotency_key": "client-generated-key-0001",
   "request_hash": "sha256",
   "audit_log_id": "uuid",
   "event_ids": ["uuid", "uuid", "uuid"],
@@ -103,6 +103,16 @@ No direct mutation endpoints were added.
   "completed_at": "timestamp"
 }
 ```
+
+## Idempotency Contract
+
+Idempotency keys are required and must be 16-128 characters.
+
+- New command: HTTP 201 with `duplicate: false`.
+- Identical replay: HTTP 200 with `duplicate: true`.
+- Changed replay: HTTP 409 with `DUPLICATE_CONFLICT`.
+
+The service recovers from the database unique-constraint collision path for concurrent requests. If the initial lookup misses because another transaction won the `(tenant_id, requested_by, idempotency_key)` race, the losing request rolls back its failed insert, reloads the winning command, and returns the deterministic replay/conflict response.
 
 ## Idempotency Replay Example
 
@@ -116,7 +126,7 @@ Same tenant + requester + idempotency key + identical canonical request hash ret
 }
 ```
 
-No second command row or receipt row is created.
+No second command row, event chain, audit row, or receipt row is created.
 
 ## Duplicate Conflict Example
 
@@ -132,7 +142,20 @@ Same tenant + requester + idempotency key + changed canonical request hash retur
 }
 ```
 
-No second command row is created.
+No second command row, event chain, audit row, or receipt row is created.
+
+## Command Target Compatibility
+
+| Command | Allowed target types |
+|---|---|
+| `START_GOVERNED_RUN` | `run`, `mission` |
+| `PAUSE_RUN` | `run` |
+| `RESUME_RUN` | `run` |
+| `CANCEL_RUN` | `run` |
+| `ASSIGN_AGENT` | `run`, `task`, `mission` |
+| `REASSIGN_AGENT` | `run`, `task`, `mission` |
+
+Invalid command-target combinations return HTTP 422 before command, event, audit, or receipt persistence.
 
 ## Audit And Receipt Behavior
 
@@ -195,6 +218,7 @@ Passed:
 - `python -m ruff check` on touched Python files -> all checks passed
 - `git diff --check` -> clean
 - SQLAlchemy model smoke check confirmed `mission_control_commands`, `mission_control_command_events`, and `mission_control_command_receipts` are registered in metadata.
+- Focused collision-recovery tests prove stale initial lookup plus unique-constraint collision reloads the winning command and creates no duplicate command, events, audit entry, or receipt.
 
 Full repository Python test command:
 

--- a/portal/auth/rbac.py
+++ b/portal/auth/rbac.py
@@ -117,6 +117,17 @@ class Permission(StrEnum):
     AUDIT_READ           = "audit:read"
     AUDIT_EXPORT         = "audit:export"
 
+    # Mission Control governed commands
+    MISSION_COMMAND_READ   = "mission_control:command_read"
+    MISSION_COMMAND_CREATE = "mission_control:command_create"
+    MISSION_RUN_START      = "mission_control:run_start"
+    MISSION_RUN_PAUSE      = "mission_control:run_pause"
+    MISSION_RUN_RESUME     = "mission_control:run_resume"
+    MISSION_RUN_CANCEL     = "mission_control:run_cancel"
+    MISSION_AGENT_ASSIGN   = "mission_control:agent_assign"
+    MISSION_AGENT_REASSIGN = "mission_control:agent_reassign"
+    MISSION_COMMAND_ADMIN  = "mission_control:command_admin"
+
 
 # ── Role → Permission mapping ─────────────────────────────────────────────────
 
@@ -150,6 +161,11 @@ ROLE_PERMISSIONS: dict[Role, frozenset[Permission]] = {
         Permission.ADMIN_AUDIT_LOG, Permission.ADMIN_BRANDING, Permission.ADMIN_QUOTA,
         # Audit
         Permission.AUDIT_READ, Permission.AUDIT_EXPORT,
+        # Mission Control governed commands
+        Permission.MISSION_COMMAND_READ, Permission.MISSION_COMMAND_CREATE,
+        Permission.MISSION_RUN_START, Permission.MISSION_RUN_PAUSE, Permission.MISSION_RUN_RESUME,
+        Permission.MISSION_RUN_CANCEL, Permission.MISSION_AGENT_ASSIGN,
+        Permission.MISSION_AGENT_REASSIGN,
     ]),
 
     Role.ATTORNEY: frozenset([
@@ -165,6 +181,9 @@ ROLE_PERMISSIONS: dict[Role, frozenset[Permission]] = {
         Permission.BILLING_TIME_TRACK, Permission.BILLING_REPORT,
         Permission.NOTIF_READ,
         Permission.AUDIT_READ,
+        Permission.MISSION_COMMAND_READ, Permission.MISSION_COMMAND_CREATE,
+        Permission.MISSION_RUN_START, Permission.MISSION_RUN_PAUSE, Permission.MISSION_RUN_RESUME,
+        Permission.MISSION_AGENT_ASSIGN,
     ]),
 
     Role.PARALEGAL: frozenset([

--- a/portal/main.py
+++ b/portal/main.py
@@ -26,6 +26,7 @@ from portal.routers import (
     documents,
     messages,
     mission_control,
+    mission_control_commands,
     notifications,
     recovery,
     sso,
@@ -129,6 +130,7 @@ def create_app() -> FastAPI:
     app.include_router(billing.router, prefix="/api/v1/billing", tags=["billing"])
     app.include_router(messages.router, prefix="/api/v1/messages", tags=["messages"])
     app.include_router(mission_control.router)
+    app.include_router(mission_control_commands.router)
     app.include_router(notifications.router, prefix="/api/v1/notifications", tags=["notifications"])
     app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
 

--- a/portal/migrations/add_mission_control_command_ledger.sql
+++ b/portal/migrations/add_mission_control_command_ledger.sql
@@ -1,0 +1,128 @@
+-- =============================================================================
+-- Migration: Add Mission Control governed command ledger
+-- Phase Two, Increment One: command persistence, events, receipts, idempotency
+-- No run, scheduler, agent, mission, or assignment mutation state is introduced.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS mission_control_commands (
+    id                UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    tenant_id         UUID NOT NULL REFERENCES tenants(id),
+    requested_by      UUID NOT NULL REFERENCES users(id),
+    command_type      VARCHAR(40) NOT NULL,
+    target_type       VARCHAR(40) NOT NULL,
+    target_id         VARCHAR(128) NOT NULL,
+    idempotency_key   VARCHAR(128) NOT NULL,
+    request_hash      VARCHAR(64) NOT NULL,
+    state             VARCHAR(40) NOT NULL,
+    reason_code       VARCHAR(80),
+    reason            TEXT,
+    payload           JSONB NOT NULL DEFAULT '{}',
+    metadata          JSONB NOT NULL DEFAULT '{}',
+    audit_log_id      UUID REFERENCES audit_logs(id),
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at      TIMESTAMPTZ,
+    CONSTRAINT ck_mission_control_commands_command_type CHECK (
+        command_type IN (
+            'START_GOVERNED_RUN',
+            'PAUSE_RUN',
+            'RESUME_RUN',
+            'CANCEL_RUN',
+            'ASSIGN_AGENT',
+            'REASSIGN_AGENT'
+        )
+    ),
+    CONSTRAINT ck_mission_control_commands_state CHECK (
+        state IN (
+            'RECEIVED',
+            'VALIDATING',
+            'REFUSED',
+            'DUPLICATE_REPLAYED',
+            'DUPLICATE_CONFLICT'
+        )
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_mission_control_command_idempotency
+    ON mission_control_commands(tenant_id, requested_by, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS ix_mission_control_commands_tenant_state_created
+    ON mission_control_commands(tenant_id, state, created_at);
+
+CREATE INDEX IF NOT EXISTS ix_mission_control_commands_target
+    ON mission_control_commands(tenant_id, target_type, target_id);
+
+CREATE TABLE IF NOT EXISTS mission_control_command_events (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    command_id      UUID NOT NULL REFERENCES mission_control_commands(id) ON DELETE CASCADE,
+    sequence        INTEGER NOT NULL,
+    event_type      VARCHAR(60) NOT NULL,
+    state           VARCHAR(40) NOT NULL,
+    payload         JSONB NOT NULL DEFAULT '{}',
+    previous_hash   VARCHAR(64),
+    event_hash      VARCHAR(64) NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_mission_control_command_event_seq UNIQUE (command_id, sequence)
+);
+
+CREATE INDEX IF NOT EXISTS ix_mission_control_command_events_command
+    ON mission_control_command_events(command_id);
+
+CREATE TABLE IF NOT EXISTS mission_control_command_receipts (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    command_id      UUID NOT NULL REFERENCES mission_control_commands(id) ON DELETE CASCADE,
+    receipt_type    VARCHAR(40) NOT NULL,
+    receipt_hash    VARCHAR(64) NOT NULL,
+    audit_log_id    UUID REFERENCES audit_logs(id),
+    evidence_refs   JSONB NOT NULL DEFAULT '[]',
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_mission_control_command_receipt UNIQUE (command_id, receipt_type)
+);
+
+CREATE INDEX IF NOT EXISTS ix_mission_control_command_receipts_command
+    ON mission_control_command_receipts(command_id);
+
+CREATE OR REPLACE FUNCTION prevent_mission_control_command_event_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION 'mission_control_command_events rows are immutable';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_mission_control_command_event_immutable
+    ON mission_control_command_events;
+CREATE TRIGGER trg_mission_control_command_event_immutable
+    BEFORE UPDATE OR DELETE ON mission_control_command_events
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_mission_control_command_event_mutation();
+
+CREATE OR REPLACE FUNCTION prevent_mission_control_command_receipt_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION 'mission_control_command_receipts rows are immutable';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_mission_control_command_receipt_immutable
+    ON mission_control_command_receipts;
+CREATE TRIGGER trg_mission_control_command_receipt_immutable
+    BEFORE UPDATE OR DELETE ON mission_control_command_receipts
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_mission_control_command_receipt_mutation();
+
+COMMENT ON TABLE mission_control_commands IS
+    'Mission Control governed command ledger projection. Increment One records and refuses only; no operational mutation path exists.';
+
+COMMENT ON TABLE mission_control_command_events IS
+    'Append-only Mission Control command event hash chain.';
+
+COMMENT ON TABLE mission_control_command_receipts IS
+    'Immutable receipts for governed Mission Control command outcomes.';
+
+-- DOWN migration notes:
+--   DROP TRIGGER IF EXISTS trg_mission_control_command_receipt_immutable ON mission_control_command_receipts;
+--   DROP FUNCTION IF EXISTS prevent_mission_control_command_receipt_mutation();
+--   DROP TRIGGER IF EXISTS trg_mission_control_command_event_immutable ON mission_control_command_events;
+--   DROP FUNCTION IF EXISTS prevent_mission_control_command_event_mutation();
+--   DROP TABLE IF EXISTS mission_control_command_receipts;
+--   DROP TABLE IF EXISTS mission_control_command_events;
+--   DROP TABLE IF EXISTS mission_control_commands;

--- a/portal/models/__init__.py
+++ b/portal/models/__init__.py
@@ -7,6 +7,11 @@ from .client import Client, Matter
 from .document import Document, DocumentFolder, DocumentShare, DocumentVersion
 from .evidence_snapshot import EvidenceSnapshot
 from .message import Message, MessageAttachment, MessageThread
+from .mission_control_command import (
+    MissionControlCommand,
+    MissionControlCommandEvent,
+    MissionControlCommandReceipt,
+)
 from .user import Permission as UserPermission
 from .user import Role as UserRole
 from .user import User, UserPermissionAssoc
@@ -32,6 +37,9 @@ __all__ = [
     "Message",
     "MessageAttachment",
     "MessageThread",
+    "MissionControlCommand",
+    "MissionControlCommandEvent",
+    "MissionControlCommandReceipt",
     "Payment",
     "TimeEntry",
     "TrustAccount",

--- a/portal/models/audit.py
+++ b/portal/models/audit.py
@@ -23,9 +23,9 @@ class AuditLog(Base):
     """
     __tablename__ = "audit_logs"
 
-    id: Mapped[uuid.UUID]            = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4))
-    tenant_id: Mapped[uuid.UUID | None] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=True)
-    user_id: Mapped[uuid.UUID | None]   = mapped_column(String(36), ForeignKey("users.id"), nullable=True)
+    id: Mapped[str]                  = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    tenant_id: Mapped[str | None]    = mapped_column(String(36), ForeignKey("tenants.id"), nullable=True)
+    user_id: Mapped[str | None]      = mapped_column(String(36), ForeignKey("users.id"), nullable=True)
 
     # Who
     actor_email: Mapped[str | None]  = mapped_column(String(255), nullable=True)

--- a/portal/models/mission_control_command.py
+++ b/portal/models/mission_control_command.py
@@ -1,0 +1,128 @@
+"""Mission Control governed command ledger models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ..database import Base
+
+
+class MissionControlCommand(Base):
+    """Tenant-scoped command request projection."""
+
+    __tablename__ = "mission_control_commands"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    tenant_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
+    requested_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+
+    command_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    target_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    target_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    idempotency_key: Mapped[str] = mapped_column(String(128), nullable=False)
+    request_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    state: Mapped[str] = mapped_column(String(40), nullable=False)
+    reason_code: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    metadata_json: Mapped[dict] = mapped_column("metadata", JSON, nullable=False, default=dict)
+
+    audit_log_id: Mapped[str | None] = mapped_column(String(36), ForeignKey("audit_logs.id"), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    events: Mapped[list[MissionControlCommandEvent]] = relationship(
+        "MissionControlCommandEvent",
+        back_populates="command",
+        lazy="selectin",
+        order_by="MissionControlCommandEvent.sequence",
+    )
+    receipts: Mapped[list[MissionControlCommandReceipt]] = relationship(
+        "MissionControlCommandReceipt",
+        back_populates="command",
+        lazy="selectin",
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "requested_by",
+            "idempotency_key",
+            name="uq_mission_control_command_idempotency",
+        ),
+        Index("ix_mission_control_commands_tenant_state_created", "tenant_id", "state", "created_at"),
+        Index("ix_mission_control_commands_target", "tenant_id", "target_type", "target_id"),
+    )
+
+
+class MissionControlCommandEvent(Base):
+    """Append-only command lifecycle event with a per-command hash chain."""
+
+    __tablename__ = "mission_control_command_events"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    command_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("mission_control_commands.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    event_type: Mapped[str] = mapped_column(String(60), nullable=False)
+    state: Mapped[str] = mapped_column(String(40), nullable=False)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    previous_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    event_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    command: Mapped[MissionControlCommand] = relationship(
+        "MissionControlCommand",
+        back_populates="events",
+    )
+
+    __table_args__ = (
+        UniqueConstraint("command_id", "sequence", name="uq_mission_control_command_event_seq"),
+        Index("ix_mission_control_command_events_command", "command_id"),
+    )
+
+
+class MissionControlCommandReceipt(Base):
+    """Immutable command receipt linking the refusal outcome to audit/evidence."""
+
+    __tablename__ = "mission_control_command_receipts"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    command_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("mission_control_commands.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    receipt_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    receipt_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    audit_log_id: Mapped[str | None] = mapped_column(String(36), ForeignKey("audit_logs.id"), nullable=True)
+    evidence_refs: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    command: Mapped[MissionControlCommand] = relationship(
+        "MissionControlCommand",
+        back_populates="receipts",
+    )
+
+    __table_args__ = (
+        UniqueConstraint("command_id", "receipt_type", name="uq_mission_control_command_receipt"),
+        Index("ix_mission_control_command_receipts_command", "command_id"),
+    )

--- a/portal/routers/mission_control_commands.py
+++ b/portal/routers/mission_control_commands.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.rbac import CurrentUser, Permission, require_permissions
 from ..database import get_db
 from ..services.mission_control_command_service import (
+    IDEMPOTENCY_KEY_MAX_LENGTH,
+    IDEMPOTENCY_KEY_MIN_LENGTH,
     CommandSubmission,
     CommandTargetType,
     CommandType,
@@ -31,12 +33,28 @@ COMMAND_PERMISSIONS: dict[CommandType, Permission] = {
     CommandType.REASSIGN_AGENT: Permission.MISSION_AGENT_REASSIGN,
 }
 
+COMMAND_TARGET_COMPATIBILITY: dict[CommandType, frozenset[CommandTargetType]] = {
+    CommandType.START_GOVERNED_RUN: frozenset({CommandTargetType.RUN, CommandTargetType.MISSION}),
+    CommandType.PAUSE_RUN: frozenset({CommandTargetType.RUN}),
+    CommandType.RESUME_RUN: frozenset({CommandTargetType.RUN}),
+    CommandType.CANCEL_RUN: frozenset({CommandTargetType.RUN}),
+    CommandType.ASSIGN_AGENT: frozenset(
+        {CommandTargetType.RUN, CommandTargetType.TASK, CommandTargetType.MISSION}
+    ),
+    CommandType.REASSIGN_AGENT: frozenset(
+        {CommandTargetType.RUN, CommandTargetType.TASK, CommandTargetType.MISSION}
+    ),
+}
+
 
 class MissionControlCommandRequest(BaseModel):
     command_type: CommandType
     target_type: CommandTargetType
     target_id: str = Field(min_length=1, max_length=128)
-    idempotency_key: str = Field(min_length=1, max_length=128)
+    idempotency_key: str = Field(
+        min_length=IDEMPOTENCY_KEY_MIN_LENGTH,
+        max_length=IDEMPOTENCY_KEY_MAX_LENGTH,
+    )
     reason: str | None = Field(default=None, max_length=2000)
     payload: dict[str, Any] = Field(default_factory=dict)
     metadata: dict[str, Any] = Field(default_factory=dict)
@@ -67,9 +85,21 @@ class MissionControlCommandResponse(BaseModel):
 )
 async def submit_command(
     body: MissionControlCommandRequest,
+    response: Response,
     current_user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_CREATE)),
     db: AsyncSession = Depends(get_db),
 ) -> MissionControlCommandResponse:
+    allowed_targets = COMMAND_TARGET_COMPATIBILITY[body.command_type]
+    if body.target_type not in allowed_targets:
+        allowed = sorted(target.value for target in allowed_targets)
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "reason_code": "INVALID_COMMAND_TARGET",
+                "allowed_target_types": allowed,
+            },
+        )
+
     specific_permission = COMMAND_PERMISSIONS[body.command_type]
     if not current_user.has_permission(specific_permission):
         raise HTTPException(
@@ -97,6 +127,9 @@ async def submit_command(
                 "command_id": exc.command_id,
             },
         ) from exc
+
+    if result.duplicate:
+        response.status_code = status.HTTP_200_OK
 
     command = result.command
     return MissionControlCommandResponse(

--- a/portal/routers/mission_control_commands.py
+++ b/portal/routers/mission_control_commands.py
@@ -1,0 +1,118 @@
+"""Governed Mission Control command ingestion."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth.rbac import CurrentUser, Permission, require_permissions
+from ..database import get_db
+from ..services.mission_control_command_service import (
+    CommandSubmission,
+    CommandTargetType,
+    CommandType,
+    DuplicateCommandConflictError,
+    submit_refusal_only_command,
+)
+
+router = APIRouter(prefix="/api/v1/mission-control", tags=["mission-control"])
+
+
+COMMAND_PERMISSIONS: dict[CommandType, Permission] = {
+    CommandType.START_GOVERNED_RUN: Permission.MISSION_RUN_START,
+    CommandType.PAUSE_RUN: Permission.MISSION_RUN_PAUSE,
+    CommandType.RESUME_RUN: Permission.MISSION_RUN_RESUME,
+    CommandType.CANCEL_RUN: Permission.MISSION_RUN_CANCEL,
+    CommandType.ASSIGN_AGENT: Permission.MISSION_AGENT_ASSIGN,
+    CommandType.REASSIGN_AGENT: Permission.MISSION_AGENT_REASSIGN,
+}
+
+
+class MissionControlCommandRequest(BaseModel):
+    command_type: CommandType
+    target_type: CommandTargetType
+    target_id: str = Field(min_length=1, max_length=128)
+    idempotency_key: str = Field(min_length=1, max_length=128)
+    reason: str | None = Field(default=None, max_length=2000)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class MissionControlCommandResponse(BaseModel):
+    command_id: str
+    command_type: str
+    target_type: str
+    target_id: str
+    state: str
+    reason_code: str | None
+    reason: str | None
+    duplicate: bool
+    idempotency_key: str
+    request_hash: str
+    audit_log_id: str | None
+    event_ids: list[str]
+    receipt_id: str | None
+    created_at: datetime | None
+    completed_at: datetime | None
+
+
+@router.post(
+    "/commands",
+    response_model=MissionControlCommandResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def submit_command(
+    body: MissionControlCommandRequest,
+    current_user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_CREATE)),
+    db: AsyncSession = Depends(get_db),
+) -> MissionControlCommandResponse:
+    specific_permission = COMMAND_PERMISSIONS[body.command_type]
+    if not current_user.has_permission(specific_permission):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Missing permissions: {specific_permission}",
+        )
+
+    submission = CommandSubmission(
+        command_type=body.command_type,
+        target_type=body.target_type,
+        target_id=body.target_id,
+        idempotency_key=body.idempotency_key,
+        reason=body.reason,
+        payload=body.payload,
+        metadata=body.metadata,
+    )
+    try:
+        result = await submit_refusal_only_command(db, submission, current_user)
+    except DuplicateCommandConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "state": "DUPLICATE_CONFLICT",
+                "reason_code": "IDEMPOTENCY_KEY_CONFLICT",
+                "command_id": exc.command_id,
+            },
+        ) from exc
+
+    command = result.command
+    return MissionControlCommandResponse(
+        command_id=str(command.id),
+        command_type=command.command_type,
+        target_type=command.target_type,
+        target_id=command.target_id,
+        state=command.state,
+        reason_code=command.reason_code,
+        reason=command.reason,
+        duplicate=result.duplicate,
+        idempotency_key=command.idempotency_key,
+        request_hash=command.request_hash,
+        audit_log_id=str(command.audit_log_id) if command.audit_log_id else None,
+        event_ids=result.event_ids,
+        receipt_id=result.receipt_id,
+        created_at=command.created_at,
+        completed_at=command.completed_at,
+    )

--- a/portal/services/audit_service.py
+++ b/portal/services/audit_service.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import uuid
 from datetime import UTC, datetime
 from typing import Any
 
@@ -24,8 +23,8 @@ log = structlog.get_logger()
 async def audit(
     db: AsyncSession,
     action: str,
-    user_id: str | uuid.UUID | None = None,
-    tenant_id: str | uuid.UUID | None = None,
+    user_id: str | None = None,
+    tenant_id: str | None = None,
     resource_type: str | None = None,
     resource_id: str | None = None,
     resource_name: str | None = None,
@@ -61,8 +60,8 @@ async def audit(
     entry_hash = _compute_hash(entry_data)
 
     entry = AuditLog(
-        tenant_id=uuid.UUID(str(tenant_id)) if tenant_id else None,
-        user_id=uuid.UUID(str(user_id)) if user_id else None,
+        tenant_id=str(tenant_id) if tenant_id else None,
+        user_id=str(user_id) if user_id else None,
         actor_email=actor_email,
         actor_role=actor_role,
         actor_ip=actor_ip,
@@ -86,8 +85,8 @@ async def audit(
         await db.flush()
     except Exception as exc:
         log.error("audit.write_failed", action=action, error=str(exc))
-        # Audit failure should not break the main flow
         await db.rollback()
+        raise
 
     log.info(
         "audit",
@@ -102,12 +101,12 @@ async def audit(
 
 async def _get_last_hash(
     db: AsyncSession,
-    tenant_id: str | uuid.UUID | None,
+    tenant_id: str | None,
 ) -> str | None:
     """Get the entry_hash of the most recent audit log entry for this tenant."""
     stmt = (
         select(AuditLog.entry_hash)
-        .where(AuditLog.tenant_id == uuid.UUID(str(tenant_id)) if tenant_id else True)
+        .where(AuditLog.tenant_id == str(tenant_id) if tenant_id else True)
         .order_by(AuditLog.created_at.desc())
         .limit(1)
     )
@@ -122,7 +121,7 @@ def _compute_hash(data: dict) -> str:
 
 async def verify_audit_chain(
     db: AsyncSession,
-    tenant_id: str | uuid.UUID | None = None,
+    tenant_id: str | None = None,
     limit: int = 1000,
 ) -> dict:
     """
@@ -131,7 +130,7 @@ async def verify_audit_chain(
     """
     stmt = (
         select(AuditLog)
-        .where(AuditLog.tenant_id == uuid.UUID(str(tenant_id)) if tenant_id else True)
+        .where(AuditLog.tenant_id == str(tenant_id) if tenant_id else True)
         .order_by(AuditLog.created_at.asc())
         .limit(limit)
     )

--- a/portal/services/mission_control_command_guard.py
+++ b/portal/services/mission_control_command_guard.py
@@ -1,0 +1,14 @@
+"""Server-side guard for Mission Control command execution."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class RefusalReason(StrEnum):
+    COMMAND_EXECUTION_NOT_ENABLED = "COMMAND_EXECUTION_NOT_ENABLED"
+
+
+def refuse_increment_one_execution() -> RefusalReason:
+    """Increment One authorizes command recording only, never execution."""
+    return RefusalReason.COMMAND_EXECUTION_NOT_ENABLED

--- a/portal/services/mission_control_command_service.py
+++ b/portal/services/mission_control_command_service.py
@@ -1,0 +1,326 @@
+"""Mission Control command ledger service."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..auth.rbac import CurrentUser
+from ..models.mission_control_command import (
+    MissionControlCommand,
+    MissionControlCommandEvent,
+    MissionControlCommandReceipt,
+)
+from ..services.audit_service import audit
+from ..websocket.connection_manager import ws_manager
+from .mission_control_command_guard import refuse_increment_one_execution
+
+log = structlog.get_logger(__name__)
+
+
+class CommandType(StrEnum):
+    START_GOVERNED_RUN = "START_GOVERNED_RUN"
+    PAUSE_RUN = "PAUSE_RUN"
+    RESUME_RUN = "RESUME_RUN"
+    CANCEL_RUN = "CANCEL_RUN"
+    ASSIGN_AGENT = "ASSIGN_AGENT"
+    REASSIGN_AGENT = "REASSIGN_AGENT"
+
+
+class CommandState(StrEnum):
+    RECEIVED = "RECEIVED"
+    VALIDATING = "VALIDATING"
+    REFUSED = "REFUSED"
+    DUPLICATE_REPLAYED = "DUPLICATE_REPLAYED"
+    DUPLICATE_CONFLICT = "DUPLICATE_CONFLICT"
+
+
+class CommandTargetType(StrEnum):
+    RUN = "run"
+    AGENT = "agent"
+    TASK = "task"
+    MISSION = "mission"
+
+
+@dataclass(frozen=True)
+class CommandSubmission:
+    command_type: CommandType
+    target_type: CommandTargetType
+    target_id: str
+    idempotency_key: str
+    reason: str | None
+    payload: dict[str, Any]
+    metadata: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    command: MissionControlCommand
+    event_ids: list[str]
+    receipt_id: str | None
+    duplicate: bool = False
+
+
+class DuplicateCommandConflictError(Exception):
+    """Raised when an idempotency key is reused with a different request hash."""
+
+    def __init__(self, command_id: str):
+        self.command_id = command_id
+        super().__init__("Idempotency key was already used for a different command request")
+
+
+def canonical_request_hash(submission: CommandSubmission) -> str:
+    """Hash only client-intended command content, never server identity context."""
+    body = {
+        "command_type": submission.command_type.value,
+        "target_type": submission.target_type.value,
+        "target_id": submission.target_id,
+        "reason": submission.reason,
+        "payload": submission.payload,
+        "metadata": submission.metadata,
+    }
+    return _sha256_json(body)
+
+
+def compute_event_hash(
+    *,
+    command_id: str,
+    sequence: int,
+    event_type: str,
+    state: str,
+    payload: dict[str, Any],
+    previous_hash: str | None,
+) -> str:
+    return _sha256_json(
+        {
+            "command_id": command_id,
+            "sequence": sequence,
+            "event_type": event_type,
+            "state": state,
+            "payload": payload,
+            "previous_hash": previous_hash,
+        }
+    )
+
+
+def compute_receipt_hash(
+    *,
+    command_id: str,
+    request_hash: str,
+    reason_code: str,
+    audit_log_id: str,
+    terminal_event_hash: str,
+) -> str:
+    return _sha256_json(
+        {
+            "command_id": command_id,
+            "request_hash": request_hash,
+            "reason_code": reason_code,
+            "audit_log_id": audit_log_id,
+            "terminal_event_hash": terminal_event_hash,
+        }
+    )
+
+
+async def submit_refusal_only_command(
+    db: AsyncSession,
+    submission: CommandSubmission,
+    current_user: CurrentUser,
+) -> CommandResult:
+    request_hash = canonical_request_hash(submission)
+    existing = await _find_existing(db, current_user, submission.idempotency_key)
+    if existing:
+        if existing.request_hash != request_hash:
+            raise DuplicateCommandConflictError(str(existing.id))
+        return await _duplicate_result(db, existing)
+
+    command_id = str(uuid.uuid4())
+    now = datetime.now(UTC)
+    reason_code = refuse_increment_one_execution().value
+    command = MissionControlCommand(
+        id=command_id,
+        tenant_id=str(current_user.tenant_id),
+        requested_by=str(current_user.user_id),
+        command_type=submission.command_type.value,
+        target_type=submission.target_type.value,
+        target_id=submission.target_id,
+        idempotency_key=submission.idempotency_key,
+        request_hash=request_hash,
+        state=CommandState.REFUSED.value,
+        reason_code=reason_code,
+        reason=submission.reason,
+        payload=submission.payload,
+        metadata_json=submission.metadata,
+        completed_at=now,
+    )
+    db.add(command)
+    await db.flush()
+
+    events = _build_events(command, reason_code)
+    db.add_all(events)
+    await db.flush()
+
+    audit_entry = await audit(
+        db,
+        action="mission_control_command_refused",
+        user_id=current_user.user_id,
+        tenant_id=current_user.tenant_id,
+        resource_type="mission_control_command",
+        resource_id=command_id,
+        resource_name=submission.command_type.value,
+        status="refused",
+        details={
+            "command_type": submission.command_type.value,
+            "target_type": submission.target_type.value,
+            "target_id": submission.target_id,
+            "idempotency_key": submission.idempotency_key,
+            "request_hash": request_hash,
+            "reason_code": reason_code,
+            "mutation_enabled": False,
+        },
+    )
+    await db.flush()
+    command.audit_log_id = str(audit_entry.id)
+
+    receipt = MissionControlCommandReceipt(
+        id=str(uuid.uuid4()),
+        command_id=command_id,
+        receipt_type="REFUSAL",
+        receipt_hash=compute_receipt_hash(
+            command_id=command_id,
+            request_hash=request_hash,
+            reason_code=reason_code,
+            audit_log_id=str(audit_entry.id),
+            terminal_event_hash=events[-1].event_hash,
+        ),
+        audit_log_id=str(audit_entry.id),
+        evidence_refs=[],
+    )
+    db.add(receipt)
+    await db.flush()
+
+    await _publish_status(current_user, command, receipt.id)
+    return CommandResult(
+        command=command,
+        event_ids=[str(event.id) for event in events],
+        receipt_id=str(receipt.id),
+    )
+
+
+async def _find_existing(
+    db: AsyncSession,
+    current_user: CurrentUser,
+    idempotency_key: str,
+) -> MissionControlCommand | None:
+    result = await db.execute(
+        select(MissionControlCommand).where(
+            MissionControlCommand.tenant_id == str(current_user.tenant_id),
+            MissionControlCommand.requested_by == str(current_user.user_id),
+            MissionControlCommand.idempotency_key == idempotency_key,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _duplicate_result(
+    db: AsyncSession,
+    command: MissionControlCommand,
+) -> CommandResult:
+    event_result = await db.execute(
+        select(MissionControlCommandEvent)
+        .where(MissionControlCommandEvent.command_id == str(command.id))
+        .order_by(MissionControlCommandEvent.sequence)
+    )
+    receipt_result = await db.execute(
+        select(MissionControlCommandReceipt).where(
+            MissionControlCommandReceipt.command_id == str(command.id),
+            MissionControlCommandReceipt.receipt_type == "REFUSAL",
+        )
+    )
+    events = list(event_result.scalars().all())
+    receipt = receipt_result.scalar_one_or_none()
+    return CommandResult(
+        command=command,
+        event_ids=[str(event.id) for event in events],
+        receipt_id=str(receipt.id) if receipt else None,
+        duplicate=True,
+    )
+
+
+def _build_events(
+    command: MissionControlCommand,
+    reason_code: str,
+) -> list[MissionControlCommandEvent]:
+    specs = [
+        ("COMMAND_RECEIVED", CommandState.RECEIVED.value, {}),
+        ("COMMAND_VALIDATING", CommandState.VALIDATING.value, {}),
+        (
+            "COMMAND_REFUSED",
+            CommandState.REFUSED.value,
+            {"reason_code": reason_code, "mutation_enabled": False},
+        ),
+    ]
+    previous_hash = None
+    events = []
+    for sequence, (event_type, state, payload) in enumerate(specs, start=1):
+        event_hash = compute_event_hash(
+            command_id=str(command.id),
+            sequence=sequence,
+            event_type=event_type,
+            state=state,
+            payload=payload,
+            previous_hash=previous_hash,
+        )
+        events.append(
+            MissionControlCommandEvent(
+                id=str(uuid.uuid4()),
+                command_id=str(command.id),
+                sequence=sequence,
+                event_type=event_type,
+                state=state,
+                payload=payload,
+                previous_hash=previous_hash,
+                event_hash=event_hash,
+            )
+        )
+        previous_hash = event_hash
+    return events
+
+
+async def _publish_status(
+    current_user: CurrentUser,
+    command: MissionControlCommand,
+    receipt_id: str,
+) -> None:
+    event = {
+        "type": "mission_control.command_status",
+        "command_id": str(command.id),
+        "state": command.state,
+        "reason_code": command.reason_code,
+        "target_type": command.target_type,
+        "target_id": command.target_id,
+        "receipt_id": receipt_id,
+    }
+    try:
+        await ws_manager.send_to_user(str(current_user.user_id), event)
+    except Exception as exc:
+        log.warning(
+            "mission_control.command_realtime_delivery_failed",
+            command_id=str(command.id),
+            user_id=str(current_user.user_id),
+            error=str(exc),
+        )
+
+
+def _sha256_json(data: dict[str, Any]) -> str:
+    serialized = json.dumps(data, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()

--- a/portal/services/mission_control_command_service.py
+++ b/portal/services/mission_control_command_service.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import structlog
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth.rbac import CurrentUser
@@ -49,6 +50,10 @@ class CommandTargetType(StrEnum):
     AGENT = "agent"
     TASK = "task"
     MISSION = "mission"
+
+
+IDEMPOTENCY_KEY_MIN_LENGTH = 16
+IDEMPOTENCY_KEY_MAX_LENGTH = 128
 
 
 @dataclass(frozen=True)
@@ -163,7 +168,22 @@ async def submit_refusal_only_command(
         completed_at=now,
     )
     db.add(command)
-    await db.flush()
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        if not _is_idempotency_collision(exc):
+            raise
+        await db.rollback()
+        existing_after_collision = await _find_existing(
+            db,
+            current_user,
+            submission.idempotency_key,
+        )
+        if existing_after_collision is None:
+            raise
+        if existing_after_collision.request_hash != request_hash:
+            raise DuplicateCommandConflictError(str(existing_after_collision.id)) from exc
+        return await _duplicate_result(db, existing_after_collision)
 
     events = _build_events(command, reason_code)
     db.add_all(events)
@@ -213,6 +233,16 @@ async def submit_refusal_only_command(
         command=command,
         event_ids=[str(event.id) for event in events],
         receipt_id=str(receipt.id),
+    )
+
+
+def _is_idempotency_collision(exc: IntegrityError) -> bool:
+    message = str(exc.orig).lower() if exc.orig else str(exc).lower()
+    return (
+        "uq_mission_control_command_idempotency" in message
+        or ("mission_control_commands.tenant_id" in message
+        and "mission_control_commands.requested_by" in message
+        and "mission_control_commands.idempotency_key" in message)
     )
 
 

--- a/portal/tests/test_mission_control_commands.py
+++ b/portal/tests/test_mission_control_commands.py
@@ -21,7 +21,12 @@ from portal.models.mission_control_command import (
 from portal.models.user import Permission as PermissionModel
 from portal.models.user import Role, RolePermission, Tenant, User, UserPermissionAssoc
 from portal.routers import mission_control, mission_control_commands
-from portal.services.mission_control_command_service import compute_event_hash
+from portal.services import mission_control_command_service
+from portal.services.mission_control_command_service import (
+    IDEMPOTENCY_KEY_MAX_LENGTH,
+    IDEMPOTENCY_KEY_MIN_LENGTH,
+    compute_event_hash,
+)
 
 TENANT_ID = "00000000-0000-0000-0000-000000000002"
 USER_ID = "00000000-0000-0000-0000-000000000001"
@@ -56,7 +61,7 @@ def _user(*permissions: Permission, tenant_id: str = TENANT_ID) -> CurrentUser:
     )
 
 
-def _body(command_type: str = "PAUSE_RUN", key: str = "idem-1") -> dict:
+def _body(command_type: str = "PAUSE_RUN", key: str = "idem-12345678901") -> dict:
     return {
         "command_type": command_type,
         "target_type": "run",
@@ -164,6 +169,89 @@ def test_unsupported_command_type_is_rejected(client: TestClient) -> None:
     assert response.status_code == 422
 
 
+@pytest.mark.parametrize(
+    ("command_type", "target_type"),
+    [
+        ("START_GOVERNED_RUN", "run"),
+        ("START_GOVERNED_RUN", "mission"),
+        ("PAUSE_RUN", "run"),
+        ("RESUME_RUN", "run"),
+        ("CANCEL_RUN", "run"),
+        ("ASSIGN_AGENT", "run"),
+        ("ASSIGN_AGENT", "task"),
+        ("ASSIGN_AGENT", "mission"),
+        ("REASSIGN_AGENT", "run"),
+        ("REASSIGN_AGENT", "task"),
+        ("REASSIGN_AGENT", "mission"),
+    ],
+)
+def test_valid_command_target_combinations_are_accepted(
+    client: TestClient,
+    command_type: str,
+    target_type: str,
+) -> None:
+    body = _body(command_type, key=f"compat-{command_type}-{target_type}-1234567890")
+    body["target_type"] = target_type
+    response = client.post("/api/v1/mission-control/commands", json=body)
+    assert response.status_code == 201
+    assert response.json()["state"] == "REFUSED"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command_type", "target_type"),
+    [
+        ("START_GOVERNED_RUN", "task"),
+        ("START_GOVERNED_RUN", "agent"),
+        ("PAUSE_RUN", "agent"),
+        ("PAUSE_RUN", "mission"),
+        ("RESUME_RUN", "task"),
+        ("CANCEL_RUN", "mission"),
+        ("ASSIGN_AGENT", "agent"),
+        ("REASSIGN_AGENT", "agent"),
+    ],
+)
+async def test_invalid_command_target_combinations_return_422_without_persistence(
+    client: TestClient,
+    db: AsyncSession,
+    command_type: str,
+    target_type: str,
+) -> None:
+    body = _body(command_type, key=f"invalid-{command_type}-{target_type}-1234567890")
+    body["target_type"] = target_type
+    response = client.post("/api/v1/mission-control/commands", json=body)
+    assert response.status_code == 422
+    assert response.json()["detail"]["reason_code"] == "INVALID_COMMAND_TARGET"
+    assert await _count(db, MissionControlCommand) == 0
+    assert await _count(db, MissionControlCommandEvent) == 0
+    assert await _count(db, AuditLog) == 0
+    assert await _count(db, MissionControlCommandReceipt) == 0
+
+
+def test_idempotency_key_below_minimum_returns_422(client: TestClient) -> None:
+    body = _body(key="x" * (IDEMPOTENCY_KEY_MIN_LENGTH - 1))
+    response = client.post("/api/v1/mission-control/commands", json=body)
+    assert response.status_code == 422
+
+
+def test_idempotency_key_exact_minimum_is_accepted(client: TestClient) -> None:
+    body = _body(key="x" * IDEMPOTENCY_KEY_MIN_LENGTH)
+    response = client.post("/api/v1/mission-control/commands", json=body)
+    assert response.status_code == 201
+
+
+def test_idempotency_key_exact_maximum_is_accepted(client: TestClient) -> None:
+    body = _body(key="x" * IDEMPOTENCY_KEY_MAX_LENGTH)
+    response = client.post("/api/v1/mission-control/commands", json=body)
+    assert response.status_code == 201
+
+
+def test_idempotency_key_above_maximum_returns_422(client: TestClient) -> None:
+    body = _body(key="x" * (IDEMPOTENCY_KEY_MAX_LENGTH + 1))
+    response = client.post("/api/v1/mission-control/commands", json=body)
+    assert response.status_code == 422
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("command_type", SUPPORTED_COMMANDS)
 async def test_supported_commands_persist_and_refuse(
@@ -173,7 +261,7 @@ async def test_supported_commands_persist_and_refuse(
 ) -> None:
     response = client.post(
         "/api/v1/mission-control/commands",
-        json=_body(command_type, key=f"key-{command_type}"),
+        json=_body(command_type, key=f"key-{command_type}-1234567890"),
     )
 
     assert response.status_code == 201
@@ -211,14 +299,90 @@ async def test_no_operational_mutation_routes_are_added(client: TestClient, db: 
 
 @pytest.mark.asyncio
 async def test_same_idempotency_key_and_request_replays(client: TestClient, db: AsyncSession) -> None:
-    first = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", "same-key"))
-    second = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", "same-key"))
+    first = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", "same-key-1234567890"))
+    second = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", "same-key-1234567890"))
 
     assert first.status_code == 201
-    assert second.status_code == 201
+    assert second.status_code == 200
     assert second.json()["duplicate"] is True
     assert second.json()["command_id"] == first.json()["command_id"]
     assert await _count(db, MissionControlCommand) == 1
+    assert await _count(db, MissionControlCommandReceipt) == 1
+    assert await _count(db, AuditLog) == 1
+    assert await _count(db, MissionControlCommandEvent) == 3
+
+
+@pytest.mark.asyncio
+async def test_idempotency_collision_reloads_winning_command(
+    client: TestClient,
+    db: AsyncSession,
+    monkeypatch,
+) -> None:
+    key = "race-key-1234567890"
+    first = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", key))
+    assert first.status_code == 201
+
+    original_find = mission_control_command_service._find_existing
+    calls = 0
+
+    async def _stale_initial_lookup(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return None
+        return await original_find(*args, **kwargs)
+
+    monkeypatch.setattr(
+        mission_control_command_service,
+        "_find_existing",
+        _stale_initial_lookup,
+    )
+    replay = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", key))
+
+    assert replay.status_code == 200
+    assert replay.json()["duplicate"] is True
+    assert replay.json()["command_id"] == first.json()["command_id"]
+    assert await _count(db, MissionControlCommand) == 1
+    assert await _count(db, MissionControlCommandEvent) == 3
+    assert await _count(db, AuditLog) == 1
+    assert await _count(db, MissionControlCommandReceipt) == 1
+
+
+@pytest.mark.asyncio
+async def test_idempotency_collision_with_changed_request_returns_conflict(
+    client: TestClient,
+    db: AsyncSession,
+    monkeypatch,
+) -> None:
+    key = "race-conflict-1234567890"
+    first = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", key))
+    assert first.status_code == 201
+
+    original_find = mission_control_command_service._find_existing
+    calls = 0
+
+    async def _stale_initial_lookup(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return None
+        return await original_find(*args, **kwargs)
+
+    monkeypatch.setattr(
+        mission_control_command_service,
+        "_find_existing",
+        _stale_initial_lookup,
+    )
+    changed = _body("PAUSE_RUN", key)
+    changed["target_id"] = "run-456"
+    replay = client.post("/api/v1/mission-control/commands", json=changed)
+
+    assert replay.status_code == 409
+    assert replay.json()["detail"]["state"] == "DUPLICATE_CONFLICT"
+    assert replay.json()["detail"]["reason_code"] == "IDEMPOTENCY_KEY_CONFLICT"
+    assert await _count(db, MissionControlCommand) == 1
+    assert await _count(db, MissionControlCommandEvent) == 3
+    assert await _count(db, AuditLog) == 1
     assert await _count(db, MissionControlCommandReceipt) == 1
 
 
@@ -227,8 +391,8 @@ async def test_same_idempotency_key_and_changed_request_conflicts(
     client: TestClient,
     db: AsyncSession,
 ) -> None:
-    first = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", "conflict-key"))
-    changed = _body("PAUSE_RUN", "conflict-key")
+    first = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", "conflict-key-1234567890"))
+    changed = _body("PAUSE_RUN", "conflict-key-1234567890")
     changed["target_id"] = "run-456"
     second = client.post("/api/v1/mission-control/commands", json=changed)
 

--- a/portal/tests/test_mission_control_commands.py
+++ b/portal/tests/test_mission_control_commands.py
@@ -1,0 +1,345 @@
+"""Mission Control governed command substrate tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from portal.auth.rbac import CurrentUser, Permission, get_current_user
+from portal.database import Base, get_db
+from portal.models.audit import AuditLog
+from portal.models.mission_control_command import (
+    MissionControlCommand,
+    MissionControlCommandEvent,
+    MissionControlCommandReceipt,
+)
+from portal.models.user import Permission as PermissionModel
+from portal.models.user import Role, RolePermission, Tenant, User, UserPermissionAssoc
+from portal.routers import mission_control, mission_control_commands
+from portal.services.mission_control_command_service import compute_event_hash
+
+TENANT_ID = "00000000-0000-0000-0000-000000000002"
+USER_ID = "00000000-0000-0000-0000-000000000001"
+
+SUPPORTED_COMMANDS = [
+    "START_GOVERNED_RUN",
+    "PAUSE_RUN",
+    "RESUME_RUN",
+    "CANCEL_RUN",
+    "ASSIGN_AGENT",
+    "REASSIGN_AGENT",
+]
+
+COMMAND_PERMISSIONS = {
+    "START_GOVERNED_RUN": Permission.MISSION_RUN_START,
+    "PAUSE_RUN": Permission.MISSION_RUN_PAUSE,
+    "RESUME_RUN": Permission.MISSION_RUN_RESUME,
+    "CANCEL_RUN": Permission.MISSION_RUN_CANCEL,
+    "ASSIGN_AGENT": Permission.MISSION_AGENT_ASSIGN,
+    "REASSIGN_AGENT": Permission.MISSION_AGENT_REASSIGN,
+}
+
+
+def _user(*permissions: Permission, tenant_id: str = TENANT_ID) -> CurrentUser:
+    return CurrentUser(
+        {
+            "sub": USER_ID,
+            "tenant_id": tenant_id,
+            "role": "FIRM_ADMIN",
+            "permissions": list(permissions),
+        }
+    )
+
+
+def _body(command_type: str = "PAUSE_RUN", key: str = "idem-1") -> dict:
+    return {
+        "command_type": command_type,
+        "target_type": "run",
+        "target_id": "run-123",
+        "idempotency_key": key,
+        "reason": "operator requested hold",
+        "payload": {"nested": {"b": 2, "a": 1}},
+        "metadata": {"source": "test"},
+        "tenant_id": "attacker-tenant",
+        "requested_by": "attacker-user",
+        "role": "SUPER_ADMIN",
+        "permissions": ["*"],
+    }
+
+
+@pytest_asyncio.fixture
+async def db() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=[
+                    Tenant.__table__,
+                    Role.__table__,
+                    PermissionModel.__table__,
+                    RolePermission.__table__,
+                    User.__table__,
+                    UserPermissionAssoc.__table__,
+                    AuditLog.__table__,
+                    MissionControlCommand.__table__,
+                    MissionControlCommandEvent.__table__,
+                    MissionControlCommandReceipt.__table__,
+                ],
+            )
+        )
+    session_maker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with session_maker() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.fixture
+def client(db: AsyncSession) -> TestClient:
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(mission_control.router)
+    app.include_router(mission_control_commands.router)
+
+    async def _override_db():
+        try:
+            yield db
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_current_user] = lambda: _user(
+        Permission.MISSION_COMMAND_CREATE,
+        Permission.MISSION_RUN_START,
+        Permission.MISSION_RUN_PAUSE,
+        Permission.MISSION_RUN_RESUME,
+        Permission.MISSION_RUN_CANCEL,
+        Permission.MISSION_AGENT_ASSIGN,
+        Permission.MISSION_AGENT_REASSIGN,
+        Permission.ADMIN_DASHBOARD,
+    )
+    return TestClient(app)
+
+
+async def _count(db: AsyncSession, model) -> int:
+    result = await db.execute(select(func.count(model.id)))
+    return result.scalar_one()
+
+
+def test_authentication_is_required(db: AsyncSession) -> None:
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(mission_control_commands.router)
+    response = TestClient(app).post("/api/v1/mission-control/commands", json=_body())
+    assert response.status_code == 401
+
+
+def test_generic_command_create_permission_is_required(client: TestClient) -> None:
+    client.app.dependency_overrides[get_current_user] = lambda: _user(Permission.MISSION_RUN_PAUSE)
+    response = client.post("/api/v1/mission-control/commands", json=_body())
+    assert response.status_code == 403
+
+
+def test_command_specific_permission_is_required(client: TestClient) -> None:
+    client.app.dependency_overrides[get_current_user] = lambda: _user(
+        Permission.MISSION_COMMAND_CREATE,
+        Permission.MISSION_RUN_START,
+    )
+    response = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN"))
+    assert response.status_code == 403
+
+
+def test_unsupported_command_type_is_rejected(client: TestClient) -> None:
+    body = _body("EXECUTE_RUN")
+    response = client.post("/api/v1/mission-control/commands", json=body)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command_type", SUPPORTED_COMMANDS)
+async def test_supported_commands_persist_and_refuse(
+    client: TestClient,
+    db: AsyncSession,
+    command_type: str,
+) -> None:
+    response = client.post(
+        "/api/v1/mission-control/commands",
+        json=_body(command_type, key=f"key-{command_type}"),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["state"] == "REFUSED"
+    assert body["reason_code"] == "COMMAND_EXECUTION_NOT_ENABLED"
+    assert body["duplicate"] is False
+    assert len(body["event_ids"]) == 3
+    assert body["receipt_id"]
+    assert body["audit_log_id"]
+
+    result = await db.execute(
+        select(MissionControlCommand).where(MissionControlCommand.id == body["command_id"])
+    )
+    command = result.scalar_one()
+    assert command.command_type == command_type
+    assert command.tenant_id == TENANT_ID
+    assert command.requested_by == USER_ID
+    assert command.state == "REFUSED"
+
+
+@pytest.mark.asyncio
+async def test_no_operational_mutation_routes_are_added(client: TestClient, db: AsyncSession) -> None:
+    paths = {route.path for route in client.app.routes}
+    assert "/runs/{id}/pause" not in paths
+    assert "/runs/{id}/resume" not in paths
+    assert "/runs/{id}/cancel" not in paths
+    assert "/agents/{id}/assign" not in paths
+    assert "/agents/{id}/reassign" not in paths
+
+    response = client.post("/api/v1/mission-control/commands", json=_body())
+    assert response.status_code == 201
+    assert await _count(db, MissionControlCommand) == 1
+
+
+@pytest.mark.asyncio
+async def test_same_idempotency_key_and_request_replays(client: TestClient, db: AsyncSession) -> None:
+    first = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", "same-key"))
+    second = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", "same-key"))
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert second.json()["duplicate"] is True
+    assert second.json()["command_id"] == first.json()["command_id"]
+    assert await _count(db, MissionControlCommand) == 1
+    assert await _count(db, MissionControlCommandReceipt) == 1
+
+
+@pytest.mark.asyncio
+async def test_same_idempotency_key_and_changed_request_conflicts(
+    client: TestClient,
+    db: AsyncSession,
+) -> None:
+    first = client.post("/api/v1/mission-control/commands", json=_body("PAUSE_RUN", "conflict-key"))
+    changed = _body("PAUSE_RUN", "conflict-key")
+    changed["target_id"] = "run-456"
+    second = client.post("/api/v1/mission-control/commands", json=changed)
+
+    assert first.status_code == 201
+    assert second.status_code == 409
+    assert second.json()["detail"]["state"] == "DUPLICATE_CONFLICT"
+    assert await _count(db, MissionControlCommand) == 1
+
+
+def test_missing_idempotency_key_returns_422(client: TestClient) -> None:
+    body = _body()
+    del body["idempotency_key"]
+    response = client.post("/api/v1/mission-control/commands", json=body)
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_tenant_and_actor_come_from_server_context(client: TestClient, db: AsyncSession) -> None:
+    response = client.post("/api/v1/mission-control/commands", json=_body())
+    assert response.status_code == 201
+    result = await db.execute(select(MissionControlCommand))
+    command = result.scalar_one()
+    assert command.tenant_id == TENANT_ID
+    assert command.requested_by == USER_ID
+
+
+@pytest.mark.asyncio
+async def test_command_event_hashes_are_deterministic(client: TestClient, db: AsyncSession) -> None:
+    response = client.post("/api/v1/mission-control/commands", json=_body())
+    assert response.status_code == 201
+
+    result = await db.execute(
+        select(MissionControlCommandEvent).order_by(MissionControlCommandEvent.sequence)
+    )
+    events = result.scalars().all()
+    previous_hash = None
+    for event in events:
+        assert event.previous_hash == previous_hash
+        assert event.event_hash == compute_event_hash(
+            command_id=event.command_id,
+            sequence=event.sequence,
+            event_type=event.event_type,
+            state=event.state,
+            payload=event.payload,
+            previous_hash=previous_hash,
+        )
+        previous_hash = event.event_hash
+
+
+@pytest.mark.asyncio
+async def test_audit_record_and_receipt_are_created(client: TestClient, db: AsyncSession) -> None:
+    response = client.post("/api/v1/mission-control/commands", json=_body())
+    assert response.status_code == 201
+    body = response.json()
+    assert await _count(db, AuditLog) == 1
+    assert await _count(db, MissionControlCommandReceipt) == 1
+
+    receipt_result = await db.execute(select(MissionControlCommandReceipt))
+    receipt = receipt_result.scalar_one()
+    assert receipt.id == body["receipt_id"]
+    assert receipt.receipt_type == "REFUSAL"
+    assert receipt.audit_log_id == body["audit_log_id"]
+
+
+@pytest.mark.asyncio
+async def test_audit_failure_rolls_back_command(client: TestClient, db: AsyncSession, monkeypatch) -> None:
+    async def _fail_audit(*args, **kwargs):
+        raise RuntimeError("audit unavailable")
+
+    monkeypatch.setattr(
+        "portal.services.mission_control_command_service.audit",
+        _fail_audit,
+    )
+    error_client = TestClient(client.app, raise_server_exceptions=False)
+    response = error_client.post("/api/v1/mission-control/commands", json=_body())
+
+    assert response.status_code == 500
+    assert await _count(db, MissionControlCommand) == 0
+    assert await _count(db, MissionControlCommandEvent) == 0
+    assert await _count(db, MissionControlCommandReceipt) == 0
+
+
+@pytest.mark.asyncio
+async def test_realtime_failure_does_not_change_refusal_outcome(
+    client: TestClient,
+    db: AsyncSession,
+    monkeypatch,
+) -> None:
+    async def _fail_send(*args, **kwargs):
+        raise RuntimeError("websocket unavailable")
+
+    monkeypatch.setattr(
+        "portal.services.mission_control_command_service.ws_manager.send_to_user",
+        _fail_send,
+    )
+    response = client.post("/api/v1/mission-control/commands", json=_body())
+    assert response.status_code == 201
+    assert response.json()["state"] == "REFUSED"
+    assert await _count(db, MissionControlCommand) == 1
+
+
+def test_existing_mission_control_summary_contract_remains_unchanged(client: TestClient, monkeypatch) -> None:
+    monkeypatch.setattr(mission_control, "_check_database", lambda: {"status": "healthy", "type": "sqlite"})
+    monkeypatch.setattr(mission_control, "_check_recovery_api", lambda: {"status": "healthy", "external_action": "locked"})
+    monkeypatch.setattr(mission_control, "_check_evidence_platform", lambda: {"status": "healthy", "cases": [{"evidence_items": 3}]})
+    monkeypatch.setattr(mission_control, "_check_scheduler", lambda: {"status": "healthy", "jobs": 4})
+    monkeypatch.setattr(mission_control, "_check_agents", lambda: {"status": "healthy", "running": 2})
+
+    response = client.get("/api/v1/mission-control/summary")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["active_runs"] == {"value": None, "status": "unavailable"}
+    assert body["pending_decisions"]["value"] is None
+    assert body["kill_switch"]["value"] == "locked"

--- a/portal/tests/test_service_units.py
+++ b/portal/tests/test_service_units.py
@@ -475,7 +475,7 @@ class TestAuditService:
         assert result["entries_checked"] == 0
 
     @pytest.mark.asyncio
-    async def test_audit_flush_failure_does_not_raise(self):
+    async def test_audit_flush_failure_rolls_back_and_raises(self):
         from portal.services.audit_service import audit
         mock_db = AsyncMock()
         mock_result = MagicMock()
@@ -484,8 +484,9 @@ class TestAuditService:
         mock_db.add = MagicMock()
         mock_db.flush = AsyncMock(side_effect=Exception("DB error"))
         mock_db.rollback = AsyncMock()
-        # Should not raise — audit failure is swallowed
-        await audit(db=mock_db, action="test.action")
+
+        with pytest.raises(Exception, match="DB error"):
+            await audit(db=mock_db, action="test.action")
         mock_db.rollback.assert_called_once()
 
 


### PR DESCRIPTION
## Scope

Implements Mission Control Phase Two Increment One only: command ledger, guard, idempotency, audit integration, command-event hash chain, refusal receipts, requester-scoped realtime best effort, and POST /api/v1/mission-control/commands.

All supported commands terminate as REFUSED with COMMAND_EXECUTION_NOT_ENABLED. No run, task, scheduler, agent, mission, assignment, runner, or UI mutation path is enabled.

## Review question

Does the new command plane persist, authorize, audit, deduplicate, receipt, and refuse commands correctly without creating any operational mutation path?

## Verification

Passed:
- python -m pytest portal\\tests\\test_mission_control_commands.py -q
- python -m pytest portal\\tests\\test_mission_control.py portal\\tests\\test_rbac.py -q
- python -m pytest portal\\tests\\test_service_units.py -q
- python -m pytest portal\\tests\\test_mission_control_commands.py portal\\tests\\test_mission_control.py portal\\tests\\test_rbac.py portal\\tests\\test_service_units.py -q
- python -m ruff check on touched Python files
- git diff --check
- SQLAlchemy command ledger metadata smoke check

Full python -m pytest --tb=short -q completed with 4 existing Windows shell-environment failures in tests/test_scheduler_executor.py around echo/sleep/false process spawning.

Evidence: docs/mission-control/phase-2-increment-1-evidence.md