### PR TITLE
Certification increment: authentication, tenant isolation, and RBAC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,25 @@ jobs:
         run: python scripts/ci/validate_repository_claims.py
       - name: Run validator tests
         run: python -m pytest scripts/ci/tests/ -q
+  auth-tenant-rbac-certification:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run auth/tenant/RBAC certification suite
+        run: set -o pipefail && python -m pytest portal/tests/test_auth_tenant_rbac_certification.py -q | tee /tmp/auth-tenant-rbac-certification.log
+      - name: Upload certification log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: auth-tenant-rbac-certification-log
+          path: /tmp/auth-tenant-rbac-certification.log
+          if-no-files-found: ignore
   security:
     runs-on: ubuntu-latest
     steps:

--- a/docs/certification/auth-tenant-rbac/increment-1/audit-evidence.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/audit-evidence.json
@@ -1,0 +1,30 @@
+{
+  "audit_correlation": {
+    "correlated_fields": [
+      "user_id",
+      "tenant_id",
+      "resource_type",
+      "resource_id",
+      "resource_name"
+    ],
+    "evidence": "audit() awaited after invoice commit in billing.create_invoice path",
+    "observed_event": "invoice_create",
+    "result": "PASS",
+    "tenant_scope": "current_user.tenant_id"
+  },
+  "result": "PASS",
+  "schema_version": "1.0",
+  "repository": "ihoward40/SintraPrime-Unified",
+  "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
+  "evidence_commit": "pending",
+  "generation_method": "Observed one real protected flow (invoice_create in billing.create_invoice) and recorded the audit fields written by the audit() call.",
+  "source_files": [
+    "portal/routers/billing.py"
+  ],
+  "source_tests": [
+    "portal/tests/test_auth_tenant_rbac_certification.py"
+  ],
+  "limitations": [
+    "request_id is not consistently populated by current router audit call sites; complete request traceability is not claimed."
+  ]
+}

--- a/docs/certification/auth-tenant-rbac/increment-1/audit-evidence.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/audit-evidence.json
@@ -16,7 +16,7 @@
   "schema_version": "1.0",
   "repository": "ihoward40/SintraPrime-Unified",
   "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
-  "evidence_commit": "pending",
+  "evidence_commit": "pending-post-remediation",
   "generation_method": "Observed one real protected flow (invoice_create in billing.create_invoice) and recorded the audit fields written by the audit() call.",
   "source_files": [
     "portal/routers/billing.py"
@@ -26,5 +26,6 @@
   ],
   "limitations": [
     "request_id is not consistently populated by current router audit call sites; complete request traceability is not claimed."
-  ]
+  ],
+  "generated_from_commit": "7f50bdc02b3750210a5424c70491a34d4079b9a1"
 }

--- a/docs/certification/auth-tenant-rbac/increment-1/authentication-authority.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/authentication-authority.json
@@ -74,9 +74,9 @@
   "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
   "result": "PASS",
   "schema_version": "1.0",
-  "security_subject_commit": "635435780d194945ed3fcb4815f2034470aa4331",
+  "security_subject_commit": "7f50bdc02b3750210a5424c70491a34d4079b9a1",
   "repository": "ihoward40/SintraPrime-Unified",
-  "evidence_commit": "pending",
+  "evidence_commit": "pending-post-remediation",
   "generation_method": "Executed pytest authentication fail-closed cases from portal/tests/test_auth_tenant_rbac_certification.py; recorded observed HTTP 401 outcomes.",
   "source_files": [
     "portal/auth/rbac.py"
@@ -86,5 +86,6 @@
   ],
   "limitations": [
     "The certification test fixture uses a short HS256 key, which raises a PyJWT InsecureKeyLengthWarning but does not fail the gate."
-  ]
+  ],
+  "generated_from_commit": "7f50bdc02b3750210a5424c70491a34d4079b9a1"
 }

--- a/docs/certification/auth-tenant-rbac/increment-1/authentication-authority.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/authentication-authority.json
@@ -1,0 +1,90 @@
+{
+  "authentication_cases": [
+    {
+      "case": "missing subject",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "empty subject",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "missing tenant",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "empty tenant",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "missing role",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "invalid role",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "malformed permission container",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "unsupported permission",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "malformed JWT",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "invalid signature",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "expired access token",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "refresh token rejected as access token",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "missing authorization header",
+      "expected": "401",
+      "result": "passed"
+    },
+    {
+      "case": "malformed authorization header",
+      "expected": "401",
+      "result": "passed"
+    }
+  ],
+  "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
+  "result": "PASS",
+  "schema_version": "1.0",
+  "security_subject_commit": "635435780d194945ed3fcb4815f2034470aa4331",
+  "repository": "ihoward40/SintraPrime-Unified",
+  "evidence_commit": "pending",
+  "generation_method": "Executed pytest authentication fail-closed cases from portal/tests/test_auth_tenant_rbac_certification.py; recorded observed HTTP 401 outcomes.",
+  "source_files": [
+    "portal/auth/rbac.py"
+  ],
+  "source_tests": [
+    "portal/tests/test_auth_tenant_rbac_certification.py"
+  ],
+  "limitations": [
+    "The certification test fixture uses a short HS256 key, which raises a PyJWT InsecureKeyLengthWarning but does not fail the gate."
+  ]
+}

--- a/docs/certification/auth-tenant-rbac/increment-1/certification-report.md
+++ b/docs/certification/auth-tenant-rbac/increment-1/certification-report.md
@@ -10,10 +10,11 @@ Conclusion: CERTIFIED FOR THE RECORDED SCOPE
 
 ## Summary
 - Authentication claim validation fails closed on missing/empty subject, tenant, role, malformed permissions, unsupported permissions, malformed JWTs, invalid signatures, expired access tokens, refresh tokens used as access tokens, and malformed authorization headers.
-- Billing payment lookup is tenant-scoped before mutation.
-- RBAC escalation paths deny ordinary users, insufficient permissions, self-role assignment, unauthorized role changes, and cross-tenant user-role mutation.
-- The live `/api/v1/` route graph was enumerated dynamically; public exceptions are explicit and protected routes are guarded.
-- WebSocket routes were discovered dynamically from source and classified separately from HTTP routes.
+- Billing payment lookup is tenant-scoped before mutation; the tenant-scoped 404 returns a stable `Invoice not found` detail without leaking tenant existence.
+- RBAC escalation paths deny ordinary users, insufficient permissions, self-role assignment (400), unauthorized role changes, and cross-tenant user-role mutation (404).
+- The live `/api/v1/` route graph was enumerated dynamically; public exceptions are explicit and protected routes are guarded. Dependency-callable identifiers are stable across runs (no memory addresses).
+- WebSocket routes were discovered dynamically from source and classified separately from HTTP routes. Non-HTTP discovery is deterministic regardless of the process working directory.
+- Blackstone protected routes now carry an explicit `get_current_user` authentication guard.
 
 ## Recorded route totals
 - HTTP routes under `/api/v1/`: 93
@@ -35,11 +36,16 @@ Conclusion: CERTIFIED FOR THE RECORDED SCOPE
 1. Malformed identity claims could escape the supported authentication-failure path.
 2. Invoice payment lookup lacked tenant scope.
 3. A Payment row could be added before invoice tenant validation.
-4. Self-role assignment required explicit denial.
+4. Self-role assignment required explicit denial (returns 400).
 5. Blackstone protected routes lacked an explicit authentication guard.
 
-## Evidence schema
+## Evidence schema and provenance
 Every JSON artifact in this directory is an object with the required fields: `schema_version`, `repository`, `baseline_commit`, `evidence_commit`, `generation_method`, `source_files`, `source_tests`, `result`, `limitations`. `route-permission-matrix.json` carries the 93 route records under its `routes` key.
+
+Provenance semantics:
+- `generated_from_commit`: the immutable security subject commit `7f50bdc02b3750210a5424c70491a34d4079b9a1` that the evidence was generated against. This is the reproducible anchor.
+- `security_subject_commit` (where present): the same immutable security subject commit.
+- `evidence_commit`: the evidence-only commit that carries these artifacts. Because embedding a commit SHA inside that same commit is self-referential, `evidence_commit` is recorded as `pending-post-remediation` until a post-commit amendment records the final evidence head SHA if required; the authoritative provenance anchor is `generated_from_commit`.
 
 ## Known limitations
 - Public exception routes remain public by design.

--- a/docs/certification/auth-tenant-rbac/increment-1/certification-report.md
+++ b/docs/certification/auth-tenant-rbac/increment-1/certification-report.md
@@ -1,0 +1,47 @@
+# Authentication, Tenant Isolation, and RBAC Certification — Increment 1
+
+Repository: `ihoward40/SintraPrime-Unified`
+Branch: `cert/auth-tenant-rbac-increment-1`
+Baseline: `0e31c20938a2abf32ee50c1f54622611642aa16b`
+Security subject commit: `7f50bdc02b3750210a5424c70491a34d4079b9a1`
+Evidence: this directory
+
+Conclusion: CERTIFIED FOR THE RECORDED SCOPE
+
+## Summary
+- Authentication claim validation fails closed on missing/empty subject, tenant, role, malformed permissions, unsupported permissions, malformed JWTs, invalid signatures, expired access tokens, refresh tokens used as access tokens, and malformed authorization headers.
+- Billing payment lookup is tenant-scoped before mutation.
+- RBAC escalation paths deny ordinary users, insufficient permissions, self-role assignment, unauthorized role changes, and cross-tenant user-role mutation.
+- The live `/api/v1/` route graph was enumerated dynamically; public exceptions are explicit and protected routes are guarded.
+- WebSocket routes were discovered dynamically from source and classified separately from HTTP routes.
+
+## Recorded route totals
+- HTTP routes under `/api/v1/`: 93
+- Explicit public exceptions: 11
+- Protected routes with recognized guard: 82
+- WebSocket routes discovered dynamically: 6
+
+## Validation commands
+- `python -m ruff check portal/auth/rbac.py portal/routers/billing.py portal/routers/users.py portal/routers/blackstone.py portal/tests/test_auth_tenant_rbac_certification.py`
+- `python -m pytest portal/tests/test_auth_tenant_rbac_certification.py -q`
+- `python -m pytest portal/tests/test_auth_units.py portal/tests/test_rbac.py portal/tests/test_service_units.py portal/tests/test_auth_tenant_rbac_certification.py -q`
+- `python -m pytest --tb=short -q`
+- `python scripts/ci/validate_repository_claims.py`
+- `python scripts/ci/report_test_inventory.py`
+- `ruff check . --output-format=github`
+- `git diff --check`
+
+## Discovered defects corrected
+1. Malformed identity claims could escape the supported authentication-failure path.
+2. Invoice payment lookup lacked tenant scope.
+3. A Payment row could be added before invoice tenant validation.
+4. Self-role assignment required explicit denial.
+5. Blackstone protected routes lacked an explicit authentication guard.
+
+## Evidence schema
+Every JSON artifact in this directory is an object with the required fields: `schema_version`, `repository`, `baseline_commit`, `evidence_commit`, `generation_method`, `source_files`, `source_tests`, `result`, `limitations`. `route-permission-matrix.json` carries the 93 route records under its `routes` key.
+
+## Known limitations
+- Public exception routes remain public by design.
+- The certification test fixture uses a short HS256 key, which raises a PyJWT `InsecureKeyLengthWarning` but does not fail the gate.
+- `request_id` is not consistently populated by current router audit call sites; full request traceability is not claimed.

