### PR TITLE
feat: add governed agent capability stack boundary

### DIFF
--- a/agent_capabilities/__init__.py
+++ b/agent_capabilities/__init__.py
@@ -1,0 +1,40 @@
+"""Governed, provider-neutral capabilities for SintraPrime agents.
+
+External projects such as browser-use, Crawl4AI, Firecrawl, Mem0, RAGFlow,
+and LocalAI can be integrated behind these contracts without granting them
+execution authority inside the platform.
+"""
+
+from .contracts import (
+    ActionDecision,
+    ActionPolicy,
+    BrowserAction,
+    BrowserActor,
+    CapabilityError,
+    Citation,
+    KnowledgeRetriever,
+    MemoryRecord,
+    MemoryStore,
+    RetrievalResult,
+    WebDocument,
+    WebReader,
+)
+from .memory import GovernedMemoryStore
+from .policy import DefaultActionPolicy
+
+__all__ = [
+    "ActionDecision",
+    "ActionPolicy",
+    "BrowserAction",
+    "BrowserActor",
+    "CapabilityError",
+    "Citation",
+    "DefaultActionPolicy",
+    "GovernedMemoryStore",
+    "KnowledgeRetriever",
+    "MemoryRecord",
+    "MemoryStore",
+    "RetrievalResult",
+    "WebDocument",
+    "WebReader",
+]

