### PR TITLE
chore(deploy-staging): migrate AWS auth to GitHub OIDC

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -9,39 +9,42 @@ on:
       - 'packages/**'
       - '.github/workflows/deploy-staging.yml'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_STAGING_ROLE_ARN }}
           aws-region: us-east-1
-      
+
       - name: Build Docker image
         run: |
           docker build -t sintraprime-unified:staging .
           aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${{ secrets.AWS_ECR_REGISTRY }}
           docker tag sintraprime-unified:staging ${{ secrets.AWS_ECR_REGISTRY }}/sintraprime-unified:staging
           docker push ${{ secrets.AWS_ECR_REGISTRY }}/sintraprime-unified:staging
-      
+
       - name: Update ECS service
         run: |
           aws ecs update-service \
             --cluster staging-sintraprime \
             --service sintraprime-api \
             --force-new-deployment
-      
+
       - name: Wait for deployment
         run: |
           aws ecs wait services-stable \
             --cluster staging-sintraprime \
             --services sintraprime-api
-      
+
       - name: Run smoke tests
         run: |
           curl -f https://staging.sintraprime.dev/health || exit 1


### PR DESCRIPTION
## Summary
Migrate the staging deployment workflow from long-lived static AWS keys to GitHub OIDC with a short-lived IAM role.

## Branch / Commit
- Branch: `chore/deploy-staging-oidc`
- Commit: `66f8d52011511f5602103b42c790e86477d26f11`

## Exact files changed
- `.github/workflows/deploy-staging.yml`

## Workflow diff
- Added top-level permissions:
  - `id-token: write`
  - `contents: read`
- Replaced static AWS credentials with OIDC role assumption:
  - removed `aws-access-key-id`
  - removed `aws-secret-access-key`
  - added `role-to-assume: ${{ secrets.AWS_STAGING_ROLE_ARN }}`
  - retained `aws-region: us-east-1`
- Kept all deploy behavior otherwise unchanged.

## Validation results
- YAML syntax parsed successfully.
- Workflow contains no references to `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY`.
- Workflow includes `id-token: write`.
- Workflow references `AWS_STAGING_ROLE_ARN` for role assumption.
- No unrelated workflow behavior changes were introduced.

## Required GitHub secret/variable changes
- Add repository secret: `AWS_STAGING_ROLE_ARN`
- Keep repository secret: `AWS_ECR_REGISTRY`
- Remove/retire the now-unused repository secrets:
  - `AWS_ACCESS_KEY_ID`
  - `AWS_SECRET_ACCESS_KEY`

## AWS owner actions required
1. Create or confirm the GitHub OIDC provider:
   - Provider URL: `https://token.actions.githubusercontent.com`
   - Audience: `sts.amazonaws.com`
2. Create an IAM role for staging deployment and attach the trust policy below.
3. Attach the least-privilege permissions policy below.
4. Store the role ARN in GitHub as `AWS_STAGING_ROLE_ARN`.
5. Confirm the role can push to ECR and update the ECS service.

### IAM trust policy
```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
      },
      "Action": "sts:AssumeRoleWithWebIdentity",
      "Condition": {
        "StringEquals": {
          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
          "token.actions.githubusercontent.com:sub": "repo:ihoward40/SintraPrime-Unified:ref:refs/heads/main"
        }
      }
    }
  ]
}
```

### IAM permissions policy
```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "EcrLogin",
      "Effect": "Allow",
      "Action": ["ecr:GetAuthorizationToken"],
      "Resource": "*"
    },
    {
      "Sid": "EcrPush",
      "Effect": "Allow",
      "Action": [
        "ecr:BatchCheckLayerAvailability",
        "ecr:CompleteLayerUpload",
        "ecr:InitiateLayerUpload",
        "ecr:PutImage",
        "ecr:UploadLayerPart",
        "ecr:BatchGetImage"
      ],
      "Resource": "arn:aws:ecr:us-east-1:<ACCOUNT_ID>:repository/sintraprime-unified"
    },
    {
      "Sid": "EcsDeploy",
      "Effect": "Allow",
      "Action": [
        "ecs:DescribeClusters",
        "ecs:DescribeServices",
        "ecs:UpdateService"
      ],
      "Resource": [
        "arn:aws:ecs:us-east-1:<ACCOUNT_ID>:cluster/staging-sintraprime",
        "arn:aws:ecs:us-east-1:<ACCOUNT_ID>:service/staging-sintraprime/sintraprime-api"
      ]
    }
  ]
}
```

> Note: `iam:PassRole` is not required by the workflow as written because it does not register a new task definition. If the workflow later gains task-definition registration, add `iam:PassRole` only for the specific ECS execution/task role ARNs.

## Owner note
This PR intentionally does not change AWS infrastructure directly. The AWS-side OIDC provider, IAM role, trust policy, and permissions policy must be applied by the owner before the workflow can be rerun.
