### PR TITLE
feat(credit-command-center): add FCRA reinvestigation tracking

### DIFF
--- a/packages/credit_command_center/__init__.py
+++ b/packages/credit_command_center/__init__.py
@@ -9,6 +9,7 @@ Core message: "Most disputes fail because the evidence was never organized."
 """
 
 from .helpers import (
+    REINVESTIGATION_EXTENSION_DAYS,
     REINVESTIGATION_WINDOW_DAYS,
     build_case_folder_path,
     build_evidence_folder_path,
@@ -37,6 +38,7 @@ from .models import (
 )
 
 __all__ = [
+    "REINVESTIGATION_EXTENSION_DAYS",
     "REINVESTIGATION_WINDOW_DAYS",
     "AccountStatus",
     "ActionReceipt",

--- a/packages/credit_command_center/__init__.py
+++ b/packages/credit_command_center/__init__.py
@@ -9,11 +9,14 @@ Core message: "Most disputes fail because the evidence was never organized."
 """
 
 from .helpers import (
+    REINVESTIGATION_WINDOW_DAYS,
     build_case_folder_path,
     build_evidence_folder_path,
     create_receipt,
+    is_reinvestigation_overdue,
     normalize_client_name,
     rate_scorecard,
+    reinvestigation_deadline,
 )
 from .models import (
     AccountStatus,
@@ -26,12 +29,15 @@ from .models import (
     EvidenceItem,
     Finding,
     FindingCategory,
+    Reinvestigation,
+    ReinvestigationStatus,
     Scorecard,
     ScorecardRating,
     ServiceTier,
 )
 
 __all__ = [
+    "REINVESTIGATION_WINDOW_DAYS",
     "AccountStatus",
     "ActionReceipt",
     "Bureau",
@@ -42,12 +48,16 @@ __all__ = [
     "EvidenceItem",
     "Finding",
     "FindingCategory",
+    "Reinvestigation",
+    "ReinvestigationStatus",
     "Scorecard",
     "ScorecardRating",
     "ServiceTier",
     "build_case_folder_path",
     "build_evidence_folder_path",
     "create_receipt",
+    "is_reinvestigation_overdue",
     "normalize_client_name",
     "rate_scorecard",
+    "reinvestigation_deadline",
 ]

--- a/packages/credit_command_center/helpers.py
+++ b/packages/credit_command_center/helpers.py
@@ -6,7 +6,7 @@ Includes folder naming conventions, scorecard rating, and receipt creation.
 from __future__ import annotations
 
 import re
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, timedelta
 
 from .models import ActionReceipt, Scorecard, ScorecardRating
 
@@ -62,6 +62,27 @@ def rate_scorecard(scorecard: Scorecard) -> ScorecardRating:
     Delegates to Scorecard.rating for consistency.
     """
     return scorecard.rating
+
+
+REINVESTIGATION_WINDOW_DAYS = 30  # FCRA 15 USC 1681i reinvestigation timeframe
+
+
+def _parse_date(value: str) -> date:
+    """Parse a YYYY-MM-DD date string."""
+    return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=UTC).date()
+
+
+def reinvestigation_deadline(opened: str) -> str:
+    """Return the 1681i deadline (opened + 30 days) as YYYY-MM-DD."""
+    opened_d = _parse_date(opened)
+    return (opened_d + timedelta(days=REINVESTIGATION_WINDOW_DAYS)).isoformat()
+
+
+def is_reinvestigation_overdue(opened: str, today: str | None = None) -> bool:
+    """True if the 1681i deadline has passed relative to `today` (default: now)."""
+    opened_d = _parse_date(opened)
+    ref = _parse_date(today) if today else datetime.now(UTC).date()
+    return ref > (opened_d + timedelta(days=REINVESTIGATION_WINDOW_DAYS))
 
 
 def create_receipt(

--- a/packages/credit_command_center/helpers.py
+++ b/packages/credit_command_center/helpers.py
@@ -64,25 +64,57 @@ def rate_scorecard(scorecard: Scorecard) -> ScorecardRating:
     return scorecard.rating
 
 
-REINVESTIGATION_WINDOW_DAYS = 30  # FCRA 15 USC 1681i reinvestigation timeframe
+REINVESTIGATION_WINDOW_DAYS = 30  # FCRA 15 USC 1681i standard reinvestigation period
+REINVESTIGATION_EXTENSION_DAYS = 15  # Additional days allowed under 1681i(a)(1)(B)
 
 
 def _parse_date(value: str) -> date:
-    """Parse a YYYY-MM-DD date string."""
-    return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=UTC).date()
+    """Parse a YYYY-MM-DD date string. Raises ValueError on invalid input."""
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=UTC).date()
+    except ValueError as exc:
+        raise ValueError(f"Invalid date format: '{value}'. Expected YYYY-MM-DD.") from exc
 
 
-def reinvestigation_deadline(opened: str) -> str:
-    """Return the 1681i deadline (opened + 30 days) as YYYY-MM-DD."""
+def reinvestigation_deadline(
+    opened: str,
+    *,
+    extension_applies: bool = False,
+) -> str:
+    """Return the FCRA 15 USC 1681i reinvestigation deadline as YYYY-MM-DD.
+
+    The standard period is 30 calendar days from the dispute's opened date.
+    When extension_applies=True (per 1681i(a)(1)(B) — an additional up-to-15
+    days because the CRA received qualifying relevant consumer information
+    during the initial period), the deadline is 45 calendar days from opened.
+
+    The caller is responsible for determining whether the statutory extension
+    legally applies. This helper does not automatically infer eligibility.
+    """
     opened_d = _parse_date(opened)
-    return (opened_d + timedelta(days=REINVESTIGATION_WINDOW_DAYS)).isoformat()
+    days = REINVESTIGATION_WINDOW_DAYS + (
+        REINVESTIGATION_EXTENSION_DAYS if extension_applies else 0
+    )
+    return (opened_d + timedelta(days=days)).isoformat()
 
 
-def is_reinvestigation_overdue(opened: str, today: str | None = None) -> bool:
-    """True if the 1681i deadline has passed relative to `today` (default: now)."""
+def is_reinvestigation_overdue(
+    opened: str,
+    today: str | None = None,
+    *,
+    extension_applies: bool = False,
+) -> bool:
+    """True if the FCRA 1681i deadline has passed relative to *today* (default: now).
+
+    Uses the same period logic as reinvestigation_deadline: 30 days standard,
+    45 days when extension_applies=True.
+    """
     opened_d = _parse_date(opened)
     ref = _parse_date(today) if today else datetime.now(UTC).date()
-    return ref > (opened_d + timedelta(days=REINVESTIGATION_WINDOW_DAYS))
+    days = REINVESTIGATION_WINDOW_DAYS + (
+        REINVESTIGATION_EXTENSION_DAYS if extension_applies else 0
+    )
+    return ref > (opened_d + timedelta(days=days))
 
 
 def create_receipt(

--- a/packages/credit_command_center/models.py
+++ b/packages/credit_command_center/models.py
@@ -81,6 +81,15 @@ class ScorecardRating(StrEnum):
     HIGH_RISK = "high_risk"
 
 
+class ReinvestigationStatus(StrEnum):
+    """FCRA 15 USC 1681i reinvestigation lifecycle."""
+
+    NOT_STARTED = "not_started"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
 # ── Models ───────────────────────────────────────────────────────────────────
 
 
@@ -157,7 +166,9 @@ class ActionReceipt(BaseModel):
     case_id: str
     timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     actor: str = Field(..., description="Who performed the action (Hermes / Isiah / System)")
-    action: str = Field(..., description="e.g. intake_received, document_cataloged, finding_created")
+    action: str = Field(
+        ..., description="e.g. intake_received, document_cataloged, finding_created"
+    )
     details: dict = Field(default_factory=dict)
     file_path: str | None = None
 
@@ -207,3 +218,14 @@ class Scorecard(BaseModel):
             "evidence": self.evidence,
             "follow_up": self.follow_up,
         }
+
+
+class Reinvestigation(BaseModel):
+    """FCRA 15 USC 1681i reinvestigation record for a disputed account."""
+
+    case_id: str = Field(..., description="Owning case, format C-0001")
+    account_ref: str = Field(..., description="Disputed account reference")
+    status: ReinvestigationStatus = ReinvestigationStatus.NOT_STARTED
+    opened_date: str = Field(..., description="Date dispute initiated (YYYY-MM-DD)")
+    completed_date: str | None = None
+    result_summary: str | None = None

--- a/tests/test_fcra_reinvestigation.py
+++ b/tests/test_fcra_reinvestigation.py
@@ -1,8 +1,15 @@
-"""Tests for FCRA 15 USC 1681i reinvestigation support (research-identified gap)."""
+"""Tests for FCRA 15 USC 1681i reinvestigation support (research-identified gap).
+
+Covers standard 30-day window, 15-day extension under 1681i(a)(1)(B),
+deadline and overdue helpers, model defaults, and input validation.
+"""
 
 from __future__ import annotations
 
+import pytest
+
 from packages.credit_command_center import (
+    REINVESTIGATION_EXTENSION_DAYS,
     REINVESTIGATION_WINDOW_DAYS,
     Reinvestigation,
     ReinvestigationStatus,
@@ -11,23 +18,65 @@ from packages.credit_command_center import (
 )
 
 
-def test_window_is_30_days():
-    assert REINVESTIGATION_WINDOW_DAYS == 30
+class TestReinvestigationWindowConstants:
+    def test_standard_window_is_30_days(self):
+        assert REINVESTIGATION_WINDOW_DAYS == 30
+
+    def test_extension_is_15_days(self):
+        assert REINVESTIGATION_EXTENSION_DAYS == 15
 
 
-def test_deadline_adds_30_days():
-    assert reinvestigation_deadline("2026-01-01") == "2026-01-31"
+class TestReinvestigationDeadline:
+    def test_standard_deadline_adds_30_days(self):
+        assert reinvestigation_deadline("2026-01-01") == "2026-01-31"
+
+    def test_authorized_extension_adds_45_days(self):
+        assert reinvestigation_deadline("2026-01-01", extension_applies=True) == "2026-02-15"
+
+    def test_extension_defaults_to_false(self):
+        assert reinvestigation_deadline("2026-01-01") == reinvestigation_deadline(
+            "2026-01-01", extension_applies=False
+        )
 
 
-def test_not_overdue_within_window():
-    assert is_reinvestigation_overdue("2026-01-01", today="2026-01-20") is False
+class TestReinvestigationOverdue:
+    def test_not_overdue_within_standard_window(self):
+        assert is_reinvestigation_overdue("2026-01-01", today="2026-01-20") is False
+
+    def test_overdue_after_standard_window_no_extension(self):
+        assert is_reinvestigation_overdue("2026-01-01", today="2026-02-01") is True
+
+    def test_not_overdue_inside_extension_period(self):
+        """When extension applies, deadline is +45 days; day +35 is not overdue."""
+        assert (
+            is_reinvestigation_overdue("2026-01-01", today="2026-02-05", extension_applies=True)
+            is False
+        )
+
+    def test_overdue_after_extension_period(self):
+        assert (
+            is_reinvestigation_overdue("2026-01-01", today="2026-02-16", extension_applies=True)
+            is True
+        )
+
+    def test_extension_defaults_to_false(self):
+        assert is_reinvestigation_overdue(
+            "2026-01-01", today="2026-02-05"
+        ) is is_reinvestigation_overdue("2026-01-01", today="2026-02-05", extension_applies=False)
 
 
-def test_overdue_after_window():
-    assert is_reinvestigation_overdue("2026-01-01", today="2026-02-01") is True
+class TestReinvestigationModel:
+    def test_default_status_is_not_started(self):
+        r = Reinvestigation(case_id="C-0001", account_ref="****1234", opened_date="2026-01-01")
+        assert r.status == ReinvestigationStatus.NOT_STARTED
+        assert r.completed_date is None
 
 
-def test_reinvestigation_model_defaults():
-    r = Reinvestigation(case_id="C-0001", account_ref="****1234", opened_date="2026-01-01")
-    assert r.status == ReinvestigationStatus.NOT_STARTED
-    assert r.completed_date is None
+class TestInvalidDateInput:
+    def test_invalid_date_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid date format"):
+            reinvestigation_deadline("not-a-date")
+
+    def test_invalid_overdue_date_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid date format"):
+            is_reinvestigation_overdue("01/01/2026", today="2026-01-20")

--- a/tests/test_fcra_reinvestigation.py
+++ b/tests/test_fcra_reinvestigation.py
@@ -1,0 +1,33 @@
+"""Tests for FCRA 15 USC 1681i reinvestigation support (research-identified gap)."""
+
+from __future__ import annotations
+
+from packages.credit_command_center import (
+    REINVESTIGATION_WINDOW_DAYS,
+    Reinvestigation,
+    ReinvestigationStatus,
+    is_reinvestigation_overdue,
+    reinvestigation_deadline,
+)
+
+
+def test_window_is_30_days():
+    assert REINVESTIGATION_WINDOW_DAYS == 30
+
+
+def test_deadline_adds_30_days():
+    assert reinvestigation_deadline("2026-01-01") == "2026-01-31"
+
+
+def test_not_overdue_within_window():
+    assert is_reinvestigation_overdue("2026-01-01", today="2026-01-20") is False
+
+
+def test_overdue_after_window():
+    assert is_reinvestigation_overdue("2026-01-01", today="2026-02-01") is True
+
+
+def test_reinvestigation_model_defaults():
+    r = Reinvestigation(case_id="C-0001", account_ref="****1234", opened_date="2026-01-01")
+    assert r.status == ReinvestigationStatus.NOT_STARTED
+    assert r.completed_date is None


### PR DESCRIPTION
## Problem
The Credit Command Center v1 models dispute cases but provides no FCRA 15 USC 1681i reinvestigation support: no 30-day window, no reinvestigation status, no overdue detection. Identified as gap F2/F3 in IKE research validation.

## Scope
- ReinvestigationStatus enum (NOT_STARTED / IN_PROGRESS / COMPLETED / FAILED)
- Reinvestigation model (case_id, account_ref, status, opened_date, completed_date, result_summary)
- REINVESTIGATION_WINDOW_DAYS = 30 and REINVESTIGATION_EXTENSION_DAYS = 15 constants
- Deadline and overdue helpers with explicit extension logic
- Package exports updated
- Updated deadline-logic tests and input-validation tests

## Files Changed
```
packages/credit_command_center/models.py   | 24 +++++++++++++++++++-
packages/credit_command_center/helpers.py  | 23 ++++++++++++++++++-
packages/credit_command_center/__init__.py | 12 +++++++++++
tests/test_fcra_reinvestigation.py        | 58 ++++++++++++++++++++++++++++++++++
4 files changed, 107 insertions(+), 24 deletions(-)
```

## Test Evidence
Collection counts:
```text
tests/test_fcra_reinvestigation.py: 13
tests/test_credit_command_center.py: 44
```

Combined passing total:
```text
.........................................................                [100%]
```

57 tests collected total (13 + 44); all 57 passed.

## Correction Commit Scope
Commit `57b0705d8aba6867a69a864cd84a311d56407ccf` changed exactly three files:
```text
packages/credit_command_center/__init__.py
packages/credit_command_center/helpers.py
tests/test_fcra_reinvestigation.py
```

The `packages/credit_command_center/__init__.py` change exports `REINVESTIGATION_EXTENSION_DAYS` through the package root, which is required by the tests. The complete PR still changes exactly four files across the full diff.

## Regression Evidence
All 44 existing Credit Command Center tests continue to pass. The 13 FCRA reinvestigation tests validate standard and authorized-extension deadline behavior. The additions are strictly additive — no existing API changed.


## Quality Checks
- ruff: All checks passed
- ruff format: 4 files already formatted
- Lint: ok on all modified files

## Known Limitations
- Thirty days is the standard reinvestigation period under FCRA 15 USC 1681i
- An additional 15 days may apply when the statutory extension conditions are satisfied (1681i(a)(1)(B))
- The helper does not determine whether the extension legally applies; the caller is responsible for that determination
- Annual-disclosure timing, furnisher-notice requirements, bureau submission, consumer notification, and other procedural nuances remain deferred
- Live CFPB guidance and state variation handling are not yet implemented

## Explicitly Deferred Work
- Automated bureau dispute submission
- Consumer notice generation (1681i results notification)
- CFPB guidance integration
- State variation handling

## Verification Confidence
High.

## IKE Certification Reference
Local certification record: `Knowledge_Vault/08_SOPs/IKE_CERTIFICATION_REPORT_v1.0.md` (not contained in this repository).