--- a/agent_capabilities/contracts.py
+++ b/agent_capabilities/contracts.py
@@ -1,0 +1,147 @@
+"""Provider-neutral capability contracts.
+
+These interfaces deliberately separate reading, retrieval, memory, and browser
+mutation.  Adapters may call third-party or self-hosted tools, but SintraPrime
+retains policy authority and audit responsibility.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+
+class CapabilityError(RuntimeError):
+    """Raised when a capability adapter cannot safely complete its operation."""
+
+
+@dataclass(frozen=True)
+class Citation:
+    source_id: str
+    locator: str
+    excerpt: str | None = None
+
+
+@dataclass(frozen=True)
+class WebDocument:
+    url: str
+    content: str
+    title: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    retrieved_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+
+
+@dataclass(frozen=True)
+class MemoryRecord:
+    memory_id: str
+    tenant_id: str
+    subject_id: str
+    text: str
+    tags: tuple[str, ...] = ()
+    sensitivity: str = "internal"
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    expires_at: datetime | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RetrievalResult:
+    content: str
+    score: float
+    citations: tuple[Citation, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class BrowserAction:
+    action: str
+    target: str
+    value: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class ActionDecision(str, Enum):
+    ALLOW = "allow"
+    REQUIRE_APPROVAL = "require_approval"
+    DENY = "deny"
+
+
+class WebReader(ABC):
+    """Read-only website ingestion (Firecrawl/Crawl4AI-style capability)."""
+
+    @abstractmethod
+    async def read(self, url: str, *, tenant_id: str) -> WebDocument:
+        raise NotImplementedError
+
+
+class BrowserActor(ABC):
+    """State-changing browser operation (browser-use-style capability)."""
+
+    @abstractmethod
+    async def act(
+        self,
+        action: BrowserAction,
+        *,
+        tenant_id: str,
+        actor_id: str,
+        approval_id: str | None = None,
+    ) -> Mapping[str, Any]:
+        raise NotImplementedError
+
+
+class MemoryStore(ABC):
+    """Durable, tenant-scoped agent memory."""
+
+    @abstractmethod
+    async def put(self, record: MemoryRecord) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def search(
+        self,
+        *,
+        tenant_id: str,
+        subject_id: str,
+        query: str,
+        limit: int = 5,
+    ) -> Sequence[MemoryRecord]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def delete(self, *, tenant_id: str, memory_id: str) -> bool:
+        raise NotImplementedError
+
+
+class KnowledgeRetriever(ABC):
+    """Citation-bearing retrieval over private knowledge."""
+
+    @abstractmethod
+    async def retrieve(
+        self,
+        query: str,
+        *,
+        tenant_id: str,
+        limit: int = 5,
+    ) -> Sequence[RetrievalResult]:
+        raise NotImplementedError
+
+
+class ActionPolicy(ABC):
+    """SintraPrime-owned authority gate for external browser adapters."""
+
+    @abstractmethod
+    def decide(
+        self,
+        action: BrowserAction,
+        *,
+        tenant_id: str,
+        actor_id: str,
+    ) -> ActionDecision:
+        raise NotImplementedError

--- a/agent_capabilities/memory.py
+++ b/agent_capabilities/memory.py
@@ -1,0 +1,73 @@
+"""A dependency-free governed memory implementation.
+
+This is intentionally small: it establishes tenant isolation, expiry, deletion,
+and deterministic retrieval semantics before any Mem0/vector-store adapter is
+allowed into the runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from datetime import datetime, timezone
+
+from .contracts import MemoryRecord, MemoryStore
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokens(value: str) -> set[str]:
+    return set(_TOKEN_RE.findall(value.lower()))
+
+
+class GovernedMemoryStore(MemoryStore):
+    """In-process reference store with strict tenant and subject boundaries."""
+
+    def __init__(self) -> None:
+        self._records: dict[tuple[str, str], MemoryRecord] = {}
+        self._lock = asyncio.Lock()
+
+    async def put(self, record: MemoryRecord) -> None:
+        if not record.tenant_id.strip():
+            raise ValueError("tenant_id is required")
+        if not record.subject_id.strip():
+            raise ValueError("subject_id is required")
+        if not record.text.strip():
+            raise ValueError("memory text is required")
+        async with self._lock:
+            self._records[(record.tenant_id, record.memory_id)] = record
+
+    async def search(
+        self,
+        *,
+        tenant_id: str,
+        subject_id: str,
+        query: str,
+        limit: int = 5,
+    ) -> list[MemoryRecord]:
+        if limit < 1:
+            return []
+        now = datetime.now(timezone.utc)
+        query_tokens = _tokens(query)
+        ranked: list[tuple[float, datetime, MemoryRecord]] = []
+
+        async with self._lock:
+            for (record_tenant, _), record in self._records.items():
+                if record_tenant != tenant_id or record.subject_id != subject_id:
+                    continue
+                if record.expires_at is not None and record.expires_at <= now:
+                    continue
+                haystack = _tokens(" ".join((record.text, *record.tags)))
+                overlap = len(query_tokens & haystack)
+                union = len(query_tokens | haystack) or 1
+                score = overlap / union
+                if query_tokens and score == 0:
+                    continue
+                ranked.append((score, record.created_at, record))
+
+        ranked.sort(key=lambda item: (item[0], item[1]), reverse=True)
+        return [item[2] for item in ranked[:limit]]
+
+    async def delete(self, *, tenant_id: str, memory_id: str) -> bool:
+        async with self._lock:
+            return self._records.pop((tenant_id, memory_id), None) is not None

--- a/agent_capabilities/policy.py
+++ b/agent_capabilities/policy.py
@@ -1,0 +1,45 @@
+"""Default authority policy for browser automation."""
+
+from __future__ import annotations
+
+from .contracts import ActionDecision, ActionPolicy, BrowserAction
+
+
+class DefaultActionPolicy(ActionPolicy):
+    """Fail closed for consequential actions and permit read-only navigation.
+
+    Provider adapters must call this policy before execution.  A later adapter
+    can connect decisions to Mission Control receipts and approval records.
+    """
+
+    _READ_ONLY = frozenset({"open", "navigate", "read", "scroll", "screenshot"})
+    _APPROVAL_REQUIRED = frozenset(
+        {
+            "click",
+            "type",
+            "upload",
+            "download",
+            "submit",
+            "send",
+            "purchase",
+            "sign",
+            "file",
+            "delete",
+        }
+    )
+
+    def decide(
+        self,
+        action: BrowserAction,
+        *,
+        tenant_id: str,
+        actor_id: str,
+    ) -> ActionDecision:
+        if not tenant_id.strip() or not actor_id.strip():
+            return ActionDecision.DENY
+        normalized = action.action.strip().lower()
+        if normalized in self._READ_ONLY:
+            return ActionDecision.ALLOW
+        if normalized in self._APPROVAL_REQUIRED:
+            return ActionDecision.REQUIRE_APPROVAL
+        return ActionDecision.DENY