--- a/docs/certification/auth-tenant-rbac/increment-1/decision-log.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/decision-log.json
@@ -23,12 +23,20 @@
       "regression_test": "portal/tests/test_auth_tenant_rbac_certification.py::test_rbac_escalation_controls",
       "result": "passed",
       "risk": "Privilege escalation by granting a higher role to the actor’s own account."
+    },
+    {
+      "affected_path": "portal/routers/blackstone.py",
+      "defect": "Protected Blackstone routes (/cases POST, /cases/{case_id} GET, /evaluate POST) lacked an explicit authentication guard.",
+      "risk": "Unauthenticated access to case intake, case status, and claim evaluation endpoints.",
+      "correction": "Added CurrentUser Depends(get_current_user) to each protected Blackstone route.",
+      "regression_test": "portal/tests/test_auth_tenant_rbac_certification.py::test_dynamic_live_app_route_discovery (route-guard assertions cover Blackstone protected routes)",
+      "result": "passed"
     }
   ],
   "schema_version": "1.0",
   "repository": "ihoward40/SintraPrime-Unified",
   "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
-  "evidence_commit": "pending",
+  "evidence_commit": "pending-post-remediation",
   "generation_method": "Mapped each corrected defect to its affected path, security risk, exact correction, regression test, and validation result.",
   "source_files": [
     "portal/auth/rbac.py",
@@ -40,5 +48,6 @@
     "portal/tests/test_auth_tenant_rbac_certification.py"
   ],
   "result": "PASS",
-  "limitations": []
+  "limitations": [],
+  "generated_from_commit": "7f50bdc02b3750210a5424c70491a34d4079b9a1"
 }

--- a/docs/certification/auth-tenant-rbac/increment-1/decision-log.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/decision-log.json
@@ -1,0 +1,44 @@
+{
+  "decisions": [
+    {
+      "affected_path": "portal/auth/rbac.py",
+      "correction": "Validate required claims and fail closed with a structured TokenError / 401 path.",
+      "defect": "Malformed identity claims could escape the supported authentication-failure path.",
+      "regression_test": "portal/tests/test_auth_tenant_rbac_certification.py::test_authentication_fails_closed_on_missing_and_invalid_claims",
+      "result": "passed",
+      "risk": "Invalid identity payloads could reach protected code paths without a normalized auth failure."
+    },
+    {
+      "affected_path": "portal/routers/billing.py",
+      "correction": "Require tenant match before payment row creation and preserve 404 parity for foreign invoices.",
+      "defect": "Invoice payment lookup lacked tenant scope.",
+      "regression_test": "portal/tests/test_auth_tenant_rbac_certification.py::test_billing_tenant_isolation_and_fail_closed_payment_flow",
+      "result": "passed",
+      "risk": "Cross-tenant invoice payment could mutate the wrong tenant or reveal invoice existence."
+    },
+    {
+      "affected_path": "portal/routers/users.py",
+      "correction": "Reject self-targeted role change attempts and unauthorized role changes for other tenants.",
+      "defect": "Users could attempt self-role assignment.",
+      "regression_test": "portal/tests/test_auth_tenant_rbac_certification.py::test_rbac_escalation_controls",
+      "result": "passed",
+      "risk": "Privilege escalation by granting a higher role to the actor’s own account."
+    }
+  ],
+  "schema_version": "1.0",
+  "repository": "ihoward40/SintraPrime-Unified",
+  "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
+  "evidence_commit": "pending",
+  "generation_method": "Mapped each corrected defect to its affected path, security risk, exact correction, regression test, and validation result.",
+  "source_files": [
+    "portal/auth/rbac.py",
+    "portal/routers/billing.py",
+    "portal/routers/users.py",
+    "portal/routers/blackstone.py"
+  ],
+  "source_tests": [
+    "portal/tests/test_auth_tenant_rbac_certification.py"
+  ],
+  "result": "PASS",
+  "limitations": []
+}

--- a/docs/certification/auth-tenant-rbac/increment-1/known-limitations.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/known-limitations.json
@@ -1,0 +1,24 @@
+{
+  "limitations": [
+    {
+      "item": "Public exception routes remain public by design.",
+      "status": "intentional"
+    },
+    {
+      "item": "The certification test fixture uses a short HS256 key, which raises a PyJWT warning but does not fail the gate.",
+      "status": "accepted"
+    }
+  ],
+  "schema_version": "1.0",
+  "repository": "ihoward40/SintraPrime-Unified",
+  "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
+  "evidence_commit": "pending",
+  "generation_method": "Compiled from accepted limitations recorded during the certification increment.",
+  "source_files": [
+    "docs/certification/auth-tenant-rbac/increment-1/"
+  ],
+  "source_tests": [
+    "portal/tests/test_auth_tenant_rbac_certification.py"
+  ],
+  "result": "PASS"
+}

--- a/docs/certification/auth-tenant-rbac/increment-1/known-limitations.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/known-limitations.json
@@ -12,7 +12,7 @@
   "schema_version": "1.0",
   "repository": "ihoward40/SintraPrime-Unified",
   "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
-  "evidence_commit": "pending",
+  "evidence_commit": "pending-post-remediation",
   "generation_method": "Compiled from accepted limitations recorded during the certification increment.",
   "source_files": [
     "docs/certification/auth-tenant-rbac/increment-1/"
@@ -20,5 +20,6 @@
   "source_tests": [
     "portal/tests/test_auth_tenant_rbac_certification.py"
   ],
-  "result": "PASS"
+  "result": "PASS",
+  "generated_from_commit": "7f50bdc02b3750210a5424c70491a34d4079b9a1"
 }

--- a/docs/certification/auth-tenant-rbac/increment-1/negative-test-results.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/negative-test-results.json
@@ -1,0 +1,74 @@
+{
+  "command_results": [
+    {
+      "command": "python -m pytest portal/tests/test_auth_tenant_rbac_certification.py -q",
+      "notes": "18 tests passed",
+      "result": "passed"
+    },
+    {
+      "command": "python -m pytest portal/tests/test_auth_units.py portal/tests/test_rbac.py portal/tests/test_service_units.py portal/tests/test_auth_tenant_rbac_certification.py -q",
+      "result": "passed"
+    },
+    {
+      "command": "python -m pytest --tb=short -q",
+      "result": "passed"
+    }
+  ],
+  "negative_cases": [
+    {
+      "cases": [
+        "missing and empty subject",
+        "missing and empty tenant",
+        "missing and invalid role",
+        "malformed permission container",
+        "unsupported permission",
+        "malformed JWT",
+        "invalid signature",
+        "expired access token",
+        "refresh token rejected as access token",
+        "missing or malformed authorization header"
+      ],
+      "group": "authentication",
+      "result": "passed"
+    },
+    {
+      "cases": [
+        "same-tenant payment succeeds",
+        "cross-tenant invoice returns 404",
+        "no payment row before tenant validation",
+        "denied request leaves invoice unchanged"
+      ],
+      "group": "billing",
+      "result": "passed"
+    },
+    {
+      "cases": [
+        "ordinary user denied administrator route",
+        "insufficient permission denied",
+        "self-role assignment denied",
+        "unauthorized role change of another user denied",
+        "cross-tenant user-role mutation denied"
+      ],
+      "group": "rbac",
+      "result": "passed"
+    }
+  ],
+  "result": "PASS",
+  "schema_version": "1.0",
+  "repository": "ihoward40/SintraPrime-Unified",
+  "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
+  "evidence_commit": "pending",
+  "generation_method": "Executed the recorded validation commands and negative-case groups; captured command results and per-group outcomes.",
+  "source_files": [
+    "portal/auth/rbac.py",
+    "portal/routers/billing.py",
+    "portal/routers/users.py",
+    "portal/routers/blackstone.py"
+  ],
+  "source_tests": [
+    "portal/tests/test_auth_tenant_rbac_certification.py"
+  ],
+  "limitations": [
+    "The certification test fixture uses a short HS256 key, which raises a PyJWT InsecureKeyLengthWarning but does not fail the gate."
+  ]
+}

--- a/docs/certification/auth-tenant-rbac/increment-1/negative-test-results.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/negative-test-results.json
@@ -45,9 +45,9 @@
       "cases": [
         "ordinary user denied administrator route",
         "insufficient permission denied",
-        "self-role assignment denied",
+        "self-role assignment denied (400)",
         "unauthorized role change of another user denied",
-        "cross-tenant user-role mutation denied"
+        "cross-tenant user-role mutation denied (404)"
       ],
       "group": "rbac",
       "result": "passed"
@@ -57,7 +57,7 @@
   "schema_version": "1.0",
   "repository": "ihoward40/SintraPrime-Unified",
   "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
-  "evidence_commit": "pending",
+  "evidence_commit": "pending-post-remediation",
   "generation_method": "Executed the recorded validation commands and negative-case groups; captured command results and per-group outcomes.",
   "source_files": [
     "portal/auth/rbac.py",
@@ -70,5 +70,6 @@
   ],
   "limitations": [
     "The certification test fixture uses a short HS256 key, which raises a PyJWT InsecureKeyLengthWarning but does not fail the gate."
-  ]
+  ],
+  "generated_from_commit": "7f50bdc02b3750210a5424c70491a34d4079b9a1"
 }

--- a/docs/certification/auth-tenant-rbac/increment-1/non-http-entrypoints.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/non-http-entrypoints.json
@@ -1,0 +1,53 @@
+{
+  "background_tasks": [],
+  "cli_admin_scripts": [],
+  "scheduler_jobs": [],
+  "service_to_service_invocations": [],
+  "websocket_routes": [
+    {
+      "module": "portal.portal.admin.dashboard",
+      "name": "dashboard",
+      "path": "/admin/ws"
+    },
+    {
+      "module": "portal.docket.docket_api",
+      "name": "docket_api",
+      "path": "/api/v1/docket/live/{case_id}"
+    },
+    {
+      "module": "portal.performance.performance_api",
+      "name": "performance_api",
+      "path": "/performance/stream"
+    },
+    {
+      "module": "portal.workflow_builder.workflow_api",
+      "name": "workflow_api",
+      "path": "/workflows/tui"
+    },
+    {
+      "module": "portal.core.universe.hive_mind_api",
+      "name": "hive_mind_api",
+      "path": "/ws/hive-mind"
+    },
+    {
+      "module": "portal.core.universe.hive_mind_api",
+      "name": "hive_mind_api",
+      "path": "/ws/messages/{agent_id}"
+    }
+  ],
+  "schema_version": "1.0",
+  "repository": "ihoward40/SintraPrime-Unified",
+  "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
+  "evidence_commit": "pending",
+  "generation_method": "Dynamic source discovery of websocket routes, scheduler jobs, background tasks, CLI/admin scripts, and service-to-service invocations.",
+  "source_files": [
+    "portal/"
+  ],
+  "source_tests": [
+    "portal/tests/test_auth_tenant_rbac_certification.py"
+  ],
+  "result": "PASS",
+  "limitations": [
+    "WebSocket routes are classified as ISOLATED NON-PRODUCTION / OUT OF SUPPORTED SCOPE; they are outside the HTTP RBAC lane of this increment."
+  ]
+}

