### PR TITLE
ci(docker): suppress image-history scan matches

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -41,9 +41,10 @@ jobs:
 
       - name: Inspect image history for secret-bearing build instructions
         run: |
+          set -euo pipefail
           docker history --no-trunc sintraprime-unified:build-verification > /tmp/sintraprime-image-history.txt
-          if grep -Ei 'TWIN_AUTH_TOKEN|POSTGRES_PASSWORD|SECRET_KEY|JWT_SECRET|MINIO_ROOT_USER|MINIO_PASSWORD|AWS_SECRET_ACCESS_KEY|STRIPE_SECRET_KEY' /tmp/sintraprime-image-history.txt; then
-            echo "Secret-bearing instruction found in image history" >&2
+          if grep -qEi 'TWIN_AUTH_TOKEN|POSTGRES_PASSWORD|SECRET_KEY|JWT_SECRET|MINIO_ROOT_USER|MINIO_PASSWORD|AWS_SECRET_ACCESS_KEY|STRIPE_SECRET_KEY' /tmp/sintraprime-image-history.txt; then
+            echo "Secret-bearing instruction detected in image history; details withheld from logs." >&2
             exit 1
           fi
-          echo "Image history contains no configured runtime-secret names."
+          echo "Image history scan passed; no configured runtime-secret names detected."


### PR DESCRIPTION
## Summary

Suppresses image-history scan matches in the Docker Image Build Verification workflow.

## Original finding

Post-merge Copilot review on PR #221 observed that the image-history scan used output-producing `grep -Ei`. If a secret-bearing instruction ever appeared in `docker history`, the matching history line could be printed into GitHub Actions logs before the job failed.

## Risk

The scan is intended to detect secret-bearing image history. Printing the matching line on detection creates a log-disclosure risk in the exact failure mode the check is meant to catch.

## Correction

- Adds `set -euo pipefail` to the image-history inspection step.
- Replaces output-producing `grep -Ei` with quiet `grep -qEi`.
- On detection, prints only a generic failure message and exits nonzero.
- On clean history, prints only a generic pass message.
- Does not change the secret-name pattern set.
- Does not print full Docker history to logs.

## Verification

Local verification from `C:\Users\admin\Desktop\Projects\SintraPrime-Unified-docker-scan-fix`:

Positive clean-history test:
- Scanner exited zero.
- Output was generic pass text only.
- No history lines printed.

Negative synthetic matching-history test:
- Synthetic history file contained a fake `TWIN_AUTH_TOKEN` marker.
- Scanner exited nonzero.
- Output was generic failure text only.
- Matching history line was not printed.
- Fake marker value was not printed.

Workflow/build checks:
- Workflow YAML parsed successfully.
- Workflow contains `grep -qEi` and `set -euo pipefail`.
- Workflow contains no `set -x`.
- Canonical image build passed:
  - `docker build --file Dockerfile --tag sintraprime-unified:build-verification .`
- Normal image-history scan passed.
- Workflow contains no registry login, image push, or deployment command.
- Runtime Compose remains fail-closed with missing required runtime secrets.
- Twin auth remains required by runtime Compose.
- Changed-file secret scan passed.
- `git diff --check` passed.
- Changed-file scope audit passed.

## Exact changed files

- `.github/workflows/docker-build.yml`

## Rollback

Before merge, close this draft PR and delete the source branch only if authorized.

After merge, revert the single PR-F commit:

```bash
git revert 37e7e55c91719b6e8f520636e028d66247745aac
```

## Nonclaims

This PR does not:

- change Docker build scope
- change runtime Compose
- change runtime authentication
- configure secrets
- inspect secret values
- push images
- deploy services
- modify PR-B or PR-C
- modify workshop, migration, payment, or runtime-auth files

## PR #221 status

PR #221 remains valid overall. This PR only remediates the post-merge review finding about log-safe negative-path scanner behavior.