--- a/docs/agent-capability-stack.md
+++ b/docs/agent-capability-stack.md
@@ -1,0 +1,69 @@
+# Governed Agent Capability Stack
+
+## Decision
+
+SintraPrime will integrate **capabilities**, not surrender orchestration authority to a second agent framework.
+
+The platform already has agent protocols, Mission Control, tenant boundaries, audit requirements, and governance authority. CrewAI, AutoGen/Microsoft Agent Framework, and Langflow therefore remain evaluation references rather than runtime dependencies.
+
+## Selected capabilities
+
+| Capability | Preferred integration posture | Reason |
+|---|---|---|
+| Durable memory | Mem0-compatible adapter behind `MemoryStore` | Useful token reduction and cross-session recall, but only after tenant isolation, deletion, expiry, provenance, and sensitivity controls are certified. |
+| Private-document retrieval | RAGFlow-compatible adapter behind `KnowledgeRetriever` | Strong document structure and citation model; retrieval results must always carry source locators. |
+| Self-hosted web reading | Crawl4AI-compatible adapter behind `WebReader` | Privacy and cost control. Firecrawl may be an optional managed fallback, not the authority layer. |
+| Browser action | browser-use-compatible adapter behind `BrowserActor` | Only for sites without suitable APIs. Every consequential action passes an explicit SintraPrime policy and approval gate. |
+| Private model endpoint | LocalAI-compatible OpenAI endpoint | Useful deployment option, but model routing stays in SintraPrime's provider boundary. |
+
+## Explicitly deferred
+
+- **AnythingLLM:** overlaps the existing SintraPrime portal and would create a second user/permission surface.
+- **CrewAI / AutoGen / Langflow:** overlap orchestration and would create competing execution semantics.
+- **Direct vendor SDK imports in domain code:** prohibited. Only adapters may depend on third-party packages.
+- **Autonomous filing, purchasing, signing, sending, or deletion:** prohibited without recorded human approval.
+
+## Authority model
+
+1. Domain agents request a capability through a SintraPrime contract.
+2. Tenant and actor identity are mandatory.
+3. Read-only operations may proceed under policy.
+4. State-changing browser actions require approval or are denied.
+5. Adapters return normalized results, citations, and metadata.
+6. Mission Control will record request, policy decision, provider, result, and correlation identifiers.
+
+## Certification increments
+
+### Increment 1 — contracts and reference controls
+
+Delivered in this branch:
+
+- provider-neutral contracts for web reading, browser action, memory, and retrieval;
+- dependency-free governed memory reference implementation;
+- fail-closed browser-action policy;
+- tests for tenant isolation, subject isolation, expiry, deletion, approval, and denial.
+
+### Increment 2 — persistence and audit
+
+- PostgreSQL-backed memory records with migration authority;
+- encryption classification and redaction boundary;
+- Mission Control receipts for memory and browser decisions;
+- retention and user-directed deletion tests;
+- persistence restart tests.
+
+### Increment 3 — provider adapters
+
+- Crawl4AI read-only adapter first;
+- Mem0 adapter second;
+- RAGFlow adapter third;
+- browser-use adapter only after approval receipts exist;
+- LocalAI endpoint certification through the existing model-provider layer.
+
+## Non-negotiable acceptance criteria
+
+- no cross-tenant or cross-subject memory retrieval;
+- no memory without provenance and sensitivity classification in persistent implementations;
+- no citation-free private-knowledge answer represented as grounded;
+- no consequential browser mutation without a valid approval receipt;
+- no provider can bypass SintraPrime policy, RBAC, audit, or redaction boundaries;
+- all external integrations remain optional and fail closed.