--- a/docs/certification/auth-tenant-rbac/increment-1/non-http-entrypoints.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/non-http-entrypoints.json
@@ -38,7 +38,7 @@
   "schema_version": "1.0",
   "repository": "ihoward40/SintraPrime-Unified",
   "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
-  "evidence_commit": "pending",
+  "evidence_commit": "pending-post-remediation",
   "generation_method": "Dynamic source discovery of websocket routes, scheduler jobs, background tasks, CLI/admin scripts, and service-to-service invocations.",
   "source_files": [
     "portal/"
@@ -49,5 +49,6 @@
   "result": "PASS",
   "limitations": [
     "WebSocket routes are classified as ISOLATED NON-PRODUCTION / OUT OF SUPPORTED SCOPE; they are outside the HTTP RBAC lane of this increment."
-  ]
+  ],
+  "generated_from_commit": "7f50bdc02b3750210a5424c70491a34d4079b9a1"
 }

--- a/docs/certification/auth-tenant-rbac/increment-1/rollback.md
+++ b/docs/certification/auth-tenant-rbac/increment-1/rollback.md
@@ -1,0 +1,12 @@
+# Rollback Plan
+
+If the certification must be reverted, undo the last two commits in reverse order:
+
+1. Remove the evidence commit:
+   - `git revert <evidence-commit>`
+2. Remove the security subject commit:
+   - `git revert <security-commit>`
+
+If the branch must be restored to the remote frozen state, push the reverted branch with `--force-with-lease` only after the revert commits are validated.
+
+Preserve the evidence artifacts when possible; they document the exact tested state that was rejected.

--- a/docs/certification/auth-tenant-rbac/increment-1/route-permission-matrix.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/route-permission-matrix.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0",
   "repository": "ihoward40/SintraPrime-Unified",
   "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
-  "evidence_commit": "pending",
+  "evidence_commit": "pending-post-remediation",
   "generation_method": "Dynamic enumeration of /api/v1 routes from the mounted FastAPI application and source-module discovery; each route classified by auth_dependency, authorization_dependency, tenant_control_mechanism.",
   "source_files": [
     "portal/routers/",
@@ -1819,5 +1819,6 @@
       "tenant_control_mechanism": "role-bound",
       "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
     }
-  ]
+  ],
+  "generated_from_commit": "7f50bdc02b3750210a5424c70491a34d4079b9a1"
 }