--- a/tests/test_agent_capabilities.py
+++ b/tests/test_agent_capabilities.py
@@ -1,0 +1,102 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agent_capabilities import (
+    ActionDecision,
+    BrowserAction,
+    DefaultActionPolicy,
+    GovernedMemoryStore,
+    MemoryRecord,
+)
+
+
+@pytest.mark.asyncio
+async def test_memory_is_tenant_and_subject_scoped() -> None:
+    store = GovernedMemoryStore()
+    await store.put(
+        MemoryRecord(
+            memory_id="m-1",
+            tenant_id="tenant-a",
+            subject_id="user-1",
+            text="User prefers citation-bearing legal research.",
+            tags=("preference", "citations"),
+        )
+    )
+
+    visible = await store.search(
+        tenant_id="tenant-a",
+        subject_id="user-1",
+        query="legal citations",
+    )
+    wrong_tenant = await store.search(
+        tenant_id="tenant-b",
+        subject_id="user-1",
+        query="legal citations",
+    )
+    wrong_subject = await store.search(
+        tenant_id="tenant-a",
+        subject_id="user-2",
+        query="legal citations",
+    )
+
+    assert [record.memory_id for record in visible] == ["m-1"]
+    assert wrong_tenant == []
+    assert wrong_subject == []
+
+
+@pytest.mark.asyncio
+async def test_expired_memory_is_not_returned_and_can_be_deleted() -> None:
+    store = GovernedMemoryStore()
+    await store.put(
+        MemoryRecord(
+            memory_id="expired",
+            tenant_id="tenant-a",
+            subject_id="user-1",
+            text="Temporary fact",
+            expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        )
+    )
+
+    assert await store.search(
+        tenant_id="tenant-a", subject_id="user-1", query="temporary"
+    ) == []
+    assert await store.delete(tenant_id="tenant-a", memory_id="expired") is True
+    assert await store.delete(tenant_id="tenant-a", memory_id="expired") is False
+
+
+def test_default_action_policy_fails_closed() -> None:
+    policy = DefaultActionPolicy()
+
+    assert (
+        policy.decide(
+            BrowserAction(action="read", target="https://example.test"),
+            tenant_id="tenant-a",
+            actor_id="agent-1",
+        )
+        is ActionDecision.ALLOW
+    )
+    assert (
+        policy.decide(
+            BrowserAction(action="submit", target="#court-filing"),
+            tenant_id="tenant-a",
+            actor_id="agent-1",
+        )
+        is ActionDecision.REQUIRE_APPROVAL
+    )
+    assert (
+        policy.decide(
+            BrowserAction(action="execute-javascript", target="document"),
+            tenant_id="tenant-a",
+            actor_id="agent-1",
+        )
+        is ActionDecision.DENY
+    )
+    assert (
+        policy.decide(
+            BrowserAction(action="read", target="https://example.test"),
+            tenant_id="",
+            actor_id="agent-1",
+        )
+        is ActionDecision.DENY
+    )


### PR DESCRIPTION
## Summary

Introduces a provider-neutral boundary for selected capabilities from the open-source agent ecosystem without replacing SintraPrime's existing orchestration, governance, RBAC, or Mission Control authority.

### Implemented

- `WebReader` contract for read-only Crawl4AI/Firecrawl-style ingestion
- `BrowserActor` contract separated from reading
- `MemoryStore` contract plus dependency-free governed reference implementation
- `KnowledgeRetriever` contract requiring citation-bearing results
- fail-closed `ActionPolicy` for browser operations
- tenant/subject isolation, expiry, deletion, approval, and denial tests
- architecture decision and staged certification plan

### Architectural ruling

Adopt capabilities, not overlapping platforms:

- advance: Mem0-compatible memory, RAGFlow-compatible retrieval, Crawl4AI-compatible reading, browser-use-compatible action, LocalAI-compatible provider endpoint
- defer: CrewAI, AutoGen/Microsoft Agent Framework, Langflow, AnythingLLM as runtime dependencies because SintraPrime already owns orchestration and portal authority

## Verification status

Code and tests were added through the GitHub connector. The repository test lane has **not** been executed in this environment. Keep this PR draft until CI and local verification are green.

## Next certification increment

1. PostgreSQL persistence and migration authority
2. Mission Control receipts and correlation IDs
3. retention/redaction/provenance controls
4. Crawl4AI adapter as the first external provider
5. Mem0 and RAGFlow adapters after persistence controls pass
6. browser-use adapter only after approval receipts are certified