--- a/docs/certification/auth-tenant-rbac/increment-1/route-permission-matrix.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/route-permission-matrix.json
@@ -1,0 +1,1823 @@
+{
+  "schema_version": "1.0",
+  "repository": "ihoward40/SintraPrime-Unified",
+  "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
+  "evidence_commit": "pending",
+  "generation_method": "Dynamic enumeration of /api/v1 routes from the mounted FastAPI application and source-module discovery; each route classified by auth_dependency, authorization_dependency, tenant_control_mechanism.",
+  "source_files": [
+    "portal/routers/",
+    "portal/app.py",
+    "portal/auth/rbac.py"
+  ],
+  "source_tests": [
+    "portal/tests/test_auth_tenant_rbac_certification.py"
+  ],
+  "result": "PASS",
+  "limitations": [
+    "Public exception routes remain public by design; each public route carries an exception_justification.",
+    "WebSocket routes are classified separately in non-http-entrypoints.json."
+  ],
+  "routes": [
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "create_api_key",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/admin/api-keys",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.admin",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "get_audit_log",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/admin/audit-log",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.admin",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "update_branding",
+      "methods": [
+        "PUT"
+      ],
+      "path": "/api/v1/admin/branding",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.admin",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "get_firm_stats",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/admin/stats",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.admin",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "storage_usage",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/admin/storage-usage",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.admin",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_role",
+      "authorization_dependency": "require_role",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_role",
+      "handler": "system_health",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/admin/system-health",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.admin",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "none",
+      "authorization_dependency": "none",
+      "dependency_calls": [
+        "portal.database:get_db"
+      ],
+      "exception_justification": "Credential exchange must be public so anonymous users can obtain a session.",
+      "handler": "login",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/auth/login",
+      "public_protected_classification": "PUBLIC",
+      "source_module": "portal.routers.auth",
+      "tenant_control_mechanism": "public",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "logout",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/auth/logout",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.auth",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "logout_all_sessions",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/auth/logout-all",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.auth",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "get_me",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/auth/me",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.auth",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "disable_mfa",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/auth/mfa/disable",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.auth",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "setup_mfa",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/auth/mfa/setup",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.auth",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "verify_mfa_setup",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/auth/mfa/verify",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.auth",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "none",
+      "authorization_dependency": "none",
+      "dependency_calls": [
+        "portal.database:get_db"
+      ],
+      "exception_justification": "Password reset completion must be public because the one-time reset token is the authorization artifact.",
+      "handler": "confirm_password_reset",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/auth/password/reset-confirm",
+      "public_protected_classification": "PUBLIC",
+      "source_module": "portal.routers.auth",
+      "tenant_control_mechanism": "public",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "none",
+      "authorization_dependency": "none",
+      "dependency_calls": [
+        "portal.database:get_db"
+      ],
+      "exception_justification": "Password reset initiation must be public to prevent account enumeration and support lost-password recovery.",
+      "handler": "request_password_reset",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/auth/password/reset-request",
+      "public_protected_classification": "PUBLIC",
+      "source_module": "portal.routers.auth",
+      "tenant_control_mechanism": "public",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "none",
+      "authorization_dependency": "none",
+      "dependency_calls": [
+        "portal.database:get_db"
+      ],
+      "exception_justification": "Refresh-token rotation is cookie-based and intentionally callable before access-token auth.",
+      "handler": "refresh_token",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/auth/refresh",
+      "public_protected_classification": "PUBLIC",
+      "source_module": "portal.routers.auth",
+      "tenant_control_mechanism": "public",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "create_expense",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/billing/expenses",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_invoices",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/billing/invoices",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "create_invoice",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/billing/invoices",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "get_invoice",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/billing/invoices/{invoice_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "download_invoice_pdf",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/billing/invoices/{invoice_id}/pdf",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "send_invoice",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/billing/invoices/{invoice_id}/send",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "record_payment",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/billing/payments",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_time_entries",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/billing/time-entries",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "create_time_entry",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/billing/time-entries",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "start_timer",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/billing/time-entries/start-timer",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "stop_timer",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/billing/time-entries/{entry_id}/stop-timer",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "record_trust_transaction",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/billing/trust-transactions",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "get_trust_ledger",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/billing/trust-transactions/{client_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.billing",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "intake_case",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/blackstone/cases",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.blackstone",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "get_case_status",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/blackstone/cases/{case_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.blackstone",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "evaluate_claim",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/blackstone/evaluate",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.blackstone",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "none",
+      "authorization_dependency": "none",
+      "dependency_calls": [],
+      "exception_justification": "Read-only health probe for the governance evaluation surface.",
+      "handler": "blackstone_health",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/blackstone/health",
+      "public_protected_classification": "PUBLIC",
+      "source_module": "portal.routers.blackstone",
+      "tenant_control_mechanism": "public",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_cases",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/cases",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "create_case",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/cases",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "conflict_check",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/cases/conflict-check",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "delete_case",
+      "methods": [
+        "DELETE"
+      ],
+      "path": "/api/v1/cases/{case_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "get_case",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/cases/{case_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "update_case",
+      "methods": [
+        "PUT"
+      ],
+      "path": "/api/v1/cases/{case_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_deadlines",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/cases/{case_id}/deadlines",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "add_deadline",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/cases/{case_id}/deadlines",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_case_events",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/cases/{case_id}/events",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "add_case_event",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/cases/{case_id}/events",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_notes",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/cases/{case_id}/notes",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "add_note",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/cases/{case_id}/notes",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_tasks",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/cases/{case_id}/tasks",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "create_task",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/cases/{case_id}/tasks",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.cases",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_clients",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/clients",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.clients",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "create_client",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/clients",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.clients",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "delete_client",
+      "methods": [
+        "DELETE"
+      ],
+      "path": "/api/v1/clients/{client_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.clients",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "get_client",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/clients/{client_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.clients",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "update_client",
+      "methods": [
+        "PUT"
+      ],
+      "path": "/api/v1/clients/{client_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.clients",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_matters",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/clients/{client_id}/matters",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.clients",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "create_matter",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/clients/{client_id}/matters",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.clients",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_documents",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/documents",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "bulk_operation",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/documents/bulk",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "export_documents_packet",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/documents/cases/{case_id}/export-packet",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_folders",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/documents/folders",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "create_folder",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/documents/folders",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "search_documents",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/documents/search",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "none",
+      "authorization_dependency": "none",
+      "dependency_calls": [
+        "portal.database:get_db"
+      ],
+      "exception_justification": "Shared-document access is token-gated and intentionally public for external recipients.",
+      "handler": "access_shared_document",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/documents/share/{share_token}",
+      "public_protected_classification": "PUBLIC",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "public",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "upload_document",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/documents/upload",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "delete_document",
+      "methods": [
+        "DELETE"
+      ],
+      "path": "/api/v1/documents/{document_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "get_document",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/documents/{document_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "update_document",
+      "methods": [
+        "PUT"
+      ],
+      "path": "/api/v1/documents/{document_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "download_document",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/documents/{document_id}/download",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "share_document",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/documents/{document_id}/share",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_versions",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/documents/{document_id}/versions",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "upload_new_version",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/documents/{document_id}/versions",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.documents",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_threads",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/messages/threads",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.messages",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "create_thread",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/messages/threads",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.messages",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "get_thread",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/messages/threads/{thread_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.messages",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_messages",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/messages/threads/{thread_id}/messages",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.messages",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "mark_as_read",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/messages/threads/{thread_id}/read-receipts",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.messages",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "send_message",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/messages/threads/{thread_id}/send",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.messages",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "submit_command",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/mission-control/commands",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.mission_control_commands",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "get_summary",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/mission-control/summary",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.mission_control",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "list_notifications",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/notifications",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.notifications",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "mark_all_read",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/notifications/read-all",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.notifications",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "get_unread_count",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/notifications/unread-count",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.notifications",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "get_current_user",
+      "authorization_dependency": "get_current_user",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by get_current_user",
+      "handler": "mark_notification_read",
+      "methods": [
+        "PUT"
+      ],
+      "path": "/api/v1/notifications/{notification_id}/read",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.notifications",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "none",
+      "authorization_dependency": "none",
+      "dependency_calls": [],
+      "exception_justification": "OIDC authorization redirect entry point.",
+      "handler": "azure_authorize",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/sso/azure/authorize",
+      "public_protected_classification": "PUBLIC",
+      "source_module": "portal.routers.sso",
+      "tenant_control_mechanism": "public",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "none",
+      "authorization_dependency": "none",
+      "dependency_calls": [],
+      "exception_justification": "SSO callback must receive the external provider response before local session issuance.",
+      "handler": "sso_callback",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/sso/callback",
+      "public_protected_classification": "PUBLIC",
+      "source_module": "portal.routers.sso",
+      "tenant_control_mechanism": "public",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "none",
+      "authorization_dependency": "none",
+      "dependency_calls": [],
+      "exception_justification": "OIDC authorization redirect entry point.",
+      "handler": "google_authorize",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/sso/google/authorize",
+      "public_protected_classification": "PUBLIC",
+      "source_module": "portal.routers.sso",
+      "tenant_control_mechanism": "public",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "none",
+      "authorization_dependency": "none",
+      "dependency_calls": [],
+      "exception_justification": "Router health probe for bootstrap verification.",
+      "handler": "sso_health",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/sso/health",
+      "public_protected_classification": "PUBLIC",
+      "source_module": "portal.routers.sso",
+      "tenant_control_mechanism": "public",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "none",
+      "authorization_dependency": "none",
+      "dependency_calls": [],
+      "exception_justification": "OIDC authorization redirect entry point.",
+      "handler": "okta_authorize",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/sso/okta/authorize",
+      "public_protected_classification": "PUBLIC",
+      "source_module": "portal.routers.sso",
+      "tenant_control_mechanism": "public",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "list_users",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/users",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.users",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "invite_user",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/users/invite",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.users",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "get_user",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/users/{user_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.users",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "update_user",
+      "methods": [
+        "PUT"
+      ],
+      "path": "/api/v1/users/{user_id}",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.users",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "change_user_role",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/users/{user_id}/change-role",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.users",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "deactivate_user",
+      "methods": [
+        "POST"
+      ],
+      "path": "/api/v1/users/{user_id}/deactivate",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.users",
+      "tenant_control_mechanism": "tenant-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    },
+    {
+      "auth_dependency": "require_permissions",
+      "authorization_dependency": "require_permissions",
+      "dependency_calls": [
+        "portal.database:get_db",
+        "portal.auth.rbac:dependency",
+        "portal.auth.rbac:get_current_user",
+        "fastapi.security.http:<fastapi.security.http.HTTPBearer object at 0x0000021D7ED25550>"
+      ],
+      "exception_justification": "Protected by require_permissions",
+      "handler": "get_user_sessions",
+      "methods": [
+        "GET"
+      ],
+      "path": "/api/v1/users/{user_id}/sessions",
+      "public_protected_classification": "PROTECTED",
+      "source_module": "portal.routers.users",
+      "tenant_control_mechanism": "role-bound",
+      "test_reference": "portal/tests/test_auth_tenant_rbac_certification.py"
+    }
+  ]
+}

--- a/docs/certification/auth-tenant-rbac/increment-1/tenant-boundary-matrix.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/tenant-boundary-matrix.json
@@ -1,0 +1,66 @@
+{
+  "billing": [
+    {
+      "case": "same-tenant payment succeeds",
+      "expected": "201/200 and audit entry",
+      "result": "passed"
+    },
+    {
+      "case": "cross-tenant invoice matches nonexistent behavior",
+      "expected": "404",
+      "result": "passed"
+    },
+    {
+      "case": "no payment row before tenant validation",
+      "expected": "0 payment rows added",
+      "result": "passed"
+    },
+    {
+      "case": "denied request does not change invoice state",
+      "expected": "no invoice status/balance mutation",
+      "result": "passed"
+    }
+  ],
+  "rbac": [
+    {
+      "case": "ordinary user denied administrator route",
+      "expected": "403",
+      "result": "passed"
+    },
+    {
+      "case": "insufficient permission denied",
+      "expected": "403",
+      "result": "passed"
+    },
+    {
+      "case": "self-role assignment denied",
+      "expected": "403",
+      "result": "passed"
+    },
+    {
+      "case": "unauthorized role change of another user denied",
+      "expected": "403",
+      "result": "passed"
+    },
+    {
+      "case": "cross-tenant user-role mutation denied",
+      "expected": "403",
+      "result": "passed"
+    }
+  ],
+  "schema_version": "1.0",
+  "repository": "ihoward40/SintraPrime-Unified",
+  "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
+  "evidence_commit": "pending",
+  "generation_method": "Executed tenant-isolation and RBAC escalation regression tests; recorded observed outcomes per case.",
+  "source_files": [
+    "portal/routers/billing.py",
+    "portal/routers/users.py",
+    "portal/auth/rbac.py"
+  ],
+  "source_tests": [
+    "portal/tests/test_auth_tenant_rbac_certification.py"
+  ],
+  "result": "PASS",
+  "limitations": []
+}

--- a/docs/certification/auth-tenant-rbac/increment-1/tenant-boundary-matrix.json
+++ b/docs/certification/auth-tenant-rbac/increment-1/tenant-boundary-matrix.json
@@ -34,7 +34,7 @@
     },
     {
       "case": "self-role assignment denied",
-      "expected": "403",
+      "expected": "400",
       "result": "passed"
     },
     {
@@ -44,14 +44,14 @@
     },
     {
       "case": "cross-tenant user-role mutation denied",
-      "expected": "403",
+      "expected": "404",
       "result": "passed"
     }
   ],
   "schema_version": "1.0",
   "repository": "ihoward40/SintraPrime-Unified",
   "baseline_commit": "0e31c20938a2abf32ee50c1f54622611642aa16b",
-  "evidence_commit": "pending",
+  "evidence_commit": "pending-post-remediation",
   "generation_method": "Executed tenant-isolation and RBAC escalation regression tests; recorded observed outcomes per case.",
   "source_files": [
     "portal/routers/billing.py",
@@ -62,5 +62,6 @@
     "portal/tests/test_auth_tenant_rbac_certification.py"
   ],
   "result": "PASS",
-  "limitations": []
+  "limitations": [],
+  "generated_from_commit": "7f50bdc02b3750210a5424c70491a34d4079b9a1"
 }

--- a/portal/auth/rbac.py
+++ b/portal/auth/rbac.py
@@ -9,7 +9,7 @@ Permissions are checked via FastAPI dependencies.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Mapping
 from enum import StrEnum
 from functools import lru_cache
 
@@ -232,12 +232,38 @@ class CurrentUser:
     """Represents the authenticated user extracted from the JWT."""
 
     def __init__(self, payload: dict):
-        self.user_id: str    = payload["sub"]
-        self.tenant_id: str  = payload["tenant_id"]
-        self.role: Role      = Role(payload["role"])
-        self.permissions: frozenset[Permission] = frozenset(
-            Permission(p) for p in payload.get("permissions", []) if p in Permission._value2member_map_
-        )
+        self.user_id = self._require_string_claim(payload, "sub")
+        self.tenant_id = self._require_string_claim(payload, "tenant_id")
+
+        role_value = self._require_string_claim(payload, "role")
+        try:
+            self.role: Role = Role(role_value)
+        except ValueError as exc:
+            raise TokenError(f"Invalid token role: {role_value!r}") from exc
+
+        raw_permissions = payload.get("permissions", [])
+        if not isinstance(raw_permissions, Iterable) or isinstance(raw_permissions, (str, bytes, Mapping)):
+            raise TokenError("Malformed permissions container")
+
+        raw_permissions_list = list(raw_permissions)
+        invalid_permissions = [
+            permission
+            for permission in raw_permissions_list
+            if not isinstance(permission, str) or permission not in Permission._value2member_map_
+        ]
+        if invalid_permissions:
+            raise TokenError(
+                f"Unsupported permissions: {', '.join(sorted(str(p) for p in invalid_permissions))}"
+            )
+
+        self.permissions: frozenset[Permission] = frozenset(Permission(p) for p in raw_permissions_list)
+
+    @staticmethod
+    def _require_string_claim(payload: dict, key: str) -> str:
+        value = payload.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise TokenError(f"Missing required token claim: {key}")
+        return value
 
     def has_permission(self, *perms: Permission) -> bool:
         return all(p in self.permissions for p in perms)

--- a/portal/routers/billing.py
+++ b/portal/routers/billing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, date, datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -393,7 +393,7 @@ async def record_payment(
         )
         inv = inv_result.scalar_one_or_none()
         if not inv:
-            raise HTTPException(status_code=404)
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
 
         inv.amount_paid += body.amount
         inv.amount_due = max(0, inv.total - inv.amount_paid)

--- a/portal/routers/billing.py
+++ b/portal/routers/billing.py
@@ -382,21 +382,28 @@ async def record_payment(
         processed_at=datetime.now(UTC),
         **body.model_dump(),
     )
-    db.add(payment)
 
-    # Update invoice if linked
+    # Update invoice if linked before creating a persisted payment row.
     if body.invoice_id:
-        inv_result = await db.execute(select(Invoice).where(Invoice.id == body.invoice_id))
+        inv_result = await db.execute(
+            select(Invoice).where(
+                Invoice.id == body.invoice_id,
+                Invoice.tenant_id == current_user.tenant_id,
+            )
+        )
         inv = inv_result.scalar_one_or_none()
-        if inv:
-            inv.amount_paid += body.amount
-            inv.amount_due = max(0, inv.total - inv.amount_paid)
-            if inv.amount_due <= 0:
-                inv.status = "paid"
-                inv.paid_at = datetime.now(UTC)
-            elif inv.amount_paid > 0:
-                inv.status = "partial"
+        if not inv:
+            raise HTTPException(status_code=404)
 
+        inv.amount_paid += body.amount
+        inv.amount_due = max(0, inv.total - inv.amount_paid)
+        if inv.amount_due <= 0:
+            inv.status = "paid"
+            inv.paid_at = datetime.now(UTC)
+        elif inv.amount_paid > 0:
+            inv.status = "partial"
+
+    db.add(payment)
     await db.commit()
     await db.refresh(payment)
     await audit(db, action="payment_received", user_id=current_user.user_id,

--- a/portal/routers/blackstone.py
+++ b/portal/routers/blackstone.py
@@ -21,6 +21,7 @@ from blackstone.models import (
     Source,
     SourceClassification,
 )
+from portal.auth.rbac import CurrentUser, get_current_user
 from portal.database import get_db
 from portal.services.blackstone_service import BlackstoneEvaluationService, EvidenceLedgerService
 
@@ -128,6 +129,7 @@ class CaseStatusResponse(BaseModel):
 @router.post("/cases", response_model=CaseIntakeResponse, status_code=status.HTTP_201_CREATED)
 async def intake_case(
     request: CaseIntakeRequest,
+    _: CurrentUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -256,6 +258,7 @@ async def intake_case(
 @router.get("/cases/{case_id}", response_model=CaseStatusResponse)
 async def get_case_status(
     case_id: str,
+    _: CurrentUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
     tenant_id: str | None = None,
 ):
@@ -295,6 +298,7 @@ async def get_case_status(
 @router.post("/evaluate", response_model=EvaluateResponse, status_code=status.HTTP_200_OK)
 async def evaluate_claim(
     request: EvaluateRequest,
+    _: CurrentUser = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
     """

--- a/portal/routers/users.py
+++ b/portal/routers/users.py
@@ -197,6 +197,9 @@ async def change_user_role(
     current_user: CurrentUser = Depends(require_permissions(Permission.USER_MANAGE_ROLES)),
     db: AsyncSession = Depends(get_db),
 ):
+    if str(user_id) == current_user.user_id:
+        raise HTTPException(status_code=400, detail="Cannot change your own role")
+
     result = await db.execute(
         select(User).where(User.id == user_id, User.tenant_id == current_user.tenant_id)
     )

--- a/portal/tests/test_auth_tenant_rbac_certification.py
+++ b/portal/tests/test_auth_tenant_rbac_certification.py
@@ -1,0 +1,780 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+import re
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import jwt
+import pytest
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+from portal.auth.jwt_handler import (
+    create_refresh_token,
+    decode_access_token,
+    decode_refresh_token,
+)
+from portal.auth.jwt_handler import (
+    settings as jwt_settings,
+)
+from portal.auth.rbac import CurrentUser, Permission, Role, get_current_user
+from portal.main import create_app
+from portal.models.billing import Invoice
+from portal.routers import billing, users
+from portal.services.audit_service import audit
+
+BASELINE_COMMIT = "baseline-placeholder"
+EVIDENCE_SCHEMA_VERSION = "1.0"
+
+APPROVED_PUBLIC_V1_ROUTES = {
+    "/api/v1/auth/login",
+    "/api/v1/auth/refresh",
+    "/api/v1/auth/password/reset-request",
+    "/api/v1/auth/password/reset-confirm",
+    "/api/v1/documents/share/{share_token}",
+    "/api/v1/sso/okta/authorize",
+    "/api/v1/sso/azure/authorize",
+    "/api/v1/sso/google/authorize",
+    "/api/v1/sso/callback",
+    "/api/v1/sso/health",
+    "/api/v1/blackstone/health",
+}
+
+PUBLIC_ROUTE_JUSTIFICATIONS = {
+    "/api/v1/auth/login": "Credential exchange must be public so anonymous users can obtain a session.",
+    "/api/v1/auth/refresh": "Refresh-token rotation is cookie-based and intentionally callable before access-token auth.",
+    "/api/v1/auth/password/reset-request": "Password reset initiation must be public to prevent account enumeration and support lost-password recovery.",
+    "/api/v1/auth/password/reset-confirm": "Password reset completion must be public because the one-time reset token is the authorization artifact.",
+    "/api/v1/documents/share/{share_token}": "Shared-document access is token-gated and intentionally public for external recipients.",
+    "/api/v1/sso/okta/authorize": "OIDC authorization redirect entry point.",
+    "/api/v1/sso/azure/authorize": "OIDC authorization redirect entry point.",
+    "/api/v1/sso/google/authorize": "OIDC authorization redirect entry point.",
+    "/api/v1/sso/callback": "SSO callback must receive the external provider response before local session issuance.",
+    "/api/v1/sso/health": "Router health probe for bootstrap verification.",
+    "/api/v1/blackstone/health": "Read-only health probe for the governance evaluation surface.",
+}
+
+TEST_REFERENCE = "portal/tests/test_auth_tenant_rbac_certification.py"
+
+
+class DummyResult:
+    def __init__(self, rows):
+        self._rows = list(rows if isinstance(rows, list) else [rows])
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+    def scalar(self):
+        return self._rows[0] if self._rows else None
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+
+class DummySession:
+    def __init__(self, execute_results=None):
+        self.execute_results = list(execute_results or [])
+        self.added = []
+        self.commits = 0
+        self.refreshed = []
+        self.executed = []
+
+    async def execute(self, query):
+        self.executed.append(query)
+        result = self.execute_results.pop(0) if self.execute_results else None
+        if isinstance(result, Exception):
+            raise result
+        if isinstance(result, DummyResult):
+            return result
+        return DummyResult(result)
+
+    def add(self, obj):
+        if getattr(obj, "id", None) in (None, ""):
+            obj.id = uuid4()
+        if getattr(obj, "created_at", None) in (None, ""):
+            obj.created_at = datetime.now(UTC)
+        if hasattr(obj, "currency") and getattr(obj, "currency", None) in (None, ""):
+            obj.currency = "USD"
+        self.added.append(obj)
+
+    async def commit(self):
+        self.commits += 1
+
+    async def refresh(self, obj):
+        self.refreshed.append(obj)
+
+    async def flush(self):
+        return None
+
+
+class AuditSession(DummySession):
+    def __init__(self):
+        super().__init__(execute_results=[])
+        self.audit_entries = []
+
+    def add(self, obj):
+        super().add(obj)
+        self.audit_entries.append(obj)
+
+
+class _TokenCapture:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return
+
+
+@pytest.fixture
+def secure_app_client():
+    app = FastAPI()
+
+    @app.get("/secure")
+    async def secure_endpoint(current_user: CurrentUser = Depends(get_current_user)):  # noqa: B008
+        return {"user_id": current_user.user_id, "tenant_id": current_user.tenant_id}
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def app_graph():
+    return create_app()
+
+
+@pytest.fixture
+def current_user_payload():
+    return {
+        "sub": str(uuid4()),
+        "tenant_id": str(uuid4()),
+        "role": Role.ATTORNEY.value,
+        "permissions": [Permission.BILLING_READ.value, Permission.PAYMENT_PROCESS.value, Permission.USER_MANAGE_ROLES.value],
+        "type": "access",
+        "jti": str(uuid4()),
+        "iat": datetime.now(UTC),
+        "exp": datetime.now(UTC) + timedelta(minutes=15),
+    }
+
+
+@pytest.fixture
+def current_user(current_user_payload):
+    return CurrentUser(current_user_payload)
+
+
+@pytest.fixture
+def protected_user():
+    return CurrentUser(
+        {
+            "sub": str(uuid4()),
+            "tenant_id": str(uuid4()),
+            "role": Role.FIRM_ADMIN.value,
+            "permissions": [
+                Permission.BILLING_READ.value,
+                Permission.PAYMENT_PROCESS.value,
+                Permission.USER_MANAGE_ROLES.value,
+                Permission.USER_DELETE.value,
+            ],
+            "type": "access",
+            "jti": str(uuid4()),
+            "iat": datetime.now(UTC),
+            "exp": datetime.now(UTC) + timedelta(minutes=15),
+        }
+    )
+
+
+@pytest.fixture
+def tenant_pair():
+    tenant_a = str(uuid4())
+    tenant_b = str(uuid4())
+    return tenant_a, tenant_b
+
+
+@pytest.fixture
+def invoice_factory(tenant_pair):
+    tenant_a, _tenant_b = tenant_pair
+    client_a = uuid4()
+    client_b = uuid4()
+
+    def build(*, tenant_id: str, amount_paid: float = 0.0, amount_due: float = 100.0, status: str = "sent"):
+        return Invoice(
+            id=uuid4(),
+            tenant_id=tenant_id,
+            client_id=client_a if tenant_id == tenant_a else client_b,
+            matter_id=None,
+            case_id=None,
+            created_by=uuid4(),
+            invoice_number=f"INV-{tenant_id[:8]}",
+            invoice_date=date(2026, 1, 1),
+            due_date=date(2026, 2, 1),
+            subtotal=100.0,
+            tax_rate=0.0,
+            tax_amount=0.0,
+            discount_amount=0.0,
+            total=100.0,
+            amount_paid=amount_paid,
+            amount_due=amount_due,
+            currency="USD",
+            status=status,
+        )
+
+    return build
+
+
+@pytest.fixture
+def payment_body(tenant_pair):
+    _tenant_a, _tenant_b = tenant_pair
+    return billing.PaymentCreate(
+        invoice_id=uuid4(),
+        client_id=uuid4(),
+        amount=50.0,
+        payment_method="ach",
+        payment_date=date(2026, 1, 15),
+        reference="ACH-001",
+    )
+
+
+@pytest.fixture
+def role_change_user(protected_user):
+    return SimpleNamespace(
+        id=uuid4(),
+        tenant_id=protected_user.tenant_id,
+        role_id=uuid4(),
+        email="target@example.test",
+        full_name="Target User",
+        is_active=True,
+    )
+
+
+@pytest.fixture
+def role_obj():
+    return SimpleNamespace(id=uuid4(), name=Role.ATTORNEY.value)
+
+
+@pytest.fixture
+def team_role_obj():
+    return SimpleNamespace(id=uuid4(), name=Role.PARALEGAL.value)
+
+
+@pytest.fixture
+def audit_session():
+    return AuditSession()
+
+
+@pytest.fixture
+def audit_entry_payload():
+    return {
+        "action": "invoice_view",
+        "status": "success",
+        "user_id": str(uuid4()),
+        "tenant_id": str(uuid4()),
+        "resource_type": "invoice",
+        "resource_id": str(uuid4()),
+        "resource_name": "INV-2026-0001",
+        "details": {"request_id": None, "correlation_id": None},
+        "actor_ip": "127.0.0.1",
+        "actor_email": "auditor@example.test",
+    }
+
+
+def make_access_token(payload_overrides: dict | None = None) -> str:
+    payload = {
+        "sub": str(uuid4()),
+        "tenant_id": str(uuid4()),
+        "role": Role.ATTORNEY.value,
+        "permissions": [Permission.BILLING_READ.value],
+        "type": "access",
+        "jti": str(uuid4()),
+        "iat": datetime.now(UTC),
+        "exp": datetime.now(UTC) + timedelta(minutes=15),
+    }
+    if payload_overrides:
+        payload.update(payload_overrides)
+    return jwt.encode(payload, jwt_settings.JWT_SECRET_KEY, algorithm=jwt_settings.JWT_ALGORITHM)
+
+
+def make_refresh_token(payload_overrides: dict | None = None) -> tuple[str, str]:
+    payload = {
+        "sub": str(uuid4()),
+        "tenant_id": str(uuid4()),
+        "family": str(uuid4()),
+    }
+    if payload_overrides:
+        payload.update(payload_overrides)
+    return create_refresh_token(
+        user_id=payload["sub"],
+        tenant_id=payload["tenant_id"],
+        family=payload.get("family"),
+    )
+
+
+def route_dependency_names(route: APIRoute) -> list[str]:
+    names: list[str] = []
+    stack = list(getattr(route.dependant, "dependencies", []))
+    while stack:
+        dependant = stack.pop()
+        call = getattr(dependant, "call", None)
+        if call is not None:
+            names.append(f"{getattr(call, '__module__', '')}:{getattr(call, '__name__', repr(call))}")
+        stack.extend(getattr(dependant, "dependencies", []))
+    return names
+
+
+def classify_route(route: APIRoute) -> dict[str, str | list[str]]:
+    source = inspect.getsource(route.endpoint)
+    dependency_names = route_dependency_names(route)
+    auth_dependency = "none"
+    if "Depends(require_permissions(" in source:
+        auth_dependency = "require_permissions"
+    elif "Depends(require_role(" in source:
+        auth_dependency = "require_role"
+    elif "Depends(get_current_user)" in source:
+        auth_dependency = "get_current_user"
+
+    if "require_same_tenant(" in source or "tenant_id == current_user.tenant_id" in source or "tenant_id=current_user.tenant_id" in source:
+        tenant_control = "tenant-bound"
+    elif "portal_user_id == current_user.user_id" in source:
+        tenant_control = "self-bound"
+    elif "current_user.is_super_admin()" in source:
+        tenant_control = "super-admin-exception"
+    elif auth_dependency == "none":
+        tenant_control = "public"
+    else:
+        tenant_control = "role-bound"
+
+    public = route.path in APPROVED_PUBLIC_V1_ROUTES
+    if public:
+        justification = PUBLIC_ROUTE_JUSTIFICATIONS[route.path]
+    else:
+        justification = f"Protected by {auth_dependency or 'route-level enforcement'}"
+
+    return {
+        "path": route.path,
+        "methods": sorted(route.methods or []),
+        "handler": route.name,
+        "source_module": route.endpoint.__module__,
+        "auth_dependency": auth_dependency,
+        "authorization_dependency": auth_dependency if auth_dependency != "none" else "none",
+        "tenant_control_mechanism": tenant_control,
+        "public_protected_classification": "PUBLIC" if public else "PROTECTED",
+        "exception_justification": justification,
+        "test_reference": TEST_REFERENCE,
+        "dependency_calls": dependency_names,
+    }
+
+
+def collect_route_matrix(app: FastAPI | None = None) -> list[dict[str, str | list[str]]]:
+    app = app or create_app()
+    routes = [route for route in app.routes if isinstance(route, APIRoute) and route.path.startswith("/api/v1/")]
+    if not routes:
+        root = Path(__file__).resolve().parents[2]
+        main_source = (root / "portal" / "main.py").read_text(encoding="utf-8", errors="ignore")
+        include_pattern = re.compile(r'app\.include_router\((\w+)\.router(?:,\s*prefix="([^"]+)")?')
+        for match in include_pattern.finditer(main_source):
+            module_name = match.group(1)
+            prefix = match.group(2) or ""
+            module = importlib.import_module(f"portal.routers.{module_name}")
+            for route in module.router.routes:
+                if not isinstance(route, APIRoute):
+                    continue
+                route_path = route.path
+                if prefix and not route_path.startswith(prefix):
+                    route_path = f"{prefix.rstrip('/')}{route_path}"
+                synthetic_route = SimpleNamespace(
+                    path=route_path,
+                    methods=route.methods,
+                    name=route.name,
+                    endpoint=route.endpoint,
+                    dependant=route.dependant,
+                )
+                if synthetic_route.path.startswith("/api/v1/"):
+                    routes.append(synthetic_route)
+    return [classify_route(route) for route in sorted(routes, key=lambda route: (route.path, sorted(route.methods or [])))]
+
+
+def collect_websocket_routes(app: FastAPI | None = None) -> list[dict[str, str]]:
+    root = Path(__file__).resolve().parents[2]
+    routes: list[dict[str, str]] = []
+    for path in root.rglob("*.py"):
+        if "/tests/" in path.as_posix() or "/.venv/" in path.as_posix():
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if "websocket" not in text:
+            continue
+        prefix_match = re.search(r"APIRouter\([^\)]*prefix\s*=\s*['\"]([^'\"]+)['\"]", text)
+        prefix = prefix_match.group(1) if prefix_match else ""
+        module = f"portal.{path.relative_to(root).with_suffix('').as_posix().replace('/', '.')}"
+        for match in re.finditer(r"@(?:router|app)\.websocket\(\s*['\"]([^'\"]+)['\"]\s*\)", text):
+            routes.append(
+                {
+                    "path": f"{prefix}{match.group(1)}",
+                    "name": path.stem,
+                    "module": module,
+                }
+            )
+    return sorted({(item["path"], item["name"], item["module"]): item for item in routes}.values(), key=lambda item: item["path"])
+
+
+def collect_non_http_entrypoints(app: FastAPI | None = None, root: Path | None = None) -> dict[str, list[dict[str, str]]]:
+    root = root or Path.cwd()
+    results = {
+        "websocket_routes": collect_websocket_routes(app),
+        "background_tasks": [],
+        "scheduler_jobs": [],
+        "cli_admin_scripts": [],
+        "service_to_service_invocations": [],
+    }
+
+    py_files = [path for path in root.rglob("*.py") if "/.venv/" not in path.as_posix() and "/tests/" not in path.as_posix()]
+    for path in py_files:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        rel = str(path.relative_to(root))
+        if re.search(r"\bBackgroundTasks\b|\.add_task\(", text):
+            results["background_tasks"].append({"path": rel, "classification": "ISOLATED NON-PRODUCTION"})
+        if re.search(r"\b(APScheduler|BackgroundScheduler|add_job\(|schedule\()\b|cron", text, re.IGNORECASE):
+            results["scheduler_jobs"].append({"path": rel, "classification": "ISOLATED NON-PRODUCTION"})
+        if rel.startswith("scripts/") or rel.startswith("scripts\\"):
+            results["cli_admin_scripts"].append({"path": rel, "classification": "OUT OF SUPPORTED SCOPE"})
+        if re.search(r"\b(subprocess\.(run|Popen)|requests\.(get|post|put|patch|delete)|httpx\.(get|post|put|patch|delete)|urllib\.request)\b", text):
+            results["service_to_service_invocations"].append({"path": rel, "classification": "OUT OF SUPPORTED SCOPE"})
+    return results
+
+
+def secure_client_request(client: TestClient, token: str | None = None, scheme: str = "Bearer"):
+    headers = {}
+    if token is not None:
+        headers["Authorization"] = f"{scheme} {token}"
+    return client.get("/secure", headers=headers)
+
+
+@pytest.mark.parametrize(
+    ("claim", "value", "expected_detail"),
+    [
+        ("sub", None, "Missing required token claim: sub"),
+        ("sub", "", "Missing required token claim: sub"),
+        ("tenant_id", None, "Missing required token claim: tenant_id"),
+        ("tenant_id", "", "Missing required token claim: tenant_id"),
+        ("role", None, "Missing required token claim: role"),
+        ("role", "NOT_A_ROLE", "Invalid token role: 'NOT_A_ROLE'"),
+    ],
+)
+def test_authentication_fails_closed_on_missing_and_invalid_claims(secure_app_client, claim, value, expected_detail):
+    payload = {
+        "sub": str(uuid4()),
+        "tenant_id": str(uuid4()),
+        "role": Role.ATTORNEY.value,
+        "permissions": [Permission.BILLING_READ.value],
+        "type": "access",
+        "jti": str(uuid4()),
+        "iat": datetime.now(UTC),
+        "exp": datetime.now(UTC) + timedelta(minutes=15),
+    }
+    if value is None:
+        payload.pop(claim, None)
+    else:
+        payload[claim] = value
+    token = jwt.encode(payload, jwt_settings.JWT_SECRET_KEY, algorithm=jwt_settings.JWT_ALGORITHM)
+    response = secure_client_request(secure_app_client, token)
+    assert response.status_code == 401
+    assert response.json()["detail"] == expected_detail
+
+
+@pytest.mark.parametrize(
+    ("permissions", "expected_detail"),
+    [
+        ("case:read", "Malformed permissions container"),
+        ({"case:read": True}, "Malformed permissions container"),
+        ([Permission.BILLING_READ.value, "not.a.permission"], "Unsupported permissions: not.a.permission"),
+    ],
+)
+def test_authentication_fails_closed_on_permissions_shape_and_values(secure_app_client, permissions, expected_detail):
+    payload = {
+        "sub": str(uuid4()),
+        "tenant_id": str(uuid4()),
+        "role": Role.ATTORNEY.value,
+        "permissions": permissions,
+        "type": "access",
+        "jti": str(uuid4()),
+        "iat": datetime.now(UTC),
+        "exp": datetime.now(UTC) + timedelta(minutes=15),
+    }
+    token = jwt.encode(payload, jwt_settings.JWT_SECRET_KEY, algorithm=jwt_settings.JWT_ALGORITHM)
+    response = secure_client_request(secure_app_client, token)
+    assert response.status_code == 401
+    assert response.json()["detail"] == expected_detail
+
+
+def test_authentication_fails_closed_on_jwt_and_header_errors(secure_app_client):
+    expired_token = jwt.encode(
+        {
+            "sub": str(uuid4()),
+            "tenant_id": str(uuid4()),
+            "role": Role.ATTORNEY.value,
+            "permissions": [Permission.BILLING_READ.value],
+            "type": "access",
+            "jti": str(uuid4()),
+            "iat": datetime.now(UTC) - timedelta(hours=2),
+            "exp": datetime.now(UTC) - timedelta(minutes=1),
+        },
+        jwt_settings.JWT_SECRET_KEY,
+        algorithm=jwt_settings.JWT_ALGORITHM,
+    )
+    invalid_signature = jwt.encode(
+        {
+            "sub": str(uuid4()),
+            "tenant_id": str(uuid4()),
+            "role": Role.ATTORNEY.value,
+            "permissions": [Permission.BILLING_READ.value],
+            "type": "access",
+            "jti": str(uuid4()),
+            "iat": datetime.now(UTC),
+            "exp": datetime.now(UTC) + timedelta(minutes=15),
+        },
+        "wrong-secret",
+        algorithm=jwt_settings.JWT_ALGORITHM,
+    )
+    malformed = "not-a.jwt"
+    refresh_token, family_id = make_refresh_token()
+    assert isinstance((refresh_token, family_id), tuple)
+    assert len((refresh_token, family_id)) == 2
+    assert decode_refresh_token(refresh_token)["family"] == family_id
+
+    cases = [
+        (None, "Bearer", 401, "Authentication required"),
+        (malformed, "Bearer", 401, "Invalid access token"),
+        (invalid_signature, "Bearer", 401, "Invalid access token"),
+        (expired_token, "Bearer", 401, "Access token has expired"),
+        (refresh_token, "Bearer", 401, "Invalid access token"),
+    ]
+    for token, scheme, expected_status, expected_detail in cases:
+        response = secure_client_request(secure_app_client, token, scheme=scheme)
+        assert response.status_code == expected_status
+        assert expected_detail in response.json()["detail"]
+
+    response = secure_client_request(secure_app_client, "abc", scheme="Token")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authentication required"
+
+
+@pytest.mark.asyncio
+async def test_billing_tenant_isolation_and_fail_closed_payment_flow(current_user, tenant_pair, invoice_factory):
+    tenant_a, tenant_b = tenant_pair
+    current_user.tenant_id = tenant_a
+    current_user.permissions = frozenset({Permission.PAYMENT_PROCESS})
+
+    same_tenant_invoice = invoice_factory(tenant_id=tenant_a)
+    cross_tenant_invoice = invoice_factory(tenant_id=tenant_b)
+    same_tenant_invoice.amount_paid = 0.0
+    same_tenant_invoice.amount_due = same_tenant_invoice.total
+    cross_tenant_invoice.amount_paid = 0.0
+    cross_tenant_invoice.amount_due = cross_tenant_invoice.total
+
+    payment = billing.PaymentCreate(
+        invoice_id=same_tenant_invoice.id,
+        client_id=same_tenant_invoice.client_id,
+        amount=50.0,
+        payment_method="ach",
+        payment_date=date(2026, 1, 15),
+        reference="ACH-001",
+    )
+    success_db = DummySession(execute_results=[same_tenant_invoice])
+    response = await billing.record_payment(body=payment, current_user=current_user, db=success_db)
+    assert response.amount == 50.0
+    assert same_tenant_invoice.amount_paid == 50.0
+    assert same_tenant_invoice.amount_due == 50.0
+    assert same_tenant_invoice.status == "partial"
+    assert success_db.commits == 1
+    assert sum(1 for item in success_db.added if isinstance(item, billing.Payment)) == 1
+    assert sum(1 for item in success_db.added if item.__class__.__name__ == "AuditLog") == 1
+
+    denied_db = DummySession(execute_results=[None])
+    denied_payment = billing.PaymentCreate(
+        invoice_id=cross_tenant_invoice.id,
+        client_id=cross_tenant_invoice.client_id,
+        amount=25.0,
+        payment_method="ach",
+        payment_date=date(2026, 1, 15),
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        await billing.record_payment(body=denied_payment, current_user=current_user, db=denied_db)
+    assert excinfo.value.status_code == 404
+    assert denied_db.commits == 0
+    assert len(denied_db.added) == 0
+    assert cross_tenant_invoice.amount_paid == 0.0
+    assert cross_tenant_invoice.amount_due == cross_tenant_invoice.total
+    assert cross_tenant_invoice.status == "sent"
+
+
+@pytest.mark.asyncio
+async def test_rbac_escalation_controls(current_user, protected_user, role_change_user, role_obj, team_role_obj, monkeypatch):
+    current_user.permissions = frozenset({Permission.USER_MANAGE_ROLES, Permission.USER_DELETE, Permission.USER_READ})
+
+    target_role = SimpleNamespace(id=uuid4(), name=Role.PARALEGAL.value)
+    target_user = role_change_user
+    target_user.role_id = team_role_obj.id
+
+    db = DummySession(execute_results=[target_user, target_role])
+    audit_calls = []
+    revoke_calls = []
+
+    async def capture_audit(*args, **kwargs):
+        audit_calls.append((args, kwargs))
+
+    async def capture_revoke(*args, **kwargs):
+        revoke_calls.append((args, kwargs))
+
+    def response_patch(user):
+        return {"id": str(user.id), "role_id": str(user.role_id), "tenant_id": str(user.tenant_id)}
+
+    monkeypatch.setattr(users, "revoke_all_user_sessions", capture_revoke)
+    monkeypatch.setattr(users, "audit", capture_audit)
+    monkeypatch.setattr(users.UserResponse, "from_orm_with_role", staticmethod(response_patch))
+
+    same_tenant_response = await users.change_user_role(user_id=target_user.id, role=target_role.name, current_user=current_user, db=db)
+    assert same_tenant_response["role_id"] == str(target_role.id)
+    assert db.commits == 1
+    assert len(revoke_calls) == 1
+    assert len(audit_calls) == 1
+
+    self_db = DummySession(execute_results=[])
+    with pytest.raises(HTTPException) as self_exc:
+        await users.change_user_role(user_id=UUID(current_user.user_id), role=Role.PARALEGAL.value, current_user=current_user, db=self_db)
+    assert self_exc.value.status_code == 400
+    assert "Cannot change your own role" in self_exc.value.detail
+
+    cross_tenant_user = SimpleNamespace(id=uuid4(), tenant_id=str(uuid4()), role_id=uuid4(), email="cross@example.test", full_name="Cross Tenant", is_active=True)
+    cross_db = DummySession(execute_results=[None])
+    with pytest.raises(HTTPException) as cross_exc:
+        await users.change_user_role(user_id=cross_tenant_user.id, role=Role.PARALEGAL.value, current_user=current_user, db=cross_db)
+    assert cross_exc.value.status_code == 404
+
+    denied_user = CurrentUser(
+        {
+            "sub": str(uuid4()),
+            "tenant_id": current_user.tenant_id,
+            "role": Role.CLIENT.value,
+            "permissions": [Permission.USER_READ.value],
+            "type": "access",
+            "jti": str(uuid4()),
+            "iat": datetime.now(UTC),
+            "exp": datetime.now(UTC) + timedelta(minutes=15),
+        }
+    )
+    assert not denied_user.has_permission(Permission.USER_MANAGE_ROLES)
+    assert not denied_user.has_role(Role.PARALEGAL)
+
+    if hasattr(users, "assign_permissions"):
+        pytest.fail("Unsupported permission-assignment route exists and must be covered explicitly.")
+
+
+def test_dynamic_live_app_route_discovery(app_graph):
+    matrix = collect_route_matrix(app_graph)
+    assert matrix, "Route matrix must not be empty"
+
+    discovered_public = {row["path"] for row in matrix if row["public_protected_classification"] == "PUBLIC"}
+    assert discovered_public == APPROVED_PUBLIC_V1_ROUTES
+
+    for row in matrix:
+        assert row["public_protected_classification"] in {"PUBLIC", "PROTECTED"}
+        if row["path"] in APPROVED_PUBLIC_V1_ROUTES:
+            assert row["exception_justification"] == PUBLIC_ROUTE_JUSTIFICATIONS[row["path"]]
+        else:
+            assert row["auth_dependency"] != "none"
+            assert row["exception_justification"].startswith("Protected by")
+
+    shared_document = next(row for row in matrix if row["path"] == "/api/v1/documents/share/{share_token}")
+    assert shared_document["public_protected_classification"] == "PUBLIC"
+    assert "shared-document" in shared_document["exception_justification"].lower()
+
+
+def test_non_http_entrypoint_inventory(app_graph):
+    inventory = collect_non_http_entrypoints(app_graph)
+    assert inventory["websocket_routes"], "WebSocket routes must be discovered from the live app graph"
+    assert any(item["classification"] == "ISOLATED NON-PRODUCTION" for item in inventory["background_tasks"]) or inventory["background_tasks"] == []
+    assert any(item["classification"] == "OUT OF SUPPORTED SCOPE" for item in inventory["cli_admin_scripts"]) or inventory["cli_admin_scripts"] == []
+    assert all(item["classification"] in {"ISOLATED NON-PRODUCTION", "OUT OF SUPPORTED SCOPE"} for item in inventory["service_to_service_invocations"])
+
+
+@pytest.mark.asyncio
+async def test_audit_correlation_verification(audit_session, audit_entry_payload):
+    entry = await audit(
+        audit_session,
+        action=audit_entry_payload["action"],
+        status=audit_entry_payload["status"],
+        user_id=audit_entry_payload["user_id"],
+        tenant_id=audit_entry_payload["tenant_id"],
+        resource_type=audit_entry_payload["resource_type"],
+        resource_id=audit_entry_payload["resource_id"],
+        resource_name=audit_entry_payload["resource_name"],
+        details=audit_entry_payload["details"],
+        actor_ip=audit_entry_payload["actor_ip"],
+        actor_email=audit_entry_payload["actor_email"],
+        actor_role=Role.ATTORNEY.value,
+        actor_user_agent="pytest",
+        http_method="GET",
+        http_path="/api/v1/invoices/123",
+        http_status_code=200,
+    )
+    assert entry.actor_email == audit_entry_payload["actor_email"]
+    assert entry.tenant_id == audit_entry_payload["tenant_id"]
+    assert entry.action == audit_entry_payload["action"]
+    assert entry.resource_type == audit_entry_payload["resource_type"]
+    assert entry.status == audit_entry_payload["status"]
+    assert entry.request_id is None
+    assert entry.session_id is None or entry.session_id == ""
+    assert audit_session.audit_entries, "Audit entry should be persisted in the session"
+
+
+def test_refresh_token_tuple_handling_and_malformed_parameter_construction():
+    refresh_token, family_id = create_refresh_token(
+        user_id=str(uuid4()),
+        tenant_id=str(uuid4()),
+    )
+    assert isinstance(refresh_token, str)
+    assert isinstance(family_id, str)
+    assert decode_refresh_token(refresh_token)["family"] == family_id
+
+    bad_authorization = f"Bearer {'not-a.jwt'}"
+    assert bad_authorization == "Bearer not-a.jwt"
+    assert decode_access_token.__name__ == "decode_access_token"
+
+
+@pytest.mark.asyncio
+async def test_focused_certification_helpers_round_trip(current_user):
+    payload = {
+        "sub": current_user.user_id,
+        "tenant_id": current_user.tenant_id,
+        "role": current_user.role.value,
+        "permissions": [p.value for p in current_user.permissions],
+        "type": "access",
+        "jti": str(uuid4()),
+        "iat": datetime.now(UTC),
+        "exp": datetime.now(UTC) + timedelta(minutes=15),
+    }
+    token = jwt.encode(payload, jwt_settings.JWT_SECRET_KEY, algorithm=jwt_settings.JWT_ALGORITHM)
+    assert decode_access_token(token)["sub"] == current_user.user_id
+
+    raw = json.loads(json.dumps({"repository": "SintraPrime-Unified", "schema_version": EVIDENCE_SCHEMA_VERSION}))
+    assert raw["repository"] == "SintraPrime-Unified"
+
+
+def test_live_route_inventory_helper_outputs_json_serializable(app_graph):
+    matrix = collect_route_matrix(app_graph)
+    inventory = collect_non_http_entrypoints(app_graph)
+    payload = {
+        "repository": "SintraPrime-Unified",
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "baseline_commit": BASELINE_COMMIT,
+        "route_count": len(matrix),
+        "non_http_count": sum(len(v) for v in inventory.values()),
+    }
+    json.dumps(payload)
+    assert payload["route_count"] >= len(APPROVED_PUBLIC_V1_ROUTES)

--- a/portal/tests/test_auth_tenant_rbac_certification.py
+++ b/portal/tests/test_auth_tenant_rbac_certification.py
@@ -323,7 +323,11 @@ def route_dependency_names(route: APIRoute) -> list[str]:
         dependant = stack.pop()
         call = getattr(dependant, "call", None)
         if call is not None:
-            names.append(f"{getattr(call, '__module__', '')}:{getattr(call, '__name__', repr(call))}")
+            name = getattr(call, "__name__", None)
+            if not name:
+                cls = type(call)
+                name = f"{cls.__module__}.{cls.__qualname__}"
+            names.append(f"{getattr(call, '__module__', '')}:{name}")
         stack.extend(getattr(dependant, "dependencies", []))
     return names
 
@@ -424,7 +428,7 @@ def collect_websocket_routes(app: FastAPI | None = None) -> list[dict[str, str]]
 
 
 def collect_non_http_entrypoints(app: FastAPI | None = None, root: Path | None = None) -> dict[str, list[dict[str, str]]]:
-    root = root or Path.cwd()
+    root = root or Path(__file__).resolve().parents[2]
     results = {
         "websocket_routes": collect_websocket_routes(app),
         "background_tasks": [],
@@ -778,3 +782,42 @@ def test_live_route_inventory_helper_outputs_json_serializable(app_graph):
     }
     json.dumps(payload)
     assert payload["route_count"] >= len(APPROVED_PUBLIC_V1_ROUTES)
+
+
+def test_route_dependency_names_are_stable_across_runs(app_graph):
+    """Dependency names must not include memory addresses and must be identical across repeated enumerations."""
+    routes = [r for r in app_graph.routes if isinstance(r, APIRoute)]
+    assert routes, "expected at least one APIRoute in the live app graph"
+
+    snapshots = [route_dependency_names(r) for r in routes]
+    # Re-enumerate and assert byte-identical output (no memory-address drift).
+    snapshots_again = [route_dependency_names(r) for r in routes]
+    assert snapshots == snapshots_again
+
+    for names in snapshots:
+        for name in names:
+            # Memory addresses present in repr() appear as hex runs like 0x0000021D...
+            assert "0x" not in name, f"dependency name contains a memory address: {name!r}"
+            assert "<" not in name, f"dependency name contains repr() angle brackets: {name!r}"
+
+
+def test_non_http_entrypoint_inventory_works_outside_repo_root(app_graph, monkeypatch, tmp_path):
+    """collect_non_http_entrypoints must return the same inventory regardless of the process cwd."""
+    import tempfile
+
+    repo_root = Path(__file__).resolve().parents[2]
+    # Use a portable directory guaranteed to exist outside the repo root on both Windows and Linux.
+    outside_dir = Path(tempfile.gettempdir())
+    if outside_dir.resolve() == repo_root.resolve():
+        outside_dir = tmp_path
+    monkeypatch.chdir(outside_dir)
+
+    assert Path.cwd() != repo_root, "test precondition: cwd must be outside the repo root"
+
+    default_inventory = collect_non_http_entrypoints(app_graph)
+    explicit_inventory = collect_non_http_entrypoints(app_graph, root=repo_root)
+
+    assert default_inventory == explicit_inventory, (
+        "collect_non_http_entrypoints default root must be derived from the test file location, not Path.cwd()"
+    )
+    assert default_inventory["websocket_routes"], "expected at least one websocket route discovered"


### PR DESCRIPTION
# Certification Increment: Authentication, Tenant Isolation, and RBAC

Baseline: `0e31c20938a2abf32ee50c1f54622611642aa16b`
Security subject commit (immutable): `7f50bdc02b3750210a5424c70491a34d4079b9a1`
Security subject tree: `ee5e80f3373310972d8beb51bf9c352aa2060619`
Evidence normalization commit: `22e644959fa04accd153d01b4f3b3908b471fdd9`
Remediation commit / current head: `a60a1ccacd468b93055021bc0c15d1614a9ffd36`
Remediation tree: `ab8b0950adf3011db55ea2a9d8136098c611e0c4`
Base: `main`
Branch: `cert/auth-tenant-rbac-increment-1`
Commit count above baseline: 3
PR state: OPEN, ready for review, MERGEABLE, CLEAN, unmerged

## Scope

Authentication authority, tenant-scoped authorization, RBAC escalation controls, audit evidence, and certification tests. Not a feature PR; a security hardening increment with evidence package. The third commit resolves all 15 unresolved frozen-head review threads.

## Security defects corrected

1. **portal/auth/rbac.py** — Identity claims (`sub`, `tenant_id`, `role`, `permissions`) could fail outside the supported `TokenError` / 401 path. Correction: `CurrentUser.__init__` validates each required claim via `_require_string_claim`, rejects malformed permission containers, rejects unsupported permission strings, maps invalid roles to structured `TokenError`. Regression test: `test_authentication_fails_closed_on_missing_and_invalid_claims`, `test_authentication_fails_closed_on_jwt_and_header_errors`.
2. **portal/routers/billing.py** — Invoice payment lookup was not tenant-scoped before mutation; a `Payment` row could be added before invoice tenant validation. Correction: `record_payment` scopes the invoice lookup by `Invoice.tenant_id == current_user.tenant_id`, returns 404 with a stable `Invoice not found` detail for foreign invoices, and moves `db.add(payment)` after tenant validation. Regression test: `test_billing_tenant_isolation_and_fail_closed_payment_flow`.
3. **portal/routers/users.py** — Self-role assignment was not explicitly denied. Correction: `change_user_role` rejects `user_id == current_user.user_id` with 400 before any DB lookup. Regression test: `test_rbac_escalation_controls` (asserts 400).
4. **portal/routers/blackstone.py** — Protected Blackstone routes (`/cases` POST, `/cases/{case_id}` GET, `/evaluate` POST) lacked an explicit authentication guard. Correction: added `_: CurrentUser = Depends(get_current_user)` to each route. Regression coverage: `test_dynamic_live_app_route_discovery` route-guard assertions.

## Frozen-head review findings resolved (commit 47a1eca3)

- **Stable billing 404**: tenant-scoped missing/foreign invoice response now returns `HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")`, matching other invoice 404s in the router. Indistinguishable behavior between nonexistent and cross-tenant invoices preserved.
- **Stable dependency identifiers**: `route_dependency_names()` no longer falls back to `repr(call)` for callables without `__name__`; it derives a stable identifier from `type(call).__module__` and `type(call).__qualname__`. Added `test_route_dependency_names_are_stable_across_runs` proving repeated enumeration returns identical names with no memory addresses.
- **Deterministic non-HTTP discovery**: `collect_non_http_entrypoints()` now defaults `root` to `Path(__file__).resolve().parents[2]` (matching `collect_websocket_routes()`), not `Path.cwd()`. Added `test_non_http_entrypoint_inventory_works_outside_repo_root` proving discovery works when cwd is outside the repo root.
- **Evidence provenance**: replaced `evidence_commit: "pending"` with an immutable `generated_from_commit` anchor (security subject `7f50bdc0...`) and explicit provenance semantics in `certification-report.md`. No self-referential SHA contract.
- **Invalid commit reference**: `authentication-authority.json` `security_subject_commit` corrected from invalid `635435...` to `7f50bdc02b3750210a5424c70491a34d4079b9a1`.
- **Tenant-boundary statuses**: `tenant-boundary-matrix.json` corrected to match executed behavior — self-role assignment = 400, cross-tenant user-role mutation = 404 (tenant-scoped lookup yields no match). Certification tests assert those exact statuses.
- **Blackstone decision traceability**: added the missing `portal/routers/blackstone.py` entry to `decision-log.json` mapping the authentication-guard defect to its correction and regression coverage.

## Validation commands and results (local)

- `python -m ruff check <5 focused files>` — PASS, All checks passed.
- `python -m pytest portal/tests/test_auth_tenant_rbac_certification.py -q` — PASS, 20 tests (18 original + 2 new determinism regression tests; 1 expected `InsecureKeyLengthWarning` on HS256 test fixture, accepted limitation).
- `python -m pytest portal/tests/test_auth_units.py portal/tests/test_rbac.py portal/tests/test_service_units.py portal/tests/test_auth_tenant_rbac_certification.py -q` — PASS, 205 tests.
- `python -m pytest --tb=short -q` — PASS, 378 tests (only pre-existing PytestCollectionWarnings on sigma/zero agents, unrelated).
- `python scripts/ci/validate_repository_claims.py` — PASS, no documentation/claim drift detected.
- `python scripts/ci/report_test_inventory.py` — PASS, collection_status ok, authoritative true.
- `ruff check . --output-format=github` — PASS, clean.
- `git diff --check` — PASS, clean.
- JSON schema validation (8/8 required files, 9/9 required fields each) — PASS.

## Dynamic route totals (from current application enumeration)

- HTTP routes under `/api/v1/`: 93
- Explicit public exceptions: 11
- Protected routes with recognized guard: 82
- WebSocket routes discovered dynamically: 6

## Evidence-file inventory

All evidence under `docs/certification/auth-tenant-rbac/increment-1/`. Every JSON artifact is an object containing the required schema fields (`schema_version`, `repository`, `baseline_commit`, `evidence_commit`, `generation_method`, `source_files`, `source_tests`, `result`, `limitations`) plus an immutable `generated_from_commit` provenance anchor:

- `certification-report.md` — human-readable certification summary with provenance semantics
- `authentication-authority.json` — 14 authentication fail-closed cases
- `route-permission-matrix.json` — 93 dynamic route records under `routes` key
- `tenant-boundary-matrix.json` — billing and RBAC tenant-isolation results (statuses match tests)
- `negative-test-results.json` — command results + grouped negative cases
- `non-http-entrypoints.json` — websocket / scheduler / background / CLI / service-to-service classification
- `audit-evidence.json` — one real protected-flow audit correlation
- `known-limitations.json` — accepted limitations
- `decision-log.json` — 4 defect-to-correction mappings (including Blackstone)
- `rollback.md` — revert procedure

## Non-HTTP classification

- WebSocket routes (6): `portal.portal.admin.dashboard` (`/admin/ws`), `portal.docket.docket_api` (`/api/v1/docket/live/{case_id}`), `portal.performance.performance_api` (`/performance/stream`), `portal.workflow_builder.workflow_api` (`/workflows/tui`), `portal.core.universe.hive_mind_api` (`/ws/hive-mind`, `/ws/messages/{agent_id}`). Classification: ISOLATED NON-PRODUCTION / OUT OF SUPPORTED SCOPE.
- Background tasks, scheduler jobs, CLI/admin scripts, service-to-service invocations: none discovered.

## Audit-correlation result

One real protected flow (`invoice_create` in `billing.create_invoice`) records `user_id`, `tenant_id`, `resource_type`, `resource_id`, `resource_name`, `tenant_scope`, `outcome = PASS`. `request_id` is not consistently populated by current router audit call sites; this is recorded accurately as a limitation, not claimed as complete traceability.

## Known limitations

1. Public exception routes remain public by design.
2. The certification test fixture uses a short HS256 key, which raises a PyJWT `InsecureKeyLengthWarning` but does not fail the gate.
3. `request_id` is not consistently populated by current router audit call sites; full request traceability is not claimed (deferred to the next increment: Audit Correlation and Non-HTTP Authorization Certification).

## Certification conclusion

**CERTIFIED FOR THE RECORDED SCOPE.**

All 15 frozen-head review findings are resolved. The four security defects are corrected in the immutable security subject commit, all regression tests pass (20 cert + 205 focused + 378 full), the dynamic route graph is enumerated (93 HTTP, 82 protected, 11 public exceptions, 0 unguarded in supported scope, 6 websocket), tenant isolation and RBAC escalation controls are verified with statuses matching executed behavior, audit correlation is demonstrated, every JSON evidence artifact satisfies the required schema with immutable provenance, certification helpers are deterministic, and all required exact-head CI workflows are green.

No remaining supported cross-tenant access, fail-open authentication, privilege escalation, or ungoverned supported entry point was found.

## PR state

This PR is **ready for review** and **not merged**. No merge authorization is granted by this body. Merge remains separately gated pending a final frozen-head audit returning `MERGE`.