### PR TITLE
Agent Commons Increment 1 — governed supervisor runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ ENV HOST=0.0.0.0
 ENV PORT=8080
 ENV LOG_LEVEL=INFO
 ENV PYTHONUNBUFFERED=1
+# Keep runtime validation aligned with the Gunicorn command below.
+ENV WEB_CONCURRENCY=4
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \

--- a/agent_commons/__init__.py
+++ b/agent_commons/__init__.py
@@ -5,10 +5,10 @@ from .store import AgentCommonsStore
 from .supervisor import GovernedSupervisor, SupervisorPolicy
 
 __all__ = [
+    "AgentCommonsStore",
     "AgentRole",
+    "GovernedSupervisor",
     "LifecycleStatus",
     "RunStatus",
-    "AgentCommonsStore",
-    "GovernedSupervisor",
     "SupervisorPolicy",
 ]

--- a/agent_commons/__init__.py
+++ b/agent_commons/__init__.py
@@ -1,0 +1,14 @@
+"""Governed multi-agent collaboration primitives for SintraPrime-Unified."""
+
+from .models import AgentRole, LifecycleStatus, RunStatus
+from .store import AgentCommonsStore
+from .supervisor import GovernedSupervisor, SupervisorPolicy
+
+__all__ = [
+    "AgentRole",
+    "LifecycleStatus",
+    "RunStatus",
+    "AgentCommonsStore",
+    "GovernedSupervisor",
+    "SupervisorPolicy",
+]

--- a/agent_commons/adapters.py
+++ b/agent_commons/adapters.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Dict, List
+
+
+@dataclass
+class AgentInvocation:
+    run_id: str
+    output: Dict[str, Any]
+    evidence: List[str] = field(default_factory=list)
+
+
+class AgentAdapter(ABC):
+    """Provider-neutral contract for Hermes, Codex, Claude, Manus, OpenAI, and local agents."""
+
+    agent_id: str
+
+    @abstractmethod
+    async def health(self) -> Dict[str, Any]: ...
+
+    @abstractmethod
+    async def capabilities(self) -> List[str]: ...
+
+    @abstractmethod
+    async def invoke(self, task: Dict[str, Any], context: Dict[str, Any]) -> AgentInvocation: ...
+
+    @abstractmethod
+    async def cancel(self, run_id: str) -> bool: ...
+
+    async def stream_events(self, run_id: str) -> AsyncIterator[Dict[str, Any]]:
+        if False:
+            yield {"run_id": run_id}
+
+
+class MockAgentAdapter(AgentAdapter):
+    """Deterministic adapter for tests and local demonstrations."""
+
+    def __init__(self, agent_id: str, capabilities: List[str], response: Dict[str, Any]) -> None:
+        self.agent_id = agent_id
+        self._capabilities = capabilities
+        self._response = response
+        self.invocations: List[Dict[str, Any]] = []
+
+    async def health(self) -> Dict[str, Any]:
+        return {"agent_id": self.agent_id, "status": "ok"}
+
+    async def capabilities(self) -> List[str]:
+        return list(self._capabilities)
+
+    async def invoke(self, task: Dict[str, Any], context: Dict[str, Any]) -> AgentInvocation:
+        self.invocations.append({"task": task, "context": context})
+        return AgentInvocation(run_id=f"{self.agent_id}-{len(self.invocations)}", output=dict(self._response))
+
+    async def cancel(self, run_id: str) -> bool:
+        return True

--- a/agent_commons/adapters.py
+++ b/agent_commons/adapters.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any
 
 
 @dataclass
 class AgentInvocation:
     run_id: str
-    output: Dict[str, Any]
-    evidence: List[str] = field(default_factory=list)
+    output: dict[str, Any]
+    evidence: list[str] = field(default_factory=list)
 
 
 class AgentAdapter(ABC):
@@ -18,18 +19,18 @@ class AgentAdapter(ABC):
     agent_id: str
 
     @abstractmethod
-    async def health(self) -> Dict[str, Any]: ...
+    async def health(self) -> dict[str, Any]: ...
 
     @abstractmethod
-    async def capabilities(self) -> List[str]: ...
+    async def capabilities(self) -> list[str]: ...
 
     @abstractmethod
-    async def invoke(self, task: Dict[str, Any], context: Dict[str, Any]) -> AgentInvocation: ...
+    async def invoke(self, task: dict[str, Any], context: dict[str, Any]) -> AgentInvocation: ...
 
     @abstractmethod
     async def cancel(self, run_id: str) -> bool: ...
 
-    async def stream_events(self, run_id: str) -> AsyncIterator[Dict[str, Any]]:
+    async def stream_events(self, run_id: str) -> AsyncIterator[dict[str, Any]]:
         if False:
             yield {"run_id": run_id}
 
@@ -37,21 +38,21 @@ class AgentAdapter(ABC):
 class MockAgentAdapter(AgentAdapter):
     """Deterministic adapter for tests and local demonstrations."""
 
-    def __init__(self, agent_id: str, capabilities: List[str], response: Dict[str, Any]) -> None:
+    def __init__(self, agent_id: str, capabilities: list[str], response: dict[str, Any]) -> None:
         self.agent_id = agent_id
         self._capabilities = capabilities
         self._response = response
-        self.invocations: List[Dict[str, Any]] = []
+        self.invocations: list[dict[str, Any]] = []
 
-    async def health(self) -> Dict[str, Any]:
+    async def health(self) -> dict[str, Any]:
         return {"agent_id": self.agent_id, "status": "ok"}
 
-    async def capabilities(self) -> List[str]:
+    async def capabilities(self) -> list[str]:
         return list(self._capabilities)
 
-    async def invoke(self, task: Dict[str, Any], context: Dict[str, Any]) -> AgentInvocation:
+    async def invoke(self, task: dict[str, Any], context: dict[str, Any]) -> AgentInvocation:
         self.invocations.append({"task": task, "context": context})
         return AgentInvocation(run_id=f"{self.agent_id}-{len(self.invocations)}", output=dict(self._response))
 
-    async def cancel(self, run_id: str) -> bool:
+    async def cancel(self, _run_id: str) -> bool:
         return True

--- a/agent_commons/events.py
+++ b/agent_commons/events.py
@@ -2,14 +2,18 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from collections.abc import AsyncIterator
+from contextlib import suppress
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, Set
+from typing import Any
 
 
 @dataclass(eq=False)
 class EventSubscription:
     tenant_id: str
-    queue: asyncio.Queue[Dict[str, Any]] = field(default_factory=lambda: asyncio.Queue(maxsize=200))
+    queue: asyncio.Queue[dict[str, Any]] = field(
+        default_factory=lambda: asyncio.Queue(maxsize=200)
+    )
 
 
 class AgentCommonsEventBus:
@@ -20,22 +24,20 @@ class AgentCommonsEventBus:
     """
 
     def __init__(self) -> None:
-        self._subscriptions: dict[str, Set[EventSubscription]] = defaultdict(set)
+        self._subscriptions: dict[str, set[EventSubscription]] = defaultdict(set)
         self._lock = asyncio.Lock()
 
-    async def publish(self, tenant_id: str, event: Dict[str, Any]) -> None:
+    async def publish(self, tenant_id: str, event: dict[str, Any]) -> None:
         payload = {"tenant_id": tenant_id, **event}
         async with self._lock:
             subscribers = tuple(self._subscriptions.get(tenant_id, set()))
         for subscription in subscribers:
             if subscription.queue.full():
-                try:
+                with suppress(asyncio.QueueEmpty):
                     subscription.queue.get_nowait()
-                except asyncio.QueueEmpty:
-                    pass
             await subscription.queue.put(payload)
 
-    async def subscribe(self, tenant_id: str) -> AsyncIterator[Dict[str, Any]]:
+    async def subscribe(self, tenant_id: str) -> AsyncIterator[dict[str, Any]]:
         subscription = EventSubscription(tenant_id=tenant_id)
         async with self._lock:
             self._subscriptions[tenant_id].add(subscription)

--- a/agent_commons/events.py
+++ b/agent_commons/events.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Dict, Set
+
+
+@dataclass(eq=False)
+class EventSubscription:
+    tenant_id: str
+    queue: asyncio.Queue[Dict[str, Any]] = field(default_factory=lambda: asyncio.Queue(maxsize=200))
+
+
+class AgentCommonsEventBus:
+    """Tenant-isolated in-process event fan-out for SSE clients.
+
+    Events are observable state changes only. Private reasoning and hidden
+    chain-of-thought are never published.
+    """
+
+    def __init__(self) -> None:
+        self._subscriptions: dict[str, Set[EventSubscription]] = defaultdict(set)
+        self._lock = asyncio.Lock()
+
+    async def publish(self, tenant_id: str, event: Dict[str, Any]) -> None:
+        payload = {"tenant_id": tenant_id, **event}
+        async with self._lock:
+            subscribers = tuple(self._subscriptions.get(tenant_id, set()))
+        for subscription in subscribers:
+            if subscription.queue.full():
+                try:
+                    subscription.queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            await subscription.queue.put(payload)
+
+    async def subscribe(self, tenant_id: str) -> AsyncIterator[Dict[str, Any]]:
+        subscription = EventSubscription(tenant_id=tenant_id)
+        async with self._lock:
+            self._subscriptions[tenant_id].add(subscription)
+        try:
+            while True:
+                yield await subscription.queue.get()
+        finally:
+            async with self._lock:
+                self._subscriptions[tenant_id].discard(subscription)
+                if not self._subscriptions[tenant_id]:
+                    self._subscriptions.pop(tenant_id, None)

--- a/agent_commons/events.py
+++ b/agent_commons/events.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from collections.abc import AsyncIterator
 from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any
@@ -19,8 +18,8 @@ class EventSubscription:
 class AgentCommonsEventBus:
     """Tenant-isolated in-process event fan-out for SSE clients.
 
-    Events are observable state changes only. Private reasoning and hidden
-    chain-of-thought are never published.
+    This implementation is safe only for a single worker. Production routing
+    rejects it unless an explicit shared event backend is configured.
     """
 
     def __init__(self) -> None:
@@ -37,15 +36,37 @@ class AgentCommonsEventBus:
                     subscription.queue.get_nowait()
             await subscription.queue.put(payload)
 
-    async def subscribe(self, tenant_id: str) -> AsyncIterator[dict[str, Any]]:
+    async def open_subscription(self, tenant_id: str) -> EventSubscription:
         subscription = EventSubscription(tenant_id=tenant_id)
         async with self._lock:
             self._subscriptions[tenant_id].add(subscription)
+        return subscription
+
+    async def close_subscription(self, subscription: EventSubscription) -> None:
+        async with self._lock:
+            subscriptions = self._subscriptions.get(subscription.tenant_id)
+            if subscriptions is None:
+                return
+            subscriptions.discard(subscription)
+            if not subscriptions:
+                self._subscriptions.pop(subscription.tenant_id, None)
+
+    async def next_event(
+        self,
+        subscription: EventSubscription,
+        timeout_seconds: float,
+    ) -> dict[str, Any] | None:
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                return await subscription.queue.get()
+        except TimeoutError:
+            return None
+
+    async def subscribe(self, tenant_id: str):
+        """Compatibility iterator for tests and non-SSE consumers."""
+        subscription = await self.open_subscription(tenant_id)
         try:
             while True:
                 yield await subscription.queue.get()
         finally:
-            async with self._lock:
-                self._subscriptions[tenant_id].discard(subscription)
-                if not self._subscriptions[tenant_id]:
-                    self._subscriptions.pop(tenant_id, None)
+            await self.close_subscription(subscription)

--- a/agent_commons/models.py
+++ b/agent_commons/models.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import time
 import uuid
 from dataclasses import dataclass, field
-from enum import Enum
-from typing import Any, Dict, List, Optional
+from enum import StrEnum
+from typing import Any
 
 
-class AgentRole(str, Enum):
+class AgentRole(StrEnum):
     OWNER = "owner"
     SUPERVISOR = "supervisor"
     WORKER = "worker"
@@ -15,7 +15,7 @@ class AgentRole(str, Enum):
     OBSERVER = "observer"
 
 
-class LifecycleStatus(str, Enum):
+class LifecycleStatus(StrEnum):
     ASSIGNED = "ASSIGNED"
     ACK = "ACK"
     IN_PROGRESS = "IN_PROGRESS"
@@ -25,7 +25,7 @@ class LifecycleStatus(str, Enum):
     CLOSED = "CLOSED"
 
 
-class RunStatus(str, Enum):
+class RunStatus(StrEnum):
     PENDING = "pending"
     RUNNING = "running"
     WAITING_APPROVAL = "waiting_approval"
@@ -42,15 +42,15 @@ class MessageRecord:
     thread_id: str
     task_id: str
     from_agent: str
-    to_agents: List[str]
+    to_agents: list[str]
     status: LifecycleStatus
-    payload: Dict[str, Any]
-    evidence: List[str] = field(default_factory=list)
+    payload: dict[str, Any]
+    evidence: list[str] = field(default_factory=list)
     correlation_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     message_id: str = field(default_factory=lambda: uuid.uuid4().hex)
     owner_decision_required: bool = False
     timestamp: float = field(default_factory=time.time)
-    trace: Dict[str, Any] = field(default_factory=dict)
+    trace: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -63,13 +63,15 @@ class SupervisorRun:
     owner_agent: str
     builder_agent: str
     reviewer_agent: str
-    acceptance_criteria: List[str]
+    acceptance_criteria: list[str]
     run_id: str = field(default_factory=lambda: uuid.uuid4().hex)
-    task_id: str = field(default_factory=lambda: f"SPU-{time.strftime('%Y%m%d')}-{uuid.uuid4().hex[:6].upper()}")
+    task_id: str = field(
+        default_factory=lambda: f"SPU-{time.strftime('%Y%m%d')}-{uuid.uuid4().hex[:6].upper()}"
+    )
     status: RunStatus = RunStatus.PENDING
-    builder_result: Optional[Dict[str, Any]] = None
-    review_result: Optional[Dict[str, Any]] = None
-    reconciliation: Optional[Dict[str, Any]] = None
-    approval_id: Optional[str] = None
+    builder_result: dict[str, Any] | None = None
+    review_result: dict[str, Any] | None = None
+    reconciliation: dict[str, Any] | None = None
+    approval_id: str | None = None
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)

--- a/agent_commons/models.py
+++ b/agent_commons/models.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class AgentRole(str, Enum):
+    OWNER = "owner"
+    SUPERVISOR = "supervisor"
+    WORKER = "worker"
+    REVIEWER = "reviewer"
+    OBSERVER = "observer"
+
+
+class LifecycleStatus(str, Enum):
+    ASSIGNED = "ASSIGNED"
+    ACK = "ACK"
+    IN_PROGRESS = "IN_PROGRESS"
+    BLOCKED = "BLOCKED"
+    RESULT = "RESULT"
+    REJECTED = "REJECTED"
+    CLOSED = "CLOSED"
+
+
+class RunStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    WAITING_APPROVAL = "waiting_approval"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class MessageRecord:
+    tenant_id: str
+    workspace_id: str
+    channel_id: str
+    thread_id: str
+    task_id: str
+    from_agent: str
+    to_agents: List[str]
+    status: LifecycleStatus
+    payload: Dict[str, Any]
+    evidence: List[str] = field(default_factory=list)
+    correlation_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    message_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    owner_decision_required: bool = False
+    timestamp: float = field(default_factory=time.time)
+    trace: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SupervisorRun:
+    tenant_id: str
+    workspace_id: str
+    channel_id: str
+    thread_id: str
+    objective: str
+    owner_agent: str
+    builder_agent: str
+    reviewer_agent: str
+    acceptance_criteria: List[str]
+    run_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    task_id: str = field(default_factory=lambda: f"SPU-{time.strftime('%Y%m%d')}-{uuid.uuid4().hex[:6].upper()}")
+    status: RunStatus = RunStatus.PENDING
+    builder_result: Optional[Dict[str, Any]] = None
+    review_result: Optional[Dict[str, Any]] = None
+    reconciliation: Optional[Dict[str, Any]] = None
+    approval_id: Optional[str] = None
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)

--- a/agent_commons/provider_adapters.py
+++ b/agent_commons/provider_adapters.py
@@ -4,13 +4,15 @@ import asyncio
 import json
 import os
 import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional
+from typing import Any
 
 from .adapters import AgentAdapter, AgentInvocation
 
-
-ProviderCallable = Callable[[Dict[str, Any], Dict[str, Any]], Awaitable[Dict[str, Any]]]
+ProviderCallable = Callable[
+    [dict[str, Any], dict[str, Any]], Awaitable[dict[str, Any]]
+]
 
 
 @dataclass(frozen=True)
@@ -31,26 +33,28 @@ class CallableAgentAdapter(AgentAdapter):
     def __init__(
         self,
         agent_id: str,
-        capabilities: List[str],
+        capabilities: list[str],
         invoke_callable: ProviderCallable,
-        policy: Optional[ProviderPolicy] = None,
+        policy: ProviderPolicy | None = None,
     ) -> None:
         self.agent_id = agent_id
         self._capabilities = tuple(capabilities)
         self._invoke_callable = invoke_callable
         self._policy = policy or ProviderPolicy()
         self._cancelled: set[str] = set()
-        self._events: dict[str, asyncio.Queue[Dict[str, Any]]] = {}
+        self._events: dict[str, asyncio.Queue[dict[str, Any]]] = {}
 
-    async def health(self) -> Dict[str, Any]:
+    async def health(self) -> dict[str, Any]:
         return {"agent_id": self.agent_id, "status": "ok", "provider": "callable"}
 
-    async def capabilities(self) -> List[str]:
+    async def capabilities(self) -> list[str]:
         return list(self._capabilities)
 
-    async def invoke(self, task: Dict[str, Any], context: Dict[str, Any]) -> AgentInvocation:
+    async def invoke(
+        self, task: dict[str, Any], context: dict[str, Any]
+    ) -> AgentInvocation:
         run_id = uuid.uuid4().hex
-        queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
         self._events[run_id] = queue
         await queue.put({"run_id": run_id, "type": "started", "agent_id": self.agent_id})
         try:
@@ -63,10 +67,19 @@ class CallableAgentAdapter(AgentAdapter):
             serialized = json.dumps(output, default=str)
             if len(serialized) > self._policy.max_output_characters:
                 raise ValueError("provider output exceeds configured limit")
-            await queue.put({"run_id": run_id, "type": "completed", "agent_id": self.agent_id})
+            await queue.put(
+                {"run_id": run_id, "type": "completed", "agent_id": self.agent_id}
+            )
             return AgentInvocation(run_id=run_id, output=output)
         except Exception as exc:
-            await queue.put({"run_id": run_id, "type": "failed", "agent_id": self.agent_id, "error": type(exc).__name__})
+            await queue.put(
+                {
+                    "run_id": run_id,
+                    "type": "failed",
+                    "agent_id": self.agent_id,
+                    "error": type(exc).__name__,
+                }
+            )
             raise
         finally:
             await queue.put({"run_id": run_id, "type": "closed"})
@@ -78,7 +91,9 @@ class CallableAgentAdapter(AgentAdapter):
             await queue.put({"run_id": run_id, "type": "cancel_requested"})
         return True
 
-    async def stream_events(self, run_id: str) -> AsyncIterator[Dict[str, Any]]:
+    async def stream_events(
+        self, run_id: str
+    ) -> AsyncIterator[dict[str, Any]]:
         queue = self._events.get(run_id)
         if queue is None:
             return
@@ -93,17 +108,22 @@ class CallableAgentAdapter(AgentAdapter):
 class OpenAISupervisorAdapter(CallableAgentAdapter):
     """Responses-API adapter with dependency injection and no import-time SDK requirement."""
 
-    def __init__(self, client: Any, model: Optional[str] = None) -> None:
+    def __init__(self, client: Any, model: str | None = None) -> None:
         self._client = client
         self._model = model or os.getenv("OPENAI_SUPERVISOR_MODEL", "gpt-5")
         super().__init__(
             agent_id="openai-supervisor",
             capabilities=["decompose", "delegate", "review", "reconcile", "escalate"],
             invoke_callable=self._invoke_openai,
-            policy=ProviderPolicy(timeout_seconds=180.0, max_output_characters=120_000),
+            policy=ProviderPolicy(
+                timeout_seconds=180.0,
+                max_output_characters=120_000,
+            ),
         )
 
-    async def _invoke_openai(self, task: Dict[str, Any], context: Dict[str, Any]) -> Dict[str, Any]:
+    async def _invoke_openai(
+        self, task: dict[str, Any], context: dict[str, Any]
+    ) -> dict[str, Any]:
         response = await self._client.responses.create(
             model=self._model,
             input=[
@@ -115,7 +135,13 @@ class OpenAISupervisorAdapter(CallableAgentAdapter):
                         "financial, or government communications. Escalate those actions to the owner."
                     ),
                 },
-                {"role": "user", "content": json.dumps({"task": task, "context": context}, default=str)},
+                {
+                    "role": "user",
+                    "content": json.dumps(
+                        {"task": task, "context": context},
+                        default=str,
+                    ),
+                },
             ],
         )
         text = getattr(response, "output_text", "")

--- a/agent_commons/provider_adapters.py
+++ b/agent_commons/provider_adapters.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional
+
+from .adapters import AgentAdapter, AgentInvocation
+
+
+ProviderCallable = Callable[[Dict[str, Any], Dict[str, Any]], Awaitable[Dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class ProviderPolicy:
+    timeout_seconds: float = 120.0
+    max_output_characters: int = 100_000
+    allowed_capabilities: tuple[str, ...] = ()
+
+
+class CallableAgentAdapter(AgentAdapter):
+    """Safe adapter around an injected async provider callable.
+
+    This is the integration seam for Hermes, Codex, Claude Code, Manus, and
+    local runtimes. Provider credentials and network clients remain outside
+    the shared orchestration core.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        capabilities: List[str],
+        invoke_callable: ProviderCallable,
+        policy: Optional[ProviderPolicy] = None,
+    ) -> None:
+        self.agent_id = agent_id
+        self._capabilities = tuple(capabilities)
+        self._invoke_callable = invoke_callable
+        self._policy = policy or ProviderPolicy()
+        self._cancelled: set[str] = set()
+        self._events: dict[str, asyncio.Queue[Dict[str, Any]]] = {}
+
+    async def health(self) -> Dict[str, Any]:
+        return {"agent_id": self.agent_id, "status": "ok", "provider": "callable"}
+
+    async def capabilities(self) -> List[str]:
+        return list(self._capabilities)
+
+    async def invoke(self, task: Dict[str, Any], context: Dict[str, Any]) -> AgentInvocation:
+        run_id = uuid.uuid4().hex
+        queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        self._events[run_id] = queue
+        await queue.put({"run_id": run_id, "type": "started", "agent_id": self.agent_id})
+        try:
+            output = await asyncio.wait_for(
+                self._invoke_callable(dict(task), dict(context)),
+                timeout=self._policy.timeout_seconds,
+            )
+            if run_id in self._cancelled:
+                raise asyncio.CancelledError
+            serialized = json.dumps(output, default=str)
+            if len(serialized) > self._policy.max_output_characters:
+                raise ValueError("provider output exceeds configured limit")
+            await queue.put({"run_id": run_id, "type": "completed", "agent_id": self.agent_id})
+            return AgentInvocation(run_id=run_id, output=output)
+        except Exception as exc:
+            await queue.put({"run_id": run_id, "type": "failed", "agent_id": self.agent_id, "error": type(exc).__name__})
+            raise
+        finally:
+            await queue.put({"run_id": run_id, "type": "closed"})
+
+    async def cancel(self, run_id: str) -> bool:
+        self._cancelled.add(run_id)
+        queue = self._events.get(run_id)
+        if queue is not None:
+            await queue.put({"run_id": run_id, "type": "cancel_requested"})
+        return True
+
+    async def stream_events(self, run_id: str) -> AsyncIterator[Dict[str, Any]]:
+        queue = self._events.get(run_id)
+        if queue is None:
+            return
+        while True:
+            event = await queue.get()
+            yield event
+            if event.get("type") == "closed":
+                self._events.pop(run_id, None)
+                return
+
+
+class OpenAISupervisorAdapter(CallableAgentAdapter):
+    """Responses-API adapter with dependency injection and no import-time SDK requirement."""
+
+    def __init__(self, client: Any, model: Optional[str] = None) -> None:
+        self._client = client
+        self._model = model or os.getenv("OPENAI_SUPERVISOR_MODEL", "gpt-5")
+        super().__init__(
+            agent_id="openai-supervisor",
+            capabilities=["decompose", "delegate", "review", "reconcile", "escalate"],
+            invoke_callable=self._invoke_openai,
+            policy=ProviderPolicy(timeout_seconds=180.0, max_output_characters=120_000),
+        )
+
+    async def _invoke_openai(self, task: Dict[str, Any], context: Dict[str, Any]) -> Dict[str, Any]:
+        response = await self._client.responses.create(
+            model=self._model,
+            input=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are SintraPrime's governed supervisor. Return concise JSON only. "
+                        "Do not claim authority to merge, deploy, transfer funds, or send legal, "
+                        "financial, or government communications. Escalate those actions to the owner."
+                    ),
+                },
+                {"role": "user", "content": json.dumps({"task": task, "context": context}, default=str)},
+            ],
+        )
+        text = getattr(response, "output_text", "")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return {"summary": text, "structured": False}

--- a/agent_commons/store.py
+++ b/agent_commons/store.py
@@ -6,7 +6,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from .models import MessageRecord, RunStatus, SupervisorRun
 
@@ -63,12 +63,21 @@ class AgentCommonsStore:
 
     def append_message(self, message: MessageRecord) -> None:
         values = (
-            message.message_id, message.tenant_id, message.workspace_id,
-            message.channel_id, message.thread_id, message.task_id,
-            message.from_agent, json.dumps(message.to_agents), message.status.value,
-            json.dumps(message.payload), json.dumps(message.evidence),
-            message.correlation_id, int(message.owner_decision_required),
-            message.timestamp, json.dumps(message.trace),
+            message.message_id,
+            message.tenant_id,
+            message.workspace_id,
+            message.channel_id,
+            message.thread_id,
+            message.task_id,
+            message.from_agent,
+            json.dumps(message.to_agents),
+            message.status.value,
+            json.dumps(message.payload),
+            json.dumps(message.evidence),
+            message.correlation_id,
+            int(message.owner_decision_required),
+            message.timestamp,
+            json.dumps(message.trace),
         )
         with self._lock, self._connection:
             self._connection.execute(
@@ -76,7 +85,13 @@ class AgentCommonsStore:
                 values,
             )
 
-    def get_thread(self, tenant_id: str, workspace_id: str, channel_id: str, thread_id: str) -> List[Dict[str, Any]]:
+    def get_thread(
+        self,
+        tenant_id: str,
+        workspace_id: str,
+        channel_id: str,
+        thread_id: str,
+    ) -> list[dict[str, Any]]:
         rows = self._connection.execute(
             """SELECT * FROM commons_messages
                WHERE tenant_id=? AND workspace_id=? AND channel_id=? AND thread_id=?
@@ -85,7 +100,11 @@ class AgentCommonsStore:
         ).fetchall()
         return [self._decode_message(row) for row in rows]
 
-    def save_run(self, run: SupervisorRun, idempotency_key: Optional[str] = None) -> SupervisorRun:
+    def save_run(
+        self,
+        run: SupervisorRun,
+        idempotency_key: str | None = None,
+    ) -> SupervisorRun:
         with self._lock, self._connection:
             if idempotency_key:
                 existing = self._connection.execute(
@@ -95,14 +114,25 @@ class AgentCommonsStore:
                 if existing:
                     return self.get_run(run.tenant_id, existing["run_id"])
             values = (
-                run.run_id, run.tenant_id, run.workspace_id, run.channel_id,
-                run.thread_id, run.task_id, run.objective, run.owner_agent,
-                run.builder_agent, run.reviewer_agent,
-                json.dumps(run.acceptance_criteria), run.status.value,
+                run.run_id,
+                run.tenant_id,
+                run.workspace_id,
+                run.channel_id,
+                run.thread_id,
+                run.task_id,
+                run.objective,
+                run.owner_agent,
+                run.builder_agent,
+                run.reviewer_agent,
+                json.dumps(run.acceptance_criteria),
+                run.status.value,
                 self._json_or_none(run.builder_result),
                 self._json_or_none(run.review_result),
-                self._json_or_none(run.reconciliation), run.approval_id,
-                idempotency_key, run.created_at, run.updated_at,
+                self._json_or_none(run.reconciliation),
+                run.approval_id,
+                idempotency_key,
+                run.created_at,
+                run.updated_at,
             )
             self._connection.execute(
                 "INSERT INTO supervisor_runs VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -118,10 +148,14 @@ class AgentCommonsStore:
                    review_result_json=?, reconciliation_json=?, approval_id=?, updated_at=?
                    WHERE tenant_id=? AND run_id=?""",
                 (
-                    run.status.value, self._json_or_none(run.builder_result),
+                    run.status.value,
+                    self._json_or_none(run.builder_result),
                     self._json_or_none(run.review_result),
-                    self._json_or_none(run.reconciliation), run.approval_id,
-                    run.updated_at, run.tenant_id, run.run_id,
+                    self._json_or_none(run.reconciliation),
+                    run.approval_id,
+                    run.updated_at,
+                    run.tenant_id,
+                    run.run_id,
                 ),
             )
             if cursor.rowcount != 1:
@@ -145,22 +179,34 @@ class AgentCommonsStore:
             )
         return approval_id
 
-    def decide_approval(self, tenant_id: str, approval_id: str, approved: bool, note: str = "") -> None:
+    def decide_approval(
+        self,
+        tenant_id: str,
+        approval_id: str,
+        approved: bool,
+        note: str = "",
+    ) -> None:
         with self._lock, self._connection:
             cursor = self._connection.execute(
                 """UPDATE owner_approvals SET status=?, decision_note=?, decided_at=?
                    WHERE tenant_id=? AND approval_id=? AND status='pending'""",
-                ("approved" if approved else "rejected", note, time.time(), tenant_id, approval_id),
+                (
+                    "approved" if approved else "rejected",
+                    note,
+                    time.time(),
+                    tenant_id,
+                    approval_id,
+                ),
             )
             if cursor.rowcount != 1:
                 raise KeyError(f"pending approval not found: {approval_id}")
 
     @staticmethod
-    def _json_or_none(value: Any) -> Optional[str]:
+    def _json_or_none(value: Any) -> str | None:
         return None if value is None else json.dumps(value)
 
     @staticmethod
-    def _decode_message(row: sqlite3.Row) -> Dict[str, Any]:
+    def _decode_message(row: sqlite3.Row) -> dict[str, Any]:
         result = dict(row)
         for key in ("to_agents_json", "payload_json", "evidence_json", "trace_json"):
             result[key.removesuffix("_json")] = json.loads(result.pop(key))
@@ -169,15 +215,26 @@ class AgentCommonsStore:
 
     @staticmethod
     def _decode_run(row: sqlite3.Row) -> SupervisorRun:
-        decode = lambda key: json.loads(row[key]) if row[key] else None
+        def decode(key: str) -> Any:
+            return json.loads(row[key]) if row[key] else None
+
         return SupervisorRun(
-            run_id=row["run_id"], tenant_id=row["tenant_id"],
-            workspace_id=row["workspace_id"], channel_id=row["channel_id"],
-            thread_id=row["thread_id"], task_id=row["task_id"],
-            objective=row["objective"], owner_agent=row["owner_agent"],
-            builder_agent=row["builder_agent"], reviewer_agent=row["reviewer_agent"],
+            run_id=row["run_id"],
+            tenant_id=row["tenant_id"],
+            workspace_id=row["workspace_id"],
+            channel_id=row["channel_id"],
+            thread_id=row["thread_id"],
+            task_id=row["task_id"],
+            objective=row["objective"],
+            owner_agent=row["owner_agent"],
+            builder_agent=row["builder_agent"],
+            reviewer_agent=row["reviewer_agent"],
             acceptance_criteria=json.loads(row["acceptance_criteria_json"]),
-            status=RunStatus(row["status"]), builder_result=decode("builder_result_json"),
-            review_result=decode("review_result_json"), reconciliation=decode("reconciliation_json"),
-            approval_id=row["approval_id"], created_at=row["created_at"], updated_at=row["updated_at"],
+            status=RunStatus(row["status"]),
+            builder_result=decode("builder_result_json"),
+            review_result=decode("review_result_json"),
+            reconciliation=decode("reconciliation_json"),
+            approval_id=row["approval_id"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
         )

--- a/agent_commons/store.py
+++ b/agent_commons/store.py
@@ -23,7 +23,7 @@ class AgentCommonsStore:
         self._migrate()
 
     def _migrate(self) -> None:
-        with self._connection:
+        with self._lock, self._connection:
             self._connection.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS commons_messages (
@@ -92,13 +92,14 @@ class AgentCommonsStore:
         channel_id: str,
         thread_id: str,
     ) -> list[dict[str, Any]]:
-        rows = self._connection.execute(
-            """SELECT * FROM commons_messages
-               WHERE tenant_id=? AND workspace_id=? AND channel_id=? AND thread_id=?
-               ORDER BY timestamp ASC""",
-            (tenant_id, workspace_id, channel_id, thread_id),
-        ).fetchall()
-        return [self._decode_message(row) for row in rows]
+        with self._lock:
+            rows = self._connection.execute(
+                """SELECT * FROM commons_messages
+                   WHERE tenant_id=? AND workspace_id=? AND channel_id=? AND thread_id=?
+                   ORDER BY timestamp ASC""",
+                (tenant_id, workspace_id, channel_id, thread_id),
+            ).fetchall()
+            return [self._decode_message(row) for row in rows]
 
     def save_run(
         self,
@@ -162,13 +163,14 @@ class AgentCommonsStore:
                 raise KeyError(f"run not found: {run.run_id}")
 
     def get_run(self, tenant_id: str, run_id: str) -> SupervisorRun:
-        row = self._connection.execute(
-            "SELECT * FROM supervisor_runs WHERE tenant_id=? AND run_id=?",
-            (tenant_id, run_id),
-        ).fetchone()
-        if row is None:
-            raise KeyError(f"run not found: {run_id}")
-        return self._decode_run(row)
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT * FROM supervisor_runs WHERE tenant_id=? AND run_id=?",
+                (tenant_id, run_id),
+            ).fetchone()
+            if row is None:
+                raise KeyError(f"run not found: {run_id}")
+            return self._decode_run(row)
 
     def create_approval(self, tenant_id: str, run_id: str, reason: str) -> str:
         approval_id = uuid.uuid4().hex

--- a/agent_commons/store.py
+++ b/agent_commons/store.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .models import LifecycleStatus, MessageRecord, RunStatus, SupervisorRun
+
+
+class AgentCommonsStore:
+    """Tenant-scoped SQLite persistence for Agent Commons threads, runs, and approvals."""
+
+    def __init__(self, database_path: str = ":memory:") -> None:
+        self.database_path = database_path
+        if database_path != ":memory:":
+            Path(database_path).parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(database_path, check_same_thread=False)
+        self._connection.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        self._migrate()
+
+    def _migrate(self) -> None:
+        with self._connection:
+            self._connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS commons_messages (
+                    message_id TEXT PRIMARY KEY,
+                    tenant_id TEXT NOT NULL,
+                    workspace_id TEXT NOT NULL,
+                    channel_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    task_id TEXT NOT NULL,
+                    from_agent TEXT NOT NULL,
+                    to_agents_json TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    evidence_json TEXT NOT NULL,
+                    correlation_id TEXT NOT NULL,
+                    owner_decision_required INTEGER NOT NULL,
+                    timestamp REAL NOT NULL,
+                    trace_json TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_commons_thread
+                    ON commons_messages(tenant_id, workspace_id, channel_id, thread_id, timestamp);
+
+                CREATE TABLE IF NOT EXISTS supervisor_runs (
+                    run_id TEXT PRIMARY KEY,
+                    tenant_id TEXT NOT NULL,
+                    workspace_id TEXT NOT NULL,
+                    channel_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    task_id TEXT NOT NULL UNIQUE,
+                    objective TEXT NOT NULL,
+                    owner_agent TEXT NOT NULL,
+                    builder_agent TEXT NOT NULL,
+                    reviewer_agent TEXT NOT NULL,
+                    acceptance_criteria_json TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    builder_result_json TEXT,
+                    review_result_json TEXT,
+                    reconciliation_json TEXT,
+                    approval_id TEXT,
+                    idempotency_key TEXT UNIQUE,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS owner_approvals (
+                    approval_id TEXT PRIMARY KEY,
+                    tenant_id TEXT NOT NULL,
+                    run_id TEXT NOT NULL,
+                    reason TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    decision_note TEXT,
+                    created_at REAL NOT NULL,
+                    decided_at REAL
+                );
+                """
+            )
+
+    def append_message(self, message: MessageRecord) -> None:
+        with self._lock, self._connection:
+            self._connection.execute(
+                """
+                INSERT INTO commons_messages VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    message.message_id,
+                    message.tenant_id,
+                    message.workspace_id,
+                    message.channel_id,
+                    message.thread_id,
+                    message.task_id,
+                    message.from_agent,
+                    json.dumps(message.to_agents),
+                    message.status.value,
+                    json.dumps(message.payload),
+                    json.dumps(message.evidence),
+                    message.correlation_id,
+                    int(message.owner_decision_required),
+                    message.timestamp,
+                    json.dumps(message.trace),
+                ),
+            )
+
+    def get_thread(self, tenant_id: str, workspace_id: str, channel_id: str, thread_id: str) -> List[Dict[str, Any]]:
+        rows = self._connection.execute(
+            """
+            SELECT * FROM commons_messages
+            WHERE tenant_id=? AND workspace_id=? AND channel_id=? AND thread_id=?
+            ORDER BY timestamp ASC
+            """,
+            (tenant_id, workspace_id, channel_id, thread_id),
+        ).fetchall()
+        return [self._decode_message(row) for row in rows]
+
+    def save_run(self, run: SupervisorRun, idempotency_key: Optional[str] = None) -> SupervisorRun:
+        with self._lock, self._connection:
+            if idempotency_key:
+                existing = self._connection.execute(
+                    "SELECT run_id FROM supervisor_runs WHERE idempotency_key=? AND tenant_id=?",
+                    (idempotency_key, run.tenant_id),
+                ).fetchone()
+                if existing:
+                    return self.get_run(run.tenant_id, existing["run_id"])
+            self._connection.execute(
+                """
+                INSERT INTO supervisor_runs VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run.run_id, run.tenant_id, run.workspace_id, run.channel_id, run.thread_id,
+                    run.task_id, run.objective, run.owner_agent, run.builder_agent, run.reviewer_agent,
+                    json.dumps(run.acceptance_criteria), run.status.value,
+                    self._json_or_none(run.builder_result), self._json_or_none(run.review_result),
+                    self._json_or_none(run.reconciliation), run.approval_id, idempotency_key,
+                    run.created_at, run.updated_at,
+                ),
+            )
+        return run
+
+    def update_run(self, run: SupervisorRun) -> None:
+        run.updated_at = time.time()
+        with self._lock, self._connection:
+            cursor = self._connection.execute(
+                """
+                UPDATE supervisor_runs SET status=?, builder_result_json=?, review_result_json=?,
+                    reconciliation_json=?, approval_id=?, updated_at=?
+                WHERE tenant_id=? AND run_id=?
+                """,
+                (
+                    run.status.value, self._json_or_none(run.builder_result), self._json_or_none(run.review_result),
+                    self._json_or_none(run.reconciliation), run.approval_id, run.updated_at,
+                    run.tenant_id, run.run_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise KeyError(f"run not found: {run.run_id}")
+
+    def get_run(self, tenant_id: str, run_id: str) -> SupervisorRun:
+        row = self._connection.execute(
+            "SELECT * FROM supervisor_runs WHERE tenant_id=? AND run_id=?",
+            (tenant_id, run_id),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"run not found: {run_id}")
+        return self._decode_run(row)
+
+    def create_approval(self, tenant_id: str, run_id: str, reason: str) -> str:
+        approval_id = uuid.uuid4().hex
+        with self._lock, self._connection:
+            self._connection.execute(
+                "INSERT INTO owner_approvals VALUES (?, ?, ?, ?, 'pending', NULL, ?, NULL)",
+                (approval_id, tenant_id, run_id, reason, time.time()),
+            )
+        return approval_id
+
+    def decide_approval(self, tenant_id: str, approval_id: str, approved: bool, note: str = "") -> None:
+        status = "approved" if approved else "rejected"
+        with self._lock, self._connection:
+            cursor = self._connection.execute(
+                """
+                UPDATE owner_approvals SET status=?, decision_note=?, decided_at=?
+                WHERE tenant_id=? AND approval_id=? AND status='pending'
+                """,
+                (status, note, time.time(), tenant_id, approval_id),
+            )
+            if cursor.rowcount != 1:
+                raise KeyError(f"pending approval not found: {approval_id}")
+
+    @staticmethod
+    def _json_or_none(value: Any) -> Optional[str]:
+        return None if value is None else json.dumps(value)
+
+    @staticmethod
+    def _decode_message(row: sqlite3.Row) -> Dict[str, Any]:
+        result = dict(row)
+        for key in ("to_agents_json", "payload_json", "evidence_json", "trace_json"):
+            result[key.removesuffix("_json")] = json.loads(result.pop(key))
+        result["owner_decision_required"] = bool(result["owner_decision_required"])
+        return result
+
+    @staticmethod
+    def _decode_run(row: sqlite3.Row) -> SupervisorRun:
+        return SupervisorRun(
+            run_id=row["run_id"], tenant_id=row["tenant_id"], workspace_id=row["workspace_id"],
+            channel_id=row["channel_id"], thread_id=row["thread_id"], task_id=row["task_id"],
+            objective=row["objective"], owner_agent=row["owner_agent"], builder_agent=row["builder_agent"],
+            reviewer_agent=row["reviewer_agent"], acceptance_criteria=json.loads(row["acceptance_criteria_json"]),
+            status=RunStatus(row["status"]), builder_result=json.loads(row["builder_result_json"]) if row["builder_result_json"] else None,
+            review_result=json.loads(row["review_result_json"]) if row["review_result_json"] else None,
+            reconciliation=json.loads(row["reconciliation_json"]) if row["reconciliation_json"] else None,
+            approval_id=row["approval_id"], created_at=row["created_at"], updated_at=row["updated_at"],
+        )

--- a/agent_commons/store.py
+++ b/agent_commons/store.py
@@ -8,14 +8,13 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .models import LifecycleStatus, MessageRecord, RunStatus, SupervisorRun
+from .models import MessageRecord, RunStatus, SupervisorRun
 
 
 class AgentCommonsStore:
     """Tenant-scoped SQLite persistence for Agent Commons threads, runs, and approvals."""
 
     def __init__(self, database_path: str = ":memory:") -> None:
-        self.database_path = database_path
         if database_path != ":memory:":
             Path(database_path).parent.mkdir(parents=True, exist_ok=True)
         self._connection = sqlite3.connect(database_path, check_same_thread=False)
@@ -28,92 +27,60 @@ class AgentCommonsStore:
             self._connection.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS commons_messages (
-                    message_id TEXT PRIMARY KEY,
-                    tenant_id TEXT NOT NULL,
-                    workspace_id TEXT NOT NULL,
-                    channel_id TEXT NOT NULL,
-                    thread_id TEXT NOT NULL,
-                    task_id TEXT NOT NULL,
-                    from_agent TEXT NOT NULL,
-                    to_agents_json TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    payload_json TEXT NOT NULL,
-                    evidence_json TEXT NOT NULL,
-                    correlation_id TEXT NOT NULL,
+                    message_id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL,
+                    workspace_id TEXT NOT NULL, channel_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL, task_id TEXT NOT NULL,
+                    from_agent TEXT NOT NULL, to_agents_json TEXT NOT NULL,
+                    status TEXT NOT NULL, payload_json TEXT NOT NULL,
+                    evidence_json TEXT NOT NULL, correlation_id TEXT NOT NULL,
                     owner_decision_required INTEGER NOT NULL,
-                    timestamp REAL NOT NULL,
-                    trace_json TEXT NOT NULL
+                    timestamp REAL NOT NULL, trace_json TEXT NOT NULL
                 );
                 CREATE INDEX IF NOT EXISTS idx_commons_thread
                     ON commons_messages(tenant_id, workspace_id, channel_id, thread_id, timestamp);
 
                 CREATE TABLE IF NOT EXISTS supervisor_runs (
-                    run_id TEXT PRIMARY KEY,
-                    tenant_id TEXT NOT NULL,
-                    workspace_id TEXT NOT NULL,
-                    channel_id TEXT NOT NULL,
-                    thread_id TEXT NOT NULL,
-                    task_id TEXT NOT NULL UNIQUE,
-                    objective TEXT NOT NULL,
-                    owner_agent TEXT NOT NULL,
-                    builder_agent TEXT NOT NULL,
-                    reviewer_agent TEXT NOT NULL,
-                    acceptance_criteria_json TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    builder_result_json TEXT,
-                    review_result_json TEXT,
-                    reconciliation_json TEXT,
-                    approval_id TEXT,
-                    idempotency_key TEXT UNIQUE,
-                    created_at REAL NOT NULL,
+                    run_id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL,
+                    workspace_id TEXT NOT NULL, channel_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL, task_id TEXT NOT NULL UNIQUE,
+                    objective TEXT NOT NULL, owner_agent TEXT NOT NULL,
+                    builder_agent TEXT NOT NULL, reviewer_agent TEXT NOT NULL,
+                    acceptance_criteria_json TEXT NOT NULL, status TEXT NOT NULL,
+                    builder_result_json TEXT, review_result_json TEXT,
+                    reconciliation_json TEXT, approval_id TEXT,
+                    idempotency_key TEXT UNIQUE, created_at REAL NOT NULL,
                     updated_at REAL NOT NULL
                 );
 
                 CREATE TABLE IF NOT EXISTS owner_approvals (
-                    approval_id TEXT PRIMARY KEY,
-                    tenant_id TEXT NOT NULL,
-                    run_id TEXT NOT NULL,
-                    reason TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    decision_note TEXT,
-                    created_at REAL NOT NULL,
-                    decided_at REAL
+                    approval_id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL,
+                    run_id TEXT NOT NULL, reason TEXT NOT NULL,
+                    status TEXT NOT NULL, decision_note TEXT,
+                    created_at REAL NOT NULL, decided_at REAL
                 );
                 """
             )
 
     def append_message(self, message: MessageRecord) -> None:
+        values = (
+            message.message_id, message.tenant_id, message.workspace_id,
+            message.channel_id, message.thread_id, message.task_id,
+            message.from_agent, json.dumps(message.to_agents), message.status.value,
+            json.dumps(message.payload), json.dumps(message.evidence),
+            message.correlation_id, int(message.owner_decision_required),
+            message.timestamp, json.dumps(message.trace),
+        )
         with self._lock, self._connection:
             self._connection.execute(
-                """
-                INSERT INTO commons_messages VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    message.message_id,
-                    message.tenant_id,
-                    message.workspace_id,
-                    message.channel_id,
-                    message.thread_id,
-                    message.task_id,
-                    message.from_agent,
-                    json.dumps(message.to_agents),
-                    message.status.value,
-                    json.dumps(message.payload),
-                    json.dumps(message.evidence),
-                    message.correlation_id,
-                    int(message.owner_decision_required),
-                    message.timestamp,
-                    json.dumps(message.trace),
-                ),
+                "INSERT INTO commons_messages VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                values,
             )
 
     def get_thread(self, tenant_id: str, workspace_id: str, channel_id: str, thread_id: str) -> List[Dict[str, Any]]:
         rows = self._connection.execute(
-            """
-            SELECT * FROM commons_messages
-            WHERE tenant_id=? AND workspace_id=? AND channel_id=? AND thread_id=?
-            ORDER BY timestamp ASC
-            """,
+            """SELECT * FROM commons_messages
+               WHERE tenant_id=? AND workspace_id=? AND channel_id=? AND thread_id=?
+               ORDER BY timestamp ASC""",
             (tenant_id, workspace_id, channel_id, thread_id),
         ).fetchall()
         return [self._decode_message(row) for row in rows]
@@ -127,18 +94,19 @@ class AgentCommonsStore:
                 ).fetchone()
                 if existing:
                     return self.get_run(run.tenant_id, existing["run_id"])
+            values = (
+                run.run_id, run.tenant_id, run.workspace_id, run.channel_id,
+                run.thread_id, run.task_id, run.objective, run.owner_agent,
+                run.builder_agent, run.reviewer_agent,
+                json.dumps(run.acceptance_criteria), run.status.value,
+                self._json_or_none(run.builder_result),
+                self._json_or_none(run.review_result),
+                self._json_or_none(run.reconciliation), run.approval_id,
+                idempotency_key, run.created_at, run.updated_at,
+            )
             self._connection.execute(
-                """
-                INSERT INTO supervisor_runs VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    run.run_id, run.tenant_id, run.workspace_id, run.channel_id, run.thread_id,
-                    run.task_id, run.objective, run.owner_agent, run.builder_agent, run.reviewer_agent,
-                    json.dumps(run.acceptance_criteria), run.status.value,
-                    self._json_or_none(run.builder_result), self._json_or_none(run.review_result),
-                    self._json_or_none(run.reconciliation), run.approval_id, idempotency_key,
-                    run.created_at, run.updated_at,
-                ),
+                "INSERT INTO supervisor_runs VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                values,
             )
         return run
 
@@ -146,15 +114,14 @@ class AgentCommonsStore:
         run.updated_at = time.time()
         with self._lock, self._connection:
             cursor = self._connection.execute(
-                """
-                UPDATE supervisor_runs SET status=?, builder_result_json=?, review_result_json=?,
-                    reconciliation_json=?, approval_id=?, updated_at=?
-                WHERE tenant_id=? AND run_id=?
-                """,
+                """UPDATE supervisor_runs SET status=?, builder_result_json=?,
+                   review_result_json=?, reconciliation_json=?, approval_id=?, updated_at=?
+                   WHERE tenant_id=? AND run_id=?""",
                 (
-                    run.status.value, self._json_or_none(run.builder_result), self._json_or_none(run.review_result),
-                    self._json_or_none(run.reconciliation), run.approval_id, run.updated_at,
-                    run.tenant_id, run.run_id,
+                    run.status.value, self._json_or_none(run.builder_result),
+                    self._json_or_none(run.review_result),
+                    self._json_or_none(run.reconciliation), run.approval_id,
+                    run.updated_at, run.tenant_id, run.run_id,
                 ),
             )
             if cursor.rowcount != 1:
@@ -179,14 +146,11 @@ class AgentCommonsStore:
         return approval_id
 
     def decide_approval(self, tenant_id: str, approval_id: str, approved: bool, note: str = "") -> None:
-        status = "approved" if approved else "rejected"
         with self._lock, self._connection:
             cursor = self._connection.execute(
-                """
-                UPDATE owner_approvals SET status=?, decision_note=?, decided_at=?
-                WHERE tenant_id=? AND approval_id=? AND status='pending'
-                """,
-                (status, note, time.time(), tenant_id, approval_id),
+                """UPDATE owner_approvals SET status=?, decision_note=?, decided_at=?
+                   WHERE tenant_id=? AND approval_id=? AND status='pending'""",
+                ("approved" if approved else "rejected", note, time.time(), tenant_id, approval_id),
             )
             if cursor.rowcount != 1:
                 raise KeyError(f"pending approval not found: {approval_id}")
@@ -205,13 +169,15 @@ class AgentCommonsStore:
 
     @staticmethod
     def _decode_run(row: sqlite3.Row) -> SupervisorRun:
+        decode = lambda key: json.loads(row[key]) if row[key] else None
         return SupervisorRun(
-            run_id=row["run_id"], tenant_id=row["tenant_id"], workspace_id=row["workspace_id"],
-            channel_id=row["channel_id"], thread_id=row["thread_id"], task_id=row["task_id"],
-            objective=row["objective"], owner_agent=row["owner_agent"], builder_agent=row["builder_agent"],
-            reviewer_agent=row["reviewer_agent"], acceptance_criteria=json.loads(row["acceptance_criteria_json"]),
-            status=RunStatus(row["status"]), builder_result=json.loads(row["builder_result_json"]) if row["builder_result_json"] else None,
-            review_result=json.loads(row["review_result_json"]) if row["review_result_json"] else None,
-            reconciliation=json.loads(row["reconciliation_json"]) if row["reconciliation_json"] else None,
+            run_id=row["run_id"], tenant_id=row["tenant_id"],
+            workspace_id=row["workspace_id"], channel_id=row["channel_id"],
+            thread_id=row["thread_id"], task_id=row["task_id"],
+            objective=row["objective"], owner_agent=row["owner_agent"],
+            builder_agent=row["builder_agent"], reviewer_agent=row["reviewer_agent"],
+            acceptance_criteria=json.loads(row["acceptance_criteria_json"]),
+            status=RunStatus(row["status"]), builder_result=decode("builder_result_json"),
+            review_result=decode("review_result_json"), reconciliation=decode("reconciliation_json"),
             approval_id=row["approval_id"], created_at=row["created_at"], updated_at=row["updated_at"],
         )

--- a/agent_commons/store.py
+++ b/agent_commons/store.py
@@ -12,7 +12,7 @@ from .models import MessageRecord, RunStatus, SupervisorRun
 
 
 class AgentCommonsStore:
-    """Tenant-scoped SQLite persistence for Agent Commons threads, runs, and approvals."""
+    """Tenant-scoped SQLite persistence for local development and tests."""
 
     def __init__(self, database_path: str = ":memory:") -> None:
         if database_path != ":memory:":
@@ -39,19 +39,6 @@ class AgentCommonsStore:
                 CREATE INDEX IF NOT EXISTS idx_commons_thread
                     ON commons_messages(tenant_id, workspace_id, channel_id, thread_id, timestamp);
 
-                CREATE TABLE IF NOT EXISTS supervisor_runs (
-                    run_id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL,
-                    workspace_id TEXT NOT NULL, channel_id TEXT NOT NULL,
-                    thread_id TEXT NOT NULL, task_id TEXT NOT NULL UNIQUE,
-                    objective TEXT NOT NULL, owner_agent TEXT NOT NULL,
-                    builder_agent TEXT NOT NULL, reviewer_agent TEXT NOT NULL,
-                    acceptance_criteria_json TEXT NOT NULL, status TEXT NOT NULL,
-                    builder_result_json TEXT, review_result_json TEXT,
-                    reconciliation_json TEXT, approval_id TEXT,
-                    idempotency_key TEXT UNIQUE, created_at REAL NOT NULL,
-                    updated_at REAL NOT NULL
-                );
-
                 CREATE TABLE IF NOT EXISTS owner_approvals (
                     approval_id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL,
                     run_id TEXT NOT NULL, reason TEXT NOT NULL,
@@ -60,24 +47,67 @@ class AgentCommonsStore:
                 );
                 """
             )
+            self._ensure_tenant_scoped_runs_table()
+
+    def _ensure_tenant_scoped_runs_table(self) -> None:
+        row = self._connection.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='supervisor_runs'"
+        ).fetchone()
+        if row is None:
+            self._create_runs_table()
+            return
+        schema = (row["sql"] or "").replace("\n", " ").lower()
+        legacy_global_unique = (
+            "task_id text not null unique" in schema
+            or "idempotency_key text unique" in schema
+        )
+        if not legacy_global_unique:
+            return
+        self._connection.execute("ALTER TABLE supervisor_runs RENAME TO supervisor_runs_legacy")
+        self._create_runs_table()
+        self._connection.execute(
+            """INSERT INTO supervisor_runs (
+                run_id, tenant_id, workspace_id, channel_id, thread_id, task_id,
+                objective, owner_agent, builder_agent, reviewer_agent,
+                acceptance_criteria_json, status, builder_result_json,
+                review_result_json, reconciliation_json, approval_id,
+                idempotency_key, created_at, updated_at
+            ) SELECT
+                run_id, tenant_id, workspace_id, channel_id, thread_id, task_id,
+                objective, owner_agent, builder_agent, reviewer_agent,
+                acceptance_criteria_json, status, builder_result_json,
+                review_result_json, reconciliation_json, approval_id,
+                idempotency_key, created_at, updated_at
+            FROM supervisor_runs_legacy"""
+        )
+        self._connection.execute("DROP TABLE supervisor_runs_legacy")
+
+    def _create_runs_table(self) -> None:
+        self._connection.execute(
+            """CREATE TABLE supervisor_runs (
+                run_id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL,
+                workspace_id TEXT NOT NULL, channel_id TEXT NOT NULL,
+                thread_id TEXT NOT NULL, task_id TEXT NOT NULL,
+                objective TEXT NOT NULL, owner_agent TEXT NOT NULL,
+                builder_agent TEXT NOT NULL, reviewer_agent TEXT NOT NULL,
+                acceptance_criteria_json TEXT NOT NULL, status TEXT NOT NULL,
+                builder_result_json TEXT, review_result_json TEXT,
+                reconciliation_json TEXT, approval_id TEXT,
+                idempotency_key TEXT, created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                UNIQUE (tenant_id, task_id),
+                UNIQUE (tenant_id, idempotency_key)
+            )"""
+        )
 
     def append_message(self, message: MessageRecord) -> None:
         values = (
-            message.message_id,
-            message.tenant_id,
-            message.workspace_id,
-            message.channel_id,
-            message.thread_id,
-            message.task_id,
-            message.from_agent,
-            json.dumps(message.to_agents),
-            message.status.value,
-            json.dumps(message.payload),
-            json.dumps(message.evidence),
-            message.correlation_id,
-            int(message.owner_decision_required),
-            message.timestamp,
-            json.dumps(message.trace),
+            message.message_id, message.tenant_id, message.workspace_id,
+            message.channel_id, message.thread_id, message.task_id,
+            message.from_agent, json.dumps(message.to_agents), message.status.value,
+            json.dumps(message.payload), json.dumps(message.evidence),
+            message.correlation_id, int(message.owner_decision_required),
+            message.timestamp, json.dumps(message.trace),
         )
         with self._lock, self._connection:
             self._connection.execute(
@@ -109,31 +139,20 @@ class AgentCommonsStore:
         with self._lock, self._connection:
             if idempotency_key:
                 existing = self._connection.execute(
-                    "SELECT run_id FROM supervisor_runs WHERE idempotency_key=? AND tenant_id=?",
-                    (idempotency_key, run.tenant_id),
+                    "SELECT run_id FROM supervisor_runs WHERE tenant_id=? AND idempotency_key=?",
+                    (run.tenant_id, idempotency_key),
                 ).fetchone()
                 if existing:
                     return self.get_run(run.tenant_id, existing["run_id"])
             values = (
-                run.run_id,
-                run.tenant_id,
-                run.workspace_id,
-                run.channel_id,
-                run.thread_id,
-                run.task_id,
-                run.objective,
-                run.owner_agent,
-                run.builder_agent,
-                run.reviewer_agent,
-                json.dumps(run.acceptance_criteria),
-                run.status.value,
+                run.run_id, run.tenant_id, run.workspace_id, run.channel_id,
+                run.thread_id, run.task_id, run.objective, run.owner_agent,
+                run.builder_agent, run.reviewer_agent,
+                json.dumps(run.acceptance_criteria), run.status.value,
                 self._json_or_none(run.builder_result),
                 self._json_or_none(run.review_result),
-                self._json_or_none(run.reconciliation),
-                run.approval_id,
-                idempotency_key,
-                run.created_at,
-                run.updated_at,
+                self._json_or_none(run.reconciliation), run.approval_id,
+                idempotency_key, run.created_at, run.updated_at,
             )
             self._connection.execute(
                 "INSERT INTO supervisor_runs VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -153,10 +172,7 @@ class AgentCommonsStore:
                     self._json_or_none(run.builder_result),
                     self._json_or_none(run.review_result),
                     self._json_or_none(run.reconciliation),
-                    run.approval_id,
-                    run.updated_at,
-                    run.tenant_id,
-                    run.run_id,
+                    run.approval_id, run.updated_at, run.tenant_id, run.run_id,
                 ),
             )
             if cursor.rowcount != 1:
@@ -193,11 +209,8 @@ class AgentCommonsStore:
                 """UPDATE owner_approvals SET status=?, decision_note=?, decided_at=?
                    WHERE tenant_id=? AND approval_id=? AND status='pending'""",
                 (
-                    "approved" if approved else "rejected",
-                    note,
-                    time.time(),
-                    tenant_id,
-                    approval_id,
+                    "approved" if approved else "rejected", note, time.time(),
+                    tenant_id, approval_id,
                 ),
             )
             if cursor.rowcount != 1:
@@ -221,22 +234,16 @@ class AgentCommonsStore:
             return json.loads(row[key]) if row[key] else None
 
         return SupervisorRun(
-            run_id=row["run_id"],
-            tenant_id=row["tenant_id"],
-            workspace_id=row["workspace_id"],
-            channel_id=row["channel_id"],
-            thread_id=row["thread_id"],
-            task_id=row["task_id"],
-            objective=row["objective"],
-            owner_agent=row["owner_agent"],
-            builder_agent=row["builder_agent"],
-            reviewer_agent=row["reviewer_agent"],
+            run_id=row["run_id"], tenant_id=row["tenant_id"],
+            workspace_id=row["workspace_id"], channel_id=row["channel_id"],
+            thread_id=row["thread_id"], task_id=row["task_id"],
+            objective=row["objective"], owner_agent=row["owner_agent"],
+            builder_agent=row["builder_agent"], reviewer_agent=row["reviewer_agent"],
             acceptance_criteria=json.loads(row["acceptance_criteria_json"]),
             status=RunStatus(row["status"]),
             builder_result=decode("builder_result_json"),
             review_result=decode("review_result_json"),
             reconciliation=decode("reconciliation_json"),
-            approval_id=row["approval_id"],
-            created_at=row["created_at"],
+            approval_id=row["approval_id"], created_at=row["created_at"],
             updated_at=row["updated_at"],
         )

--- a/agent_commons/store.py
+++ b/agent_commons/store.py
@@ -188,6 +188,16 @@ class AgentCommonsStore:
                 raise KeyError(f"run not found: {run_id}")
             return self._decode_run(row)
 
+    def list_runs(self, tenant_id: str, limit: int = 50) -> list[SupervisorRun]:
+        bounded_limit = max(1, min(limit, 200))
+        with self._lock:
+            rows = self._connection.execute(
+                """SELECT * FROM supervisor_runs
+                   WHERE tenant_id=? ORDER BY updated_at DESC LIMIT ?""",
+                (tenant_id, bounded_limit),
+            ).fetchall()
+            return [self._decode_run(row) for row in rows]
+
     def create_approval(self, tenant_id: str, run_id: str, reason: str) -> str:
         approval_id = uuid.uuid4().hex
         with self._lock, self._connection:

--- a/agent_commons/supervisor.py
+++ b/agent_commons/supervisor.py
@@ -95,6 +95,7 @@ class GovernedSupervisor:
             return run
 
         run.status = RunStatus.RUNNING
+        self.store.update_run(run)
         self._record(
             run,
             "supervisor",
@@ -107,43 +108,61 @@ class GovernedSupervisor:
             },
         )
 
-        context = self._build_context(run)
-        builder = await self.adapters[builder_agent].invoke(
-            {
-                "task_id": run.task_id,
-                "objective": objective,
-                "acceptance_criteria": run.acceptance_criteria,
-            },
-            context,
-        )
-        run.builder_result = builder.output
-        self._record(
-            run,
-            builder_agent,
-            ["supervisor"],
-            LifecycleStatus.RESULT,
-            builder.output,
-            evidence=builder.evidence,
-        )
+        try:
+            context = self._build_context(run)
+            builder = await self.adapters[builder_agent].invoke(
+                {
+                    "task_id": run.task_id,
+                    "objective": objective,
+                    "acceptance_criteria": run.acceptance_criteria,
+                },
+                context,
+            )
+            run.builder_result = builder.output
+            self._record(
+                run,
+                builder_agent,
+                ["supervisor"],
+                LifecycleStatus.RESULT,
+                builder.output,
+                evidence=builder.evidence,
+            )
 
-        review = await self.adapters[reviewer_agent].invoke(
-            {
-                "task_id": run.task_id,
-                "objective": "Independently review the builder result",
-                "candidate": builder.output,
-                "acceptance_criteria": run.acceptance_criteria,
-            },
-            self._build_context(run),
-        )
-        run.review_result = review.output
-        self._record(
-            run,
-            reviewer_agent,
-            ["supervisor"],
-            LifecycleStatus.RESULT,
-            review.output,
-            evidence=review.evidence,
-        )
+            review = await self.adapters[reviewer_agent].invoke(
+                {
+                    "task_id": run.task_id,
+                    "objective": "Independently review the builder result",
+                    "candidate": builder.output,
+                    "acceptance_criteria": run.acceptance_criteria,
+                },
+                self._build_context(run),
+            )
+            run.review_result = review.output
+            self._record(
+                run,
+                reviewer_agent,
+                ["supervisor"],
+                LifecycleStatus.RESULT,
+                review.output,
+                evidence=review.evidence,
+            )
+        except Exception as exc:
+            run.status = RunStatus.FAILED
+            run.reconciliation = {
+                "summary": "Agent invocation failed.",
+                "failure_type": type(exc).__name__,
+                "failed_agent": reviewer_agent if run.builder_result is not None else builder_agent,
+            }
+            self._record(
+                run,
+                "supervisor",
+                [owner_agent],
+                LifecycleStatus.BLOCKED,
+                run.reconciliation,
+                False,
+            )
+            self.store.update_run(run)
+            raise
 
         disagreement = self._material_disagreement(builder.output, review.output)
         run.reconciliation = {

--- a/agent_commons/supervisor.py
+++ b/agent_commons/supervisor.py
@@ -225,6 +225,43 @@ class GovernedSupervisor:
         self.store.update_run(run)
         return run
 
+    def approve_pre_execution(
+        self,
+        tenant_id: str,
+        run_id: str,
+        approval_id: str,
+        note: str = "",
+    ) -> SupervisorRun:
+        """Record owner authorization without claiming the work has executed."""
+        run = self.store.get_run(tenant_id, run_id)
+        if run.approval_id != approval_id or run.status != RunStatus.WAITING_APPROVAL:
+            raise ValueError("approval does not match a waiting supervisor run")
+        if run.builder_result is not None or not (
+            run.reconciliation and run.reconciliation.get("blocked_actions")
+        ):
+            raise ValueError("run is not a pre-execution action gate")
+        self.store.decide_approval(tenant_id, approval_id, approved=True, note=note)
+        run.status = RunStatus.PENDING
+        run.reconciliation = {
+            **run.reconciliation,
+            "summary": "Owner approval recorded; supervised execution has not yet run.",
+            "authorization_recorded": True,
+            "execution_pending": True,
+        }
+        self._record(
+            run,
+            run.owner_agent,
+            ["supervisor"],
+            LifecycleStatus.ACK,
+            {
+                "decision": "approved",
+                "note": note,
+                "execution_pending": True,
+            },
+        )
+        self.store.update_run(run)
+        return run
+
     def reject(
         self,
         tenant_id: str,

--- a/agent_commons/supervisor.py
+++ b/agent_commons/supervisor.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping
+
+from .adapters import AgentAdapter
+from .models import LifecycleStatus, MessageRecord, RunStatus, SupervisorRun
+from .store import AgentCommonsStore
+
+
+@dataclass(frozen=True)
+class SupervisorPolicy:
+    max_delegation_depth: int = 2
+    require_independent_review: bool = True
+    material_disagreement_threshold: float = 0.5
+    prohibited_actions: tuple[str, ...] = (
+        "merge",
+        "deploy",
+        "send_legal_communication",
+        "send_financial_communication",
+        "send_government_communication",
+        "transfer_funds",
+        "execute_unapproved_external_action",
+    )
+
+
+class GovernedSupervisor:
+    """Coordinates a builder/reviewer pair while preserving owner authority."""
+
+    def __init__(
+        self,
+        store: AgentCommonsStore,
+        adapters: Mapping[str, AgentAdapter],
+        policy: SupervisorPolicy | None = None,
+    ) -> None:
+        self.store = store
+        self.adapters = dict(adapters)
+        self.policy = policy or SupervisorPolicy()
+
+    async def run_objective(
+        self,
+        *,
+        tenant_id: str,
+        workspace_id: str,
+        channel_id: str,
+        thread_id: str,
+        owner_agent: str,
+        objective: str,
+        builder_agent: str,
+        reviewer_agent: str,
+        acceptance_criteria: Iterable[str],
+        idempotency_key: str,
+        requested_actions: Iterable[str] = (),
+    ) -> SupervisorRun:
+        self._validate_agents(builder_agent, reviewer_agent)
+        blocked_actions = sorted(set(requested_actions).intersection(self.policy.prohibited_actions))
+
+        run = SupervisorRun(
+            tenant_id=tenant_id,
+            workspace_id=workspace_id,
+            channel_id=channel_id,
+            thread_id=thread_id,
+            objective=objective,
+            owner_agent=owner_agent,
+            builder_agent=builder_agent,
+            reviewer_agent=reviewer_agent,
+            acceptance_criteria=list(acceptance_criteria),
+        )
+        run = self.store.save_run(run, idempotency_key=idempotency_key)
+        if run.status != RunStatus.PENDING:
+            return run
+
+        if blocked_actions:
+            run.status = RunStatus.WAITING_APPROVAL
+            run.reconciliation = {
+                "summary": "Objective requests owner-controlled actions.",
+                "blocked_actions": blocked_actions,
+                "material_disagreement": True,
+            }
+            run.approval_id = self.store.create_approval(
+                tenant_id, run.run_id, f"Owner approval required for: {', '.join(blocked_actions)}"
+            )
+            self._record(run, "supervisor", [owner_agent], LifecycleStatus.BLOCKED, run.reconciliation, True)
+            self.store.update_run(run)
+            return run
+
+        run.status = RunStatus.RUNNING
+        self._record(
+            run,
+            "supervisor",
+            [builder_agent],
+            LifecycleStatus.ASSIGNED,
+            {"objective": objective, "acceptance_criteria": run.acceptance_criteria, "role": "builder"},
+        )
+
+        context = self._build_context(run)
+        builder = await self.adapters[builder_agent].invoke(
+            {"task_id": run.task_id, "objective": objective, "acceptance_criteria": run.acceptance_criteria},
+            context,
+        )
+        run.builder_result = builder.output
+        self._record(run, builder_agent, ["supervisor"], LifecycleStatus.RESULT, builder.output, evidence=builder.evidence)
+
+        review = await self.adapters[reviewer_agent].invoke(
+            {
+                "task_id": run.task_id,
+                "objective": "Independently review the builder result",
+                "candidate": builder.output,
+                "acceptance_criteria": run.acceptance_criteria,
+            },
+            self._build_context(run),
+        )
+        run.review_result = review.output
+        self._record(run, reviewer_agent, ["supervisor"], LifecycleStatus.RESULT, review.output, evidence=review.evidence)
+
+        disagreement = self._material_disagreement(builder.output, review.output)
+        run.reconciliation = {
+            "summary": review.output.get("summary") or builder.output.get("summary") or "Supervisor run completed.",
+            "builder": builder_agent,
+            "reviewer": reviewer_agent,
+            "material_disagreement": disagreement,
+            "acceptance_criteria": run.acceptance_criteria,
+        }
+        if disagreement:
+            run.status = RunStatus.WAITING_APPROVAL
+            run.approval_id = self.store.create_approval(
+                tenant_id, run.run_id, "Builder and reviewer materially disagree. Owner decision required."
+            )
+            self._record(run, "supervisor", [owner_agent], LifecycleStatus.BLOCKED, run.reconciliation, True)
+        else:
+            run.status = RunStatus.COMPLETED
+            self._record(run, "supervisor", [owner_agent], LifecycleStatus.RESULT, run.reconciliation, False)
+
+        self.store.update_run(run)
+        return run
+
+    def approve(self, tenant_id: str, run_id: str, approval_id: str, note: str = "") -> SupervisorRun:
+        run = self.store.get_run(tenant_id, run_id)
+        if run.approval_id != approval_id or run.status != RunStatus.WAITING_APPROVAL:
+            raise ValueError("approval does not match a waiting supervisor run")
+        self.store.decide_approval(tenant_id, approval_id, approved=True, note=note)
+        run.status = RunStatus.COMPLETED
+        self._record(run, run.owner_agent, ["supervisor"], LifecycleStatus.CLOSED, {"decision": "approved", "note": note})
+        self.store.update_run(run)
+        return run
+
+    def reject(self, tenant_id: str, run_id: str, approval_id: str, note: str = "") -> SupervisorRun:
+        run = self.store.get_run(tenant_id, run_id)
+        if run.approval_id != approval_id or run.status != RunStatus.WAITING_APPROVAL:
+            raise ValueError("approval does not match a waiting supervisor run")
+        self.store.decide_approval(tenant_id, approval_id, approved=False, note=note)
+        run.status = RunStatus.CANCELLED
+        self._record(run, run.owner_agent, ["supervisor"], LifecycleStatus.REJECTED, {"decision": "rejected", "note": note})
+        self.store.update_run(run)
+        return run
+
+    def _build_context(self, run: SupervisorRun) -> Dict[str, Any]:
+        messages = self.store.get_thread(run.tenant_id, run.workspace_id, run.channel_id, run.thread_id)
+        bounded = messages[-50:]
+        return {
+            "tenant_id": run.tenant_id,
+            "workspace_id": run.workspace_id,
+            "channel_id": run.channel_id,
+            "thread_id": run.thread_id,
+            "task_id": run.task_id,
+            "thread_history": bounded,
+            "provenance": [{"message_id": m["message_id"], "from_agent": m["from_agent"]} for m in bounded],
+        }
+
+    def _record(
+        self,
+        run: SupervisorRun,
+        from_agent: str,
+        to_agents: List[str],
+        status: LifecycleStatus,
+        payload: Dict[str, Any],
+        owner_decision_required: bool = False,
+        evidence: List[str] | None = None,
+    ) -> None:
+        self.store.append_message(
+            MessageRecord(
+                tenant_id=run.tenant_id,
+                workspace_id=run.workspace_id,
+                channel_id=run.channel_id,
+                thread_id=run.thread_id,
+                task_id=run.task_id,
+                from_agent=from_agent,
+                to_agents=to_agents,
+                status=status,
+                payload=payload,
+                evidence=evidence or [],
+                owner_decision_required=owner_decision_required,
+                trace={"supervisor_run_id": run.run_id},
+            )
+        )
+
+    def _validate_agents(self, builder_agent: str, reviewer_agent: str) -> None:
+        if builder_agent == reviewer_agent:
+            raise ValueError("builder and reviewer must be independent agents")
+        missing = [agent for agent in (builder_agent, reviewer_agent) if agent not in self.adapters]
+        if missing:
+            raise KeyError(f"unregistered adapters: {', '.join(missing)}")
+
+    @staticmethod
+    def _material_disagreement(builder: Dict[str, Any], reviewer: Dict[str, Any]) -> bool:
+        if reviewer.get("material_disagreement") is True:
+            return True
+        if reviewer.get("approved") is False:
+            return True
+        builder_decision = builder.get("decision")
+        reviewer_decision = reviewer.get("decision")
+        return bool(builder_decision and reviewer_decision and builder_decision != reviewer_decision)

--- a/agent_commons/supervisor.py
+++ b/agent_commons/supervisor.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Mapping
+from typing import Any
 
 from .adapters import AgentAdapter
 from .models import LifecycleStatus, MessageRecord, RunStatus, SupervisorRun
@@ -78,9 +79,18 @@ class GovernedSupervisor:
                 "material_disagreement": True,
             }
             run.approval_id = self.store.create_approval(
-                tenant_id, run.run_id, f"Owner approval required for: {', '.join(blocked_actions)}"
+                tenant_id,
+                run.run_id,
+                f"Owner approval required for: {', '.join(blocked_actions)}",
             )
-            self._record(run, "supervisor", [owner_agent], LifecycleStatus.BLOCKED, run.reconciliation, True)
+            self._record(
+                run,
+                "supervisor",
+                [owner_agent],
+                LifecycleStatus.BLOCKED,
+                run.reconciliation,
+                True,
+            )
             self.store.update_run(run)
             return run
 
@@ -90,16 +100,31 @@ class GovernedSupervisor:
             "supervisor",
             [builder_agent],
             LifecycleStatus.ASSIGNED,
-            {"objective": objective, "acceptance_criteria": run.acceptance_criteria, "role": "builder"},
+            {
+                "objective": objective,
+                "acceptance_criteria": run.acceptance_criteria,
+                "role": "builder",
+            },
         )
 
         context = self._build_context(run)
         builder = await self.adapters[builder_agent].invoke(
-            {"task_id": run.task_id, "objective": objective, "acceptance_criteria": run.acceptance_criteria},
+            {
+                "task_id": run.task_id,
+                "objective": objective,
+                "acceptance_criteria": run.acceptance_criteria,
+            },
             context,
         )
         run.builder_result = builder.output
-        self._record(run, builder_agent, ["supervisor"], LifecycleStatus.RESULT, builder.output, evidence=builder.evidence)
+        self._record(
+            run,
+            builder_agent,
+            ["supervisor"],
+            LifecycleStatus.RESULT,
+            builder.output,
+            evidence=builder.evidence,
+        )
 
         review = await self.adapters[reviewer_agent].invoke(
             {
@@ -111,11 +136,20 @@ class GovernedSupervisor:
             self._build_context(run),
         )
         run.review_result = review.output
-        self._record(run, reviewer_agent, ["supervisor"], LifecycleStatus.RESULT, review.output, evidence=review.evidence)
+        self._record(
+            run,
+            reviewer_agent,
+            ["supervisor"],
+            LifecycleStatus.RESULT,
+            review.output,
+            evidence=review.evidence,
+        )
 
         disagreement = self._material_disagreement(builder.output, review.output)
         run.reconciliation = {
-            "summary": review.output.get("summary") or builder.output.get("summary") or "Supervisor run completed.",
+            "summary": review.output.get("summary")
+            or builder.output.get("summary")
+            or "Supervisor run completed.",
             "builder": builder_agent,
             "reviewer": reviewer_agent,
             "material_disagreement": disagreement,
@@ -124,38 +158,83 @@ class GovernedSupervisor:
         if disagreement:
             run.status = RunStatus.WAITING_APPROVAL
             run.approval_id = self.store.create_approval(
-                tenant_id, run.run_id, "Builder and reviewer materially disagree. Owner decision required."
+                tenant_id,
+                run.run_id,
+                "Builder and reviewer materially disagree. Owner decision required.",
             )
-            self._record(run, "supervisor", [owner_agent], LifecycleStatus.BLOCKED, run.reconciliation, True)
+            self._record(
+                run,
+                "supervisor",
+                [owner_agent],
+                LifecycleStatus.BLOCKED,
+                run.reconciliation,
+                True,
+            )
         else:
             run.status = RunStatus.COMPLETED
-            self._record(run, "supervisor", [owner_agent], LifecycleStatus.RESULT, run.reconciliation, False)
+            self._record(
+                run,
+                "supervisor",
+                [owner_agent],
+                LifecycleStatus.RESULT,
+                run.reconciliation,
+                False,
+            )
 
         self.store.update_run(run)
         return run
 
-    def approve(self, tenant_id: str, run_id: str, approval_id: str, note: str = "") -> SupervisorRun:
+    def approve(
+        self,
+        tenant_id: str,
+        run_id: str,
+        approval_id: str,
+        note: str = "",
+    ) -> SupervisorRun:
         run = self.store.get_run(tenant_id, run_id)
         if run.approval_id != approval_id or run.status != RunStatus.WAITING_APPROVAL:
             raise ValueError("approval does not match a waiting supervisor run")
         self.store.decide_approval(tenant_id, approval_id, approved=True, note=note)
         run.status = RunStatus.COMPLETED
-        self._record(run, run.owner_agent, ["supervisor"], LifecycleStatus.CLOSED, {"decision": "approved", "note": note})
+        self._record(
+            run,
+            run.owner_agent,
+            ["supervisor"],
+            LifecycleStatus.CLOSED,
+            {"decision": "approved", "note": note},
+        )
         self.store.update_run(run)
         return run
 
-    def reject(self, tenant_id: str, run_id: str, approval_id: str, note: str = "") -> SupervisorRun:
+    def reject(
+        self,
+        tenant_id: str,
+        run_id: str,
+        approval_id: str,
+        note: str = "",
+    ) -> SupervisorRun:
         run = self.store.get_run(tenant_id, run_id)
         if run.approval_id != approval_id or run.status != RunStatus.WAITING_APPROVAL:
             raise ValueError("approval does not match a waiting supervisor run")
         self.store.decide_approval(tenant_id, approval_id, approved=False, note=note)
         run.status = RunStatus.CANCELLED
-        self._record(run, run.owner_agent, ["supervisor"], LifecycleStatus.REJECTED, {"decision": "rejected", "note": note})
+        self._record(
+            run,
+            run.owner_agent,
+            ["supervisor"],
+            LifecycleStatus.REJECTED,
+            {"decision": "rejected", "note": note},
+        )
         self.store.update_run(run)
         return run
 
-    def _build_context(self, run: SupervisorRun) -> Dict[str, Any]:
-        messages = self.store.get_thread(run.tenant_id, run.workspace_id, run.channel_id, run.thread_id)
+    def _build_context(self, run: SupervisorRun) -> dict[str, Any]:
+        messages = self.store.get_thread(
+            run.tenant_id,
+            run.workspace_id,
+            run.channel_id,
+            run.thread_id,
+        )
         bounded = messages[-50:]
         return {
             "tenant_id": run.tenant_id,
@@ -164,18 +243,21 @@ class GovernedSupervisor:
             "thread_id": run.thread_id,
             "task_id": run.task_id,
             "thread_history": bounded,
-            "provenance": [{"message_id": m["message_id"], "from_agent": m["from_agent"]} for m in bounded],
+            "provenance": [
+                {"message_id": message["message_id"], "from_agent": message["from_agent"]}
+                for message in bounded
+            ],
         }
 
     def _record(
         self,
         run: SupervisorRun,
         from_agent: str,
-        to_agents: List[str],
+        to_agents: list[str],
         status: LifecycleStatus,
-        payload: Dict[str, Any],
+        payload: dict[str, Any],
         owner_decision_required: bool = False,
-        evidence: List[str] | None = None,
+        evidence: list[str] | None = None,
     ) -> None:
         self.store.append_message(
             MessageRecord(
@@ -197,16 +279,26 @@ class GovernedSupervisor:
     def _validate_agents(self, builder_agent: str, reviewer_agent: str) -> None:
         if builder_agent == reviewer_agent:
             raise ValueError("builder and reviewer must be independent agents")
-        missing = [agent for agent in (builder_agent, reviewer_agent) if agent not in self.adapters]
+        missing = [
+            agent
+            for agent in (builder_agent, reviewer_agent)
+            if agent not in self.adapters
+        ]
         if missing:
             raise KeyError(f"unregistered adapters: {', '.join(missing)}")
 
     @staticmethod
-    def _material_disagreement(builder: Dict[str, Any], reviewer: Dict[str, Any]) -> bool:
+    def _material_disagreement(
+        builder: dict[str, Any], reviewer: dict[str, Any]
+    ) -> bool:
         if reviewer.get("material_disagreement") is True:
             return True
         if reviewer.get("approved") is False:
             return True
         builder_decision = builder.get("decision")
         reviewer_decision = reviewer.get("decision")
-        return bool(builder_decision and reviewer_decision and builder_decision != reviewer_decision)
+        return bool(
+            builder_decision
+            and reviewer_decision
+            and builder_decision != reviewer_decision
+        )

--- a/agent_commons/tests/test_events_and_providers.py
+++ b/agent_commons/tests/test_events_and_providers.py
@@ -9,17 +9,20 @@ from agent_commons.provider_adapters import CallableAgentAdapter, ProviderPolicy
 @pytest.mark.asyncio
 async def test_event_bus_isolates_tenants():
     bus = AgentCommonsEventBus()
-    tenant_a = bus.subscribe("tenant-a").__aiter__()
-    tenant_b = bus.subscribe("tenant-b").__aiter__()
+    tenant_a = await bus.open_subscription("tenant-a")
+    tenant_b = await bus.open_subscription("tenant-b")
+    try:
+        await bus.publish("tenant-a", {"type": "run.updated", "data": {"run_id": "a"}})
 
-    await bus.publish("tenant-a", {"type": "run.updated", "data": {"run_id": "a"}})
+        event = await bus.next_event(tenant_a, 0.2)
+        assert event is not None
+        assert event["tenant_id"] == "tenant-a"
+        assert event["data"]["run_id"] == "a"
 
-    event = await asyncio.wait_for(tenant_a.__anext__(), timeout=0.2)
-    assert event["tenant_id"] == "tenant-a"
-    assert event["data"]["run_id"] == "a"
-
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(tenant_b.__anext__(), timeout=0.05)
+        assert await bus.next_event(tenant_b, 0.05) is None
+    finally:
+        await bus.close_subscription(tenant_a)
+        await bus.close_subscription(tenant_b)
 
 
 @pytest.mark.asyncio

--- a/agent_commons/tests/test_events_and_providers.py
+++ b/agent_commons/tests/test_events_and_providers.py
@@ -1,0 +1,58 @@
+import asyncio
+
+import pytest
+
+from agent_commons.events import AgentCommonsEventBus
+from agent_commons.provider_adapters import CallableAgentAdapter, ProviderPolicy
+
+
+@pytest.mark.asyncio
+async def test_event_bus_isolates_tenants():
+    bus = AgentCommonsEventBus()
+    tenant_a = bus.subscribe("tenant-a").__aiter__()
+    tenant_b = bus.subscribe("tenant-b").__aiter__()
+
+    await bus.publish("tenant-a", {"type": "run.updated", "data": {"run_id": "a"}})
+
+    event = await asyncio.wait_for(tenant_a.__anext__(), timeout=0.2)
+    assert event["tenant_id"] == "tenant-a"
+    assert event["data"]["run_id"] == "a"
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(tenant_b.__anext__(), timeout=0.05)
+
+
+@pytest.mark.asyncio
+async def test_callable_adapter_invokes_provider_and_streams_observable_events():
+    async def provider(task, context):
+        return {"summary": task["objective"], "context_task": context["task_id"]}
+
+    adapter = CallableAgentAdapter(
+        "worker",
+        ["build"],
+        provider,
+        ProviderPolicy(timeout_seconds=1.0, max_output_characters=1_000),
+    )
+
+    invocation = await adapter.invoke({"objective": "build"}, {"task_id": "T-1"})
+    assert invocation.output == {"summary": "build", "context_task": "T-1"}
+
+    events = [event async for event in adapter.stream_events(invocation.run_id)]
+    assert [event["type"] for event in events] == ["started", "completed", "closed"]
+
+
+@pytest.mark.asyncio
+async def test_callable_adapter_enforces_timeout():
+    async def slow_provider(task, context):
+        await asyncio.sleep(0.1)
+        return {"summary": "late"}
+
+    adapter = CallableAgentAdapter(
+        "slow",
+        ["build"],
+        slow_provider,
+        ProviderPolicy(timeout_seconds=0.01),
+    )
+
+    with pytest.raises(asyncio.TimeoutError):
+        await adapter.invoke({"objective": "wait"}, {"task_id": "T-2"})

--- a/agent_commons/tests/test_events_and_providers.py
+++ b/agent_commons/tests/test_events_and_providers.py
@@ -43,7 +43,7 @@ async def test_callable_adapter_invokes_provider_and_streams_observable_events()
 
 @pytest.mark.asyncio
 async def test_callable_adapter_enforces_timeout():
-    async def slow_provider(task, context):
+    async def slow_provider(_task, _context):
         await asyncio.sleep(0.1)
         return {"summary": "late"}
 

--- a/agent_commons/tests/test_router_config_and_sse.py
+++ b/agent_commons/tests/test_router_config_and_sse.py
@@ -1,11 +1,31 @@
+from types import SimpleNamespace
+
 import pytest
 
 from portal.routers import agent_commons
 
 
+@pytest.fixture(autouse=True)
+def development_runtime(monkeypatch):
+    monkeypatch.setattr(
+        agent_commons,
+        "get_settings",
+        lambda: SimpleNamespace(ENVIRONMENT="development"),
+    )
+    monkeypatch.setenv("WEB_CONCURRENCY", "1")
+    monkeypatch.setenv("AGENT_COMMONS_STORAGE_MODE", "sqlite")
+    monkeypatch.setenv("AGENT_COMMONS_EVENT_BACKEND", "in_process")
+    agent_commons.get_store.cache_clear()
+    agent_commons.get_event_bus.cache_clear()
+    agent_commons.get_supervisor.cache_clear()
+    yield
+    agent_commons.get_store.cache_clear()
+    agent_commons.get_event_bus.cache_clear()
+    agent_commons.get_supervisor.cache_clear()
+
+
 def test_adapter_mode_defaults_to_disabled(monkeypatch):
     monkeypatch.delenv("AGENT_COMMONS_ADAPTER_MODE", raising=False)
-    agent_commons.get_supervisor.cache_clear()
 
     assert agent_commons.get_adapter_mode() == agent_commons.ADAPTER_MODE_DISABLED
     assert agent_commons.get_supervisor().adapters == {}

--- a/agent_commons/tests/test_router_config_and_sse.py
+++ b/agent_commons/tests/test_router_config_and_sse.py
@@ -1,0 +1,40 @@
+import pytest
+
+from portal.routers import agent_commons
+
+
+def test_adapter_mode_defaults_to_disabled(monkeypatch):
+    monkeypatch.delenv("AGENT_COMMONS_ADAPTER_MODE", raising=False)
+    agent_commons.get_supervisor.cache_clear()
+
+    assert agent_commons.get_adapter_mode() == agent_commons.ADAPTER_MODE_DISABLED
+    assert agent_commons.get_supervisor().adapters == {}
+
+
+def test_mock_adapters_require_explicit_configuration(monkeypatch):
+    monkeypatch.setenv("AGENT_COMMONS_ADAPTER_MODE", "mock")
+    agent_commons.get_supervisor.cache_clear()
+
+    supervisor = agent_commons.get_supervisor()
+
+    assert agent_commons.get_adapter_mode() == agent_commons.ADAPTER_MODE_MOCK
+    assert set(supervisor.adapters) == {"hermes", "codex", "claude-code", "manus"}
+
+
+def test_invalid_adapter_mode_fails_closed(monkeypatch):
+    monkeypatch.setenv("AGENT_COMMONS_ADAPTER_MODE", "production-mock")
+
+    with pytest.raises(RuntimeError, match="AGENT_COMMONS_ADAPTER_MODE"):
+        agent_commons.get_adapter_mode()
+
+
+def test_sse_frame_declares_id_event_retry_and_json_data():
+    frame = agent_commons._encode_sse(
+        {"type": "supervisor.run.updated", "data": {"run_id": "run-1"}},
+        event_id=7,
+    )
+
+    assert frame.startswith("id: 7\n")
+    assert "event: supervisor.run.updated\n" in frame
+    assert f"retry: {agent_commons.SSE_RETRY_MILLISECONDS}\n" in frame
+    assert 'data: {"type": "supervisor.run.updated", "data": {"run_id": "run-1"}}\n\n' in frame

--- a/agent_commons/tests/test_second_defect_corrections.py
+++ b/agent_commons/tests/test_second_defect_corrections.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 
 from agent_commons.adapters import MockAgentAdapter
@@ -6,6 +8,14 @@ from agent_commons.models import RunStatus, SupervisorRun
 from agent_commons.store import AgentCommonsStore
 from agent_commons.supervisor import GovernedSupervisor
 from portal.routers import agent_commons
+
+
+def set_environment(monkeypatch, environment: str) -> None:
+    monkeypatch.setattr(
+        agent_commons,
+        "get_settings",
+        lambda: SimpleNamespace(ENVIRONMENT=environment),
+    )
 
 
 @pytest.mark.asyncio
@@ -88,7 +98,7 @@ def test_task_and_idempotency_uniqueness_are_tenant_scoped():
 
 
 def test_production_requires_shared_postgres(monkeypatch):
-    monkeypatch.setenv("APP_ENV", "production")
+    set_environment(monkeypatch, "production")
     monkeypatch.setenv("AGENT_COMMONS_STORAGE_MODE", "sqlite")
     monkeypatch.setenv("AGENT_COMMONS_EVENT_BACKEND", "redis")
 
@@ -97,7 +107,7 @@ def test_production_requires_shared_postgres(monkeypatch):
 
 
 def test_multi_worker_requires_shared_event_broker(monkeypatch):
-    monkeypatch.setenv("APP_ENV", "development")
+    set_environment(monkeypatch, "development")
     monkeypatch.setenv("WEB_CONCURRENCY", "4")
     monkeypatch.setenv("AGENT_COMMONS_STORAGE_MODE", "sqlite")
     monkeypatch.setenv("AGENT_COMMONS_EVENT_BACKEND", "in_process")
@@ -107,7 +117,7 @@ def test_multi_worker_requires_shared_event_broker(monkeypatch):
 
 
 def test_unimplemented_shared_backends_remain_fail_closed(monkeypatch):
-    monkeypatch.setenv("APP_ENV", "development")
+    set_environment(monkeypatch, "development")
     monkeypatch.setenv("WEB_CONCURRENCY", "1")
     monkeypatch.setenv("AGENT_COMMONS_STORAGE_MODE", "postgres")
     monkeypatch.setenv("AGENT_COMMONS_EVENT_BACKEND", "in_process")

--- a/agent_commons/tests/test_second_defect_corrections.py
+++ b/agent_commons/tests/test_second_defect_corrections.py
@@ -1,0 +1,118 @@
+import asyncio
+
+import pytest
+
+from agent_commons.adapters import MockAgentAdapter
+from agent_commons.events import AgentCommonsEventBus
+from agent_commons.models import RunStatus, SupervisorRun
+from agent_commons.store import AgentCommonsStore
+from agent_commons.supervisor import GovernedSupervisor
+from portal.routers import agent_commons
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_timeout_preserves_subscription():
+    events = AgentCommonsEventBus()
+    subscription = await events.open_subscription("tenant-a")
+    try:
+        assert await events.next_event(subscription, 0.001) is None
+        await events.publish("tenant-a", {"type": "after-heartbeat"})
+        delivered = await events.next_event(subscription, 0.1)
+        assert delivered is not None
+        assert delivered["type"] == "after-heartbeat"
+    finally:
+        await events.close_subscription(subscription)
+
+
+class FailingAdapter(MockAgentAdapter):
+    async def invoke(self, task, context):
+        del task, context
+        raise TimeoutError("provider timeout")
+
+
+@pytest.mark.asyncio
+async def test_invocation_failure_is_persisted_as_failed():
+    store = AgentCommonsStore()
+    supervisor = GovernedSupervisor(
+        store,
+        {
+            "builder": FailingAdapter("builder", ["build"], {}),
+            "reviewer": MockAgentAdapter("reviewer", ["review"], {"approved": True}),
+        },
+    )
+
+    with pytest.raises(TimeoutError, match="provider timeout"):
+        await supervisor.run_objective(
+            tenant_id="tenant-a",
+            workspace_id="ws",
+            channel_id="engineering",
+            thread_id="failure-thread",
+            owner_agent="owner",
+            objective="Exercise timeout handling",
+            builder_agent="builder",
+            reviewer_agent="reviewer",
+            acceptance_criteria=[],
+            idempotency_key="failure-key",
+        )
+
+    messages = store.get_thread("tenant-a", "ws", "engineering", "failure-thread")
+    run_id = messages[0]["trace"]["supervisor_run_id"]
+    persisted = store.get_run("tenant-a", run_id)
+    assert persisted.status is RunStatus.FAILED
+    assert persisted.reconciliation == {
+        "summary": "Agent invocation failed.",
+        "failure_type": "TimeoutError",
+        "failed_agent": "builder",
+    }
+
+
+def test_task_and_idempotency_uniqueness_are_tenant_scoped():
+    store = AgentCommonsStore()
+    common = {
+        "workspace_id": "ws",
+        "channel_id": "engineering",
+        "thread_id": "thread",
+        "objective": "Tenant scoped run",
+        "owner_agent": "owner",
+        "builder_agent": "builder",
+        "reviewer_agent": "reviewer",
+        "acceptance_criteria": [],
+        "task_id": "SPU-SHARED-TASK",
+    }
+    first = SupervisorRun(tenant_id="tenant-a", **common)
+    second = SupervisorRun(tenant_id="tenant-b", **common)
+
+    store.save_run(first, idempotency_key="shared-idempotency-key")
+    store.save_run(second, idempotency_key="shared-idempotency-key")
+
+    assert store.get_run("tenant-a", first.run_id).tenant_id == "tenant-a"
+    assert store.get_run("tenant-b", second.run_id).tenant_id == "tenant-b"
+
+
+def test_production_requires_shared_postgres(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("AGENT_COMMONS_STORAGE_MODE", "sqlite")
+    monkeypatch.setenv("AGENT_COMMONS_EVENT_BACKEND", "redis")
+
+    with pytest.raises(RuntimeError, match="shared PostgreSQL"):
+        agent_commons.validate_runtime_backends()
+
+
+def test_multi_worker_requires_shared_event_broker(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("WEB_CONCURRENCY", "4")
+    monkeypatch.setenv("AGENT_COMMONS_STORAGE_MODE", "sqlite")
+    monkeypatch.setenv("AGENT_COMMONS_EVENT_BACKEND", "in_process")
+
+    with pytest.raises(RuntimeError, match="shared event broker"):
+        agent_commons.validate_runtime_backends()
+
+
+def test_unimplemented_shared_backends_remain_fail_closed(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.setenv("WEB_CONCURRENCY", "1")
+    monkeypatch.setenv("AGENT_COMMONS_STORAGE_MODE", "postgres")
+    monkeypatch.setenv("AGENT_COMMONS_EVENT_BACKEND", "in_process")
+
+    with pytest.raises(RuntimeError, match="not implemented"):
+        agent_commons.validate_runtime_backends()

--- a/agent_commons/tests/test_second_defect_corrections.py
+++ b/agent_commons/tests/test_second_defect_corrections.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 
 from agent_commons.adapters import MockAgentAdapter

--- a/agent_commons/tests/test_store_concurrency.py
+++ b/agent_commons/tests/test_store_concurrency.py
@@ -1,0 +1,62 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from agent_commons.models import LifecycleStatus, MessageRecord, SupervisorRun
+from agent_commons.store import AgentCommonsStore
+
+
+def test_store_serializes_concurrent_reads_and_writes(tmp_path):
+    store = AgentCommonsStore(str(tmp_path / "agent_commons.sqlite3"))
+    run = SupervisorRun(
+        tenant_id="tenant-a",
+        workspace_id="workspace-a",
+        channel_id="channel-a",
+        thread_id="thread-a",
+        objective="exercise concurrent access",
+        owner_agent="owner",
+        builder_agent="builder",
+        reviewer_agent="reviewer",
+        acceptance_criteria=["no sqlite race errors"],
+    )
+    store.save_run(run, idempotency_key="concurrency-test")
+
+    def append(index: int) -> None:
+        store.append_message(
+            MessageRecord(
+                tenant_id="tenant-a",
+                workspace_id="workspace-a",
+                channel_id="channel-a",
+                thread_id="thread-a",
+                task_id=run.task_id,
+                from_agent=f"worker-{index}",
+                to_agents=["supervisor"],
+                status=LifecycleStatus.RESULT,
+                payload={"index": index},
+            )
+        )
+
+    def read(_: int) -> tuple[str, int]:
+        stored = store.get_run("tenant-a", run.run_id)
+        messages = store.get_thread(
+            "tenant-a",
+            "workspace-a",
+            "channel-a",
+            "thread-a",
+        )
+        return stored.run_id, len(messages)
+
+    with ThreadPoolExecutor(max_workers=12) as executor:
+        append_futures = [executor.submit(append, index) for index in range(100)]
+        read_futures = [executor.submit(read, index) for index in range(100)]
+        for future in append_futures:
+            future.result()
+        read_results = [future.result() for future in read_futures]
+
+    assert all(run_id == run.run_id for run_id, _ in read_results)
+    assert len(
+        store.get_thread(
+            "tenant-a",
+            "workspace-a",
+            "channel-a",
+            "thread-a",
+        )
+    ) == 100

--- a/agent_commons/tests/test_supervisor.py
+++ b/agent_commons/tests/test_supervisor.py
@@ -1,0 +1,117 @@
+import pytest
+
+from agent_commons.adapters import MockAgentAdapter
+from agent_commons.models import RunStatus
+from agent_commons.store import AgentCommonsStore
+from agent_commons.supervisor import GovernedSupervisor
+
+
+@pytest.mark.asyncio
+async def test_builder_and_reviewer_complete_without_owner_gate():
+    store = AgentCommonsStore()
+    supervisor = GovernedSupervisor(
+        store,
+        {
+            "builder": MockAgentAdapter("builder", ["build"], {"summary": "candidate", "decision": "ship"}),
+            "reviewer": MockAgentAdapter("reviewer", ["review"], {"summary": "review passed", "approved": True, "decision": "ship"}),
+        },
+    )
+
+    run = await supervisor.run_objective(
+        tenant_id="tenant-a",
+        workspace_id="ws-1",
+        channel_id="engineering",
+        thread_id="thread-1",
+        owner_agent="isiah",
+        objective="Build a bounded feature",
+        builder_agent="builder",
+        reviewer_agent="reviewer",
+        acceptance_criteria=["tests pass"],
+        idempotency_key="objective-1",
+    )
+
+    assert run.status is RunStatus.COMPLETED
+    assert run.approval_id is None
+    messages = store.get_thread("tenant-a", "ws-1", "engineering", "thread-1")
+    assert [message["status"] for message in messages] == ["ASSIGNED", "RESULT", "RESULT", "RESULT"]
+
+
+@pytest.mark.asyncio
+async def test_material_disagreement_requires_owner_approval():
+    store = AgentCommonsStore()
+    supervisor = GovernedSupervisor(
+        store,
+        {
+            "builder": MockAgentAdapter("builder", ["build"], {"decision": "ship"}),
+            "reviewer": MockAgentAdapter("reviewer", ["review"], {"approved": False, "material_disagreement": True}),
+        },
+    )
+
+    run = await supervisor.run_objective(
+        tenant_id="tenant-a",
+        workspace_id="ws-1",
+        channel_id="engineering",
+        thread_id="thread-2",
+        owner_agent="isiah",
+        objective="Review risky change",
+        builder_agent="builder",
+        reviewer_agent="reviewer",
+        acceptance_criteria=["no material defects"],
+        idempotency_key="objective-2",
+    )
+
+    assert run.status is RunStatus.WAITING_APPROVAL
+    assert run.approval_id
+    approved = supervisor.approve("tenant-a", run.run_id, run.approval_id, "Owner accepts the risk")
+    assert approved.status is RunStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_prohibited_action_stops_before_agent_invocation():
+    store = AgentCommonsStore()
+    builder = MockAgentAdapter("builder", ["build"], {"decision": "ship"})
+    reviewer = MockAgentAdapter("reviewer", ["review"], {"approved": True})
+    supervisor = GovernedSupervisor(store, {"builder": builder, "reviewer": reviewer})
+
+    run = await supervisor.run_objective(
+        tenant_id="tenant-a",
+        workspace_id="ws-1",
+        channel_id="engineering",
+        thread_id="thread-3",
+        owner_agent="isiah",
+        objective="Deploy to production",
+        builder_agent="builder",
+        reviewer_agent="reviewer",
+        acceptance_criteria=[],
+        idempotency_key="objective-3",
+        requested_actions=["deploy"],
+    )
+
+    assert run.status is RunStatus.WAITING_APPROVAL
+    assert builder.invocations == []
+    assert reviewer.invocations == []
+
+
+@pytest.mark.asyncio
+async def test_idempotency_returns_existing_run():
+    store = AgentCommonsStore()
+    supervisor = GovernedSupervisor(
+        store,
+        {
+            "builder": MockAgentAdapter("builder", ["build"], {"decision": "ship"}),
+            "reviewer": MockAgentAdapter("reviewer", ["review"], {"approved": True, "decision": "ship"}),
+        },
+    )
+    kwargs = dict(
+        tenant_id="tenant-a", workspace_id="ws-1", channel_id="engineering", thread_id="thread-4",
+        owner_agent="isiah", objective="Idempotent task", builder_agent="builder", reviewer_agent="reviewer",
+        acceptance_criteria=[], idempotency_key="same-key",
+    )
+    first = await supervisor.run_objective(**kwargs)
+    second = await supervisor.run_objective(**kwargs)
+    assert first.run_id == second.run_id
+
+
+def test_cross_tenant_thread_access_fails_closed():
+    store = AgentCommonsStore()
+    assert store.get_thread("tenant-b", "ws-1", "engineering", "missing") == []

--- a/agent_commons/tests/test_supervisor.py
+++ b/agent_commons/tests/test_supervisor.py
@@ -12,8 +12,14 @@ async def test_builder_and_reviewer_complete_without_owner_gate():
     supervisor = GovernedSupervisor(
         store,
         {
-            "builder": MockAgentAdapter("builder", ["build"], {"summary": "candidate", "decision": "ship"}),
-            "reviewer": MockAgentAdapter("reviewer", ["review"], {"summary": "review passed", "approved": True, "decision": "ship"}),
+            "builder": MockAgentAdapter(
+                "builder", ["build"], {"summary": "candidate", "decision": "ship"}
+            ),
+            "reviewer": MockAgentAdapter(
+                "reviewer",
+                ["review"],
+                {"summary": "review passed", "approved": True, "decision": "ship"},
+            ),
         },
     )
 
@@ -33,7 +39,12 @@ async def test_builder_and_reviewer_complete_without_owner_gate():
     assert run.status is RunStatus.COMPLETED
     assert run.approval_id is None
     messages = store.get_thread("tenant-a", "ws-1", "engineering", "thread-1")
-    assert [message["status"] for message in messages] == ["ASSIGNED", "RESULT", "RESULT", "RESULT"]
+    assert [message["status"] for message in messages] == [
+        "ASSIGNED",
+        "RESULT",
+        "RESULT",
+        "RESULT",
+    ]
 
 
 @pytest.mark.asyncio
@@ -43,7 +54,11 @@ async def test_material_disagreement_requires_owner_approval():
         store,
         {
             "builder": MockAgentAdapter("builder", ["build"], {"decision": "ship"}),
-            "reviewer": MockAgentAdapter("reviewer", ["review"], {"approved": False, "material_disagreement": True}),
+            "reviewer": MockAgentAdapter(
+                "reviewer",
+                ["review"],
+                {"approved": False, "material_disagreement": True},
+            ),
         },
     )
 
@@ -62,7 +77,12 @@ async def test_material_disagreement_requires_owner_approval():
 
     assert run.status is RunStatus.WAITING_APPROVAL
     assert run.approval_id
-    approved = supervisor.approve("tenant-a", run.run_id, run.approval_id, "Owner accepts the risk")
+    approved = supervisor.approve(
+        "tenant-a",
+        run.run_id,
+        run.approval_id,
+        "Owner accepts the risk",
+    )
     assert approved.status is RunStatus.COMPLETED
 
 
@@ -99,14 +119,25 @@ async def test_idempotency_returns_existing_run():
         store,
         {
             "builder": MockAgentAdapter("builder", ["build"], {"decision": "ship"}),
-            "reviewer": MockAgentAdapter("reviewer", ["review"], {"approved": True, "decision": "ship"}),
+            "reviewer": MockAgentAdapter(
+                "reviewer",
+                ["review"],
+                {"approved": True, "decision": "ship"},
+            ),
         },
     )
-    kwargs = dict(
-        tenant_id="tenant-a", workspace_id="ws-1", channel_id="engineering", thread_id="thread-4",
-        owner_agent="isiah", objective="Idempotent task", builder_agent="builder", reviewer_agent="reviewer",
-        acceptance_criteria=[], idempotency_key="same-key",
-    )
+    kwargs = {
+        "tenant_id": "tenant-a",
+        "workspace_id": "ws-1",
+        "channel_id": "engineering",
+        "thread_id": "thread-4",
+        "owner_agent": "isiah",
+        "objective": "Idempotent task",
+        "builder_agent": "builder",
+        "reviewer_agent": "reviewer",
+        "acceptance_criteria": [],
+        "idempotency_key": "same-key",
+    }
     first = await supervisor.run_objective(**kwargs)
     second = await supervisor.run_objective(**kwargs)
     assert first.run_id == second.run_id

--- a/agent_commons/tests/test_third_defect_corrections.py
+++ b/agent_commons/tests/test_third_defect_corrections.py
@@ -114,3 +114,9 @@ async def test_approved_action_gate_does_not_claim_completion():
     assert updated["status"] == RunStatus.PENDING.value
     assert updated["reconciliation"]["execution_pending"] is True
     assert updated["builder_result"] is None
+
+    messages = store.get_thread("tenant-a", "ws", "channel", "thread")
+    statuses = [message["status"] for message in messages]
+    assert statuses == ["BLOCKED", "ACK"]
+    assert "CLOSED" not in statuses
+    assert messages[-1]["payload"]["execution_pending"] is True

--- a/agent_commons/tests/test_third_defect_corrections.py
+++ b/agent_commons/tests/test_third_defect_corrections.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent_commons.adapters import MockAgentAdapter
+from agent_commons.events import AgentCommonsEventBus
+from agent_commons.models import RunStatus, SupervisorRun
+from agent_commons.store import AgentCommonsStore
+from agent_commons.supervisor import GovernedSupervisor
+from portal.routers import agent_commons
+
+
+def test_frontend_uses_portal_token_and_authoritative_resync():
+    source = Path("web/src/pages/AgentCommons.tsx").read_text(encoding="utf-8")
+
+    assert "sintraprime_token" in source
+    assert "localStorage.getItem('access_token')" not in source
+    assert "'/runs?limit=50'" in source
+    assert "await loadRuns();" in source
+
+
+def test_runtime_uses_authoritative_portal_environment(monkeypatch):
+    monkeypatch.setattr(
+        agent_commons,
+        "get_settings",
+        lambda: SimpleNamespace(ENVIRONMENT="production"),
+    )
+    monkeypatch.setenv("AGENT_COMMONS_STORAGE_MODE", "sqlite")
+    monkeypatch.setenv("AGENT_COMMONS_EVENT_BACKEND", "redis")
+
+    with pytest.raises(RuntimeError, match="shared PostgreSQL"):
+        agent_commons.validate_runtime_backends()
+
+
+def test_multi_worker_count_blocks_in_process_events(monkeypatch):
+    monkeypatch.setattr(
+        agent_commons,
+        "get_settings",
+        lambda: SimpleNamespace(ENVIRONMENT="development"),
+    )
+    monkeypatch.setenv("WEB_CONCURRENCY", "4")
+    monkeypatch.setenv("AGENT_COMMONS_STORAGE_MODE", "sqlite")
+    monkeypatch.setenv("AGENT_COMMONS_EVENT_BACKEND", "in_process")
+
+    with pytest.raises(RuntimeError, match="shared event broker"):
+        agent_commons.validate_runtime_backends()
+
+
+def test_list_runs_is_tenant_scoped_and_recent_first():
+    store = AgentCommonsStore()
+    first = SupervisorRun(
+        tenant_id="tenant-a",
+        workspace_id="ws",
+        channel_id="channel",
+        thread_id="thread-a",
+        objective="first",
+        owner_agent="owner",
+        builder_agent="builder",
+        reviewer_agent="reviewer",
+        acceptance_criteria=[],
+    )
+    second = SupervisorRun(
+        tenant_id="tenant-b",
+        workspace_id="ws",
+        channel_id="channel",
+        thread_id="thread-b",
+        objective="other tenant",
+        owner_agent="owner",
+        builder_agent="builder",
+        reviewer_agent="reviewer",
+        acceptance_criteria=[],
+    )
+    store.save_run(first, idempotency_key="first-key")
+    store.save_run(second, idempotency_key="second-key")
+
+    runs = store.list_runs("tenant-a")
+    assert [run.run_id for run in runs] == [first.run_id]
+
+
+@pytest.mark.asyncio
+async def test_approved_action_gate_does_not_claim_completion():
+    store = AgentCommonsStore()
+    supervisor = GovernedSupervisor(
+        store,
+        {
+            "builder": MockAgentAdapter("builder", ["build"], {"decision": "ship"}),
+            "reviewer": MockAgentAdapter("reviewer", ["review"], {"approved": True}),
+        },
+    )
+    run = await supervisor.run_objective(
+        tenant_id="tenant-a",
+        workspace_id="ws",
+        channel_id="channel",
+        thread_id="thread",
+        owner_agent="owner",
+        objective="Deploy after approval",
+        builder_agent="builder",
+        reviewer_agent="reviewer",
+        acceptance_criteria=[],
+        idempotency_key="approval-key",
+        requested_actions=["deploy"],
+    )
+    assert run.status is RunStatus.WAITING_APPROVAL
+
+    updated = await agent_commons.approve_run(
+        run.run_id,
+        agent_commons.ApprovalRequest(note="approved"),
+        user=SimpleNamespace(tenant_id="tenant-a", user_id="owner"),
+        supervisor=supervisor,
+        events=AgentCommonsEventBus(),
+    )
+
+    assert updated["status"] == RunStatus.PENDING.value
+    assert updated["reconciliation"]["execution_pending"] is True
+    assert updated["builder_result"] is None

--- a/portal/main.py
+++ b/portal/main.py
@@ -7,10 +7,8 @@ from contextlib import asynccontextmanager
 from dotenv import load_dotenv
 from fastapi import FastAPI
 
-# Load environment variables
 load_dotenv()
 
-# Import settings and services using get_settings() instead of module-level constants
 from portal.admin.dashboard import router as admin_dashboard_router
 from portal.config import get_settings
 from portal.middleware.correlation_middleware import CorrelationMiddleware
@@ -20,6 +18,7 @@ from portal.middleware.session_middleware import SessionMiddleware
 from portal.middleware.timestamp_middleware import TimestampMiddleware
 from portal.routers import (
     admin,
+    agent_commons,
     auth,
     billing,
     blackstone,
@@ -47,13 +46,8 @@ def build_session_config() -> SessionConfig:
     """Build a boot-safe SSO session config from application settings."""
     settings = get_settings()
     jwt_secret_key = settings.JWT_SECRET_KEY
-
-    # The shipped development JWT placeholder can be shorter than the SSO
-    # config requires. Fall back to the app SECRET_KEY for local smoke tests
-    # while still respecting an explicitly configured JWT_SECRET_KEY.
     if len(jwt_secret_key) < 32:
         jwt_secret_key = settings.SECRET_KEY
-
     return SessionConfig(
         jwt_secret_key=jwt_secret_key,
         jwt_algorithm=settings.JWT_ALGORITHM,
@@ -74,16 +68,11 @@ def build_session_config() -> SessionConfig:
 async def lifespan(app: FastAPI):
     """Application startup and shutdown."""
     logger.info("Portal starting up...")
-
-    # Initialize services
     session_config = build_session_config()
     app.state.session_manager = SessionManager(session_config)
     app.state.jwt_service = JWTTokenService(session_config)
-
-    # Initialize security layer
     settings = get_settings()
     app.state.security_layer = SecurityLayer(settings)
-
     logger.info("Portal startup complete")
     yield
     logger.info("Portal shutting down...")
@@ -92,36 +81,24 @@ async def lifespan(app: FastAPI):
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     settings = get_settings()
-
     app = FastAPI(
         title="SintraPrime Unified Portal",
         description="Unified authentication, trust compliance, and admin interface",
         version="1.0.0",
         lifespan=lifespan,
     )
-
-    # CORS Middleware (single path only - use settings)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.CORS_ORIGINS,
         allow_credentials=True,
         allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-        allow_headers=["*"]
+        allow_headers=["*"],
     )
-
-    # Session Middleware (must come before routers that use request.session)
     app.add_middleware(SessionMiddleware)
-
-    # Rate Limiter Middleware
     app.add_middleware(RateLimiterMiddleware)
-
-    # Timestamp Middleware
     app.add_middleware(TimestampMiddleware)
-
-    # Correlation Middleware (must be outermost to provide request IDs to all downstream)
     app.add_middleware(CorrelationMiddleware)
 
-    # Register routers
     app.include_router(sso.router, prefix="/api/v1/sso", tags=["sso"])
     app.include_router(admin.router, prefix="/api/v1/admin", tags=["admin"])
     app.include_router(documents.router, prefix="/api/v1/documents", tags=["documents"])
@@ -136,16 +113,15 @@ def create_app() -> FastAPI:
     app.include_router(messages.router, prefix="/api/v1/messages", tags=["messages"])
     app.include_router(mission_control.router)
     app.include_router(mission_control_commands.router)
+    app.include_router(agent_commons.router)
     app.include_router(notifications.router, prefix="/api/v1/notifications", tags=["notifications"])
     app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
     app.include_router(admin_dashboard_router, prefix="/api/v1", tags=["admin-dashboard"])
 
-    # Health check
     @app.get("/health")
     async def health_check():
         return {"status": "ok", "service": "portal"}
 
-    # Root
     @app.get("/")
     async def root():
         return {"message": "SintraPrime Unified Portal", "version": "1.0.0"}
@@ -153,7 +129,6 @@ def create_app() -> FastAPI:
     return app
 
 
-# Module-level app for ASGI servers (gunicorn, uvicorn, Cloud Run)
 app = create_app()
 
 

--- a/portal/routers/agent_commons.py
+++ b/portal/routers/agent_commons.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import os
 from functools import lru_cache
-from typing import Any, Dict, List
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
@@ -15,7 +15,14 @@ from agent_commons.events import AgentCommonsEventBus
 from agent_commons.models import RunStatus
 from agent_commons.store import AgentCommonsStore
 from agent_commons.supervisor import GovernedSupervisor
-from portal.auth.rbac import CurrentUser, Permission, Role, get_current_user, require_permissions, require_role
+from portal.auth.rbac import (
+    CurrentUser,
+    Permission,
+    Role,
+    get_current_user,
+    require_permissions,
+    require_role,
+)
 
 router = APIRouter(prefix="/api/v1/agent-commons", tags=["agent-commons"])
 
@@ -27,8 +34,8 @@ class ObjectiveRequest(BaseModel):
     objective: str = Field(min_length=3, max_length=20_000)
     builder_agent: str = Field(min_length=1, max_length=120)
     reviewer_agent: str = Field(min_length=1, max_length=120)
-    acceptance_criteria: List[str] = Field(default_factory=list, max_length=50)
-    requested_actions: List[str] = Field(default_factory=list, max_length=25)
+    acceptance_criteria: list[str] = Field(default_factory=list, max_length=50)
+    requested_actions: list[str] = Field(default_factory=list, max_length=25)
     idempotency_key: str = Field(min_length=8, max_length=200)
 
 
@@ -41,7 +48,10 @@ class MessageRequest(BaseModel):
     channel_id: str = Field(min_length=1, max_length=120)
     thread_id: str = Field(min_length=1, max_length=160)
     message: str = Field(min_length=1, max_length=20_000)
-    to_agents: List[str] = Field(default_factory=lambda: ["supervisor"], max_length=25)
+    to_agents: list[str] = Field(
+        default_factory=lambda: ["supervisor"],
+        max_length=25,
+    )
 
 
 @lru_cache(maxsize=1)
@@ -57,18 +67,36 @@ def get_event_bus() -> AgentCommonsEventBus:
 
 @lru_cache(maxsize=1)
 def get_supervisor() -> GovernedSupervisor:
-    # Safe defaults keep the API bootable without external credentials.
-    # Production adapters are registered through the application composition layer.
     adapters = {
-        "hermes": MockAgentAdapter("hermes", ["orchestrate", "evidence"], {"summary": "Hermes adapter not connected", "decision": "hold"}),
-        "codex": MockAgentAdapter("codex", ["code", "test"], {"summary": "Codex adapter not connected", "decision": "hold"}),
-        "claude-code": MockAgentAdapter("claude-code", ["review", "architecture"], {"summary": "Claude adapter not connected", "approved": False, "material_disagreement": True}),
-        "manus": MockAgentAdapter("manus", ["research", "implement"], {"summary": "Manus adapter not connected", "decision": "hold"}),
+        "hermes": MockAgentAdapter(
+            "hermes",
+            ["orchestrate", "evidence"],
+            {"summary": "Hermes adapter not connected", "decision": "hold"},
+        ),
+        "codex": MockAgentAdapter(
+            "codex",
+            ["code", "test"],
+            {"summary": "Codex adapter not connected", "decision": "hold"},
+        ),
+        "claude-code": MockAgentAdapter(
+            "claude-code",
+            ["review", "architecture"],
+            {
+                "summary": "Claude adapter not connected",
+                "approved": False,
+                "material_disagreement": True,
+            },
+        ),
+        "manus": MockAgentAdapter(
+            "manus",
+            ["research", "implement"],
+            {"summary": "Manus adapter not connected", "decision": "hold"},
+        ),
     }
     return GovernedSupervisor(get_store(), adapters)
 
 
-def _run_payload(run: Any) -> Dict[str, Any]:
+def _run_payload(run: Any) -> dict[str, Any]:
     return {
         "run_id": run.run_id,
         "task_id": run.task_id,
@@ -93,11 +121,20 @@ def _run_payload(run: Any) -> Dict[str, Any]:
 async def list_agents(
     user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_READ)),
     supervisor: GovernedSupervisor = Depends(get_supervisor),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     agents = []
     for agent_id, adapter in supervisor.adapters.items():
-        health, capabilities = await asyncio.gather(adapter.health(), adapter.capabilities())
-        agents.append({"agent_id": agent_id, "health": health, "capabilities": capabilities})
+        health, capabilities = await asyncio.gather(
+            adapter.health(),
+            adapter.capabilities(),
+        )
+        agents.append(
+            {
+                "agent_id": agent_id,
+                "health": health,
+                "capabilities": capabilities,
+            }
+        )
     return {"tenant_id": user.tenant_id, "agents": agents}
 
 
@@ -107,7 +144,7 @@ async def create_objective(
     user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_CREATE)),
     supervisor: GovernedSupervisor = Depends(get_supervisor),
     events: AgentCommonsEventBus = Depends(get_event_bus),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     try:
         run = await supervisor.run_objective(
             tenant_id=user.tenant_id,
@@ -125,7 +162,10 @@ async def create_objective(
     except (KeyError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     payload = _run_payload(run)
-    await events.publish(user.tenant_id, {"type": "supervisor.run.updated", "data": payload})
+    await events.publish(
+        user.tenant_id,
+        {"type": "supervisor.run.updated", "data": payload},
+    )
     return payload
 
 
@@ -134,7 +174,7 @@ async def get_run(
     run_id: str,
     user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_READ)),
     store: AgentCommonsStore = Depends(get_store),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     try:
         return _run_payload(store.get_run(user.tenant_id, run_id))
     except KeyError as exc:
@@ -148,13 +188,18 @@ async def get_thread(
     thread_id: str,
     user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_READ)),
     store: AgentCommonsStore = Depends(get_store),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     return {
         "tenant_id": user.tenant_id,
         "workspace_id": workspace_id,
         "channel_id": channel_id,
         "thread_id": thread_id,
-        "messages": store.get_thread(user.tenant_id, workspace_id, channel_id, thread_id),
+        "messages": store.get_thread(
+            user.tenant_id,
+            workspace_id,
+            channel_id,
+            thread_id,
+        ),
     }
 
 
@@ -165,13 +210,25 @@ async def approve_run(
     user: CurrentUser = Depends(require_role(Role.FIRM_ADMIN)),
     supervisor: GovernedSupervisor = Depends(get_supervisor),
     events: AgentCommonsEventBus = Depends(get_event_bus),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     run = supervisor.store.get_run(user.tenant_id, run_id)
     if run.status is not RunStatus.WAITING_APPROVAL or not run.approval_id:
         raise HTTPException(status_code=409, detail="run is not waiting for approval")
-    updated = supervisor.approve(user.tenant_id, run_id, run.approval_id, request.note)
+    updated = supervisor.approve(
+        user.tenant_id,
+        run_id,
+        run.approval_id,
+        request.note,
+    )
     payload = _run_payload(updated)
-    await events.publish(user.tenant_id, {"type": "supervisor.run.approved", "actor_id": user.user_id, "data": payload})
+    await events.publish(
+        user.tenant_id,
+        {
+            "type": "supervisor.run.approved",
+            "actor_id": user.user_id,
+            "data": payload,
+        },
+    )
     return payload
 
 
@@ -182,13 +239,25 @@ async def reject_run(
     user: CurrentUser = Depends(require_role(Role.FIRM_ADMIN)),
     supervisor: GovernedSupervisor = Depends(get_supervisor),
     events: AgentCommonsEventBus = Depends(get_event_bus),
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     run = supervisor.store.get_run(user.tenant_id, run_id)
     if run.status is not RunStatus.WAITING_APPROVAL or not run.approval_id:
         raise HTTPException(status_code=409, detail="run is not waiting for approval")
-    updated = supervisor.reject(user.tenant_id, run_id, run.approval_id, request.note)
+    updated = supervisor.reject(
+        user.tenant_id,
+        run_id,
+        run.approval_id,
+        request.note,
+    )
     payload = _run_payload(updated)
-    await events.publish(user.tenant_id, {"type": "supervisor.run.rejected", "actor_id": user.user_id, "data": payload})
+    await events.publish(
+        user.tenant_id,
+        {
+            "type": "supervisor.run.rejected",
+            "actor_id": user.user_id,
+            "data": payload,
+        },
+    )
     return payload
 
 
@@ -202,9 +271,15 @@ async def stream_events(
         iterator = events.subscribe(user.tenant_id).__aiter__()
         while True:
             try:
-                event = await asyncio.wait_for(iterator.__anext__(), timeout=heartbeat_seconds)
-                yield f"event: {event.get('type', 'message')}\ndata: {json.dumps(event, default=str)}\n\n"
-            except asyncio.TimeoutError:
+                event = await asyncio.wait_for(
+                    iterator.__anext__(),
+                    timeout=heartbeat_seconds,
+                )
+                yield (
+                    f"event: {event.get('type', 'message')}\n"
+                    f"data: {json.dumps(event, default=str)}\n\n"
+                )
+            except TimeoutError:
                 yield ": heartbeat\n\n"
             except StopAsyncIteration:
                 return

--- a/portal/routers/agent_commons.py
+++ b/portal/routers/agent_commons.py
@@ -19,7 +19,6 @@ from portal.auth.rbac import (
     CurrentUser,
     Permission,
     Role,
-    get_current_user,
     require_permissions,
     require_role,
 )
@@ -28,6 +27,10 @@ router = APIRouter(prefix="/api/v1/agent-commons", tags=["agent-commons"])
 ADAPTER_MODE_DISABLED = "disabled"
 ADAPTER_MODE_MOCK = "mock"
 SUPPORTED_ADAPTER_MODES = {ADAPTER_MODE_DISABLED, ADAPTER_MODE_MOCK}
+STORAGE_MODE_SQLITE = "sqlite"
+STORAGE_MODE_POSTGRES = "postgres"
+EVENT_BACKEND_IN_PROCESS = "in_process"
+EVENT_BACKEND_REDIS = "redis"
 SSE_RETRY_MILLISECONDS = 3_000
 
 
@@ -47,17 +50,6 @@ class ApprovalRequest(BaseModel):
     note: str = Field(default="", max_length=4_000)
 
 
-class MessageRequest(BaseModel):
-    workspace_id: str = Field(min_length=1, max_length=120)
-    channel_id: str = Field(min_length=1, max_length=120)
-    thread_id: str = Field(min_length=1, max_length=160)
-    message: str = Field(min_length=1, max_length=20_000)
-    to_agents: list[str] = Field(
-        default_factory=lambda: ["supervisor"],
-        max_length=25,
-    )
-
-
 def get_adapter_mode() -> str:
     mode = os.getenv("AGENT_COMMONS_ADAPTER_MODE", ADAPTER_MODE_DISABLED).strip().lower()
     if mode not in SUPPORTED_ADAPTER_MODES:
@@ -68,14 +60,62 @@ def get_adapter_mode() -> str:
     return mode
 
 
+def _is_production() -> bool:
+    value = os.getenv("APP_ENV", os.getenv("ENVIRONMENT", "development"))
+    return value.strip().lower() in {"prod", "production"}
+
+
+def _worker_count() -> int:
+    raw = os.getenv("WEB_CONCURRENCY", os.getenv("GUNICORN_WORKERS", "1"))
+    try:
+        return max(1, int(raw))
+    except ValueError as exc:
+        raise RuntimeError("worker count must be an integer") from exc
+
+
+def get_storage_mode() -> str:
+    return os.getenv("AGENT_COMMONS_STORAGE_MODE", STORAGE_MODE_SQLITE).strip().lower()
+
+
+def get_event_backend() -> str:
+    return os.getenv("AGENT_COMMONS_EVENT_BACKEND", EVENT_BACKEND_IN_PROCESS).strip().lower()
+
+
+def validate_runtime_backends() -> None:
+    storage_mode = get_storage_mode()
+    event_backend = get_event_backend()
+    if storage_mode not in {STORAGE_MODE_SQLITE, STORAGE_MODE_POSTGRES}:
+        raise RuntimeError("unsupported Agent Commons storage mode")
+    if event_backend not in {EVENT_BACKEND_IN_PROCESS, EVENT_BACKEND_REDIS}:
+        raise RuntimeError("unsupported Agent Commons event backend")
+    if _is_production() and storage_mode != STORAGE_MODE_POSTGRES:
+        raise RuntimeError(
+            "Agent Commons is disabled in production until shared PostgreSQL persistence is configured"
+        )
+    if (_is_production() or _worker_count() > 1) and event_backend != EVENT_BACKEND_REDIS:
+        raise RuntimeError(
+            "Agent Commons is disabled for production or multi-worker use until a shared event broker is configured"
+        )
+    if storage_mode == STORAGE_MODE_POSTGRES:
+        raise RuntimeError(
+            "Agent Commons PostgreSQL persistence is not implemented in Increment 1; feature remains fail-closed"
+        )
+    if event_backend == EVENT_BACKEND_REDIS:
+        raise RuntimeError(
+            "Agent Commons Redis event delivery is not implemented in Increment 1; feature remains fail-closed"
+        )
+
+
 @lru_cache(maxsize=1)
 def get_store() -> AgentCommonsStore:
+    validate_runtime_backends()
     database_path = os.getenv("AGENT_COMMONS_DB_PATH", "data/agent_commons.sqlite3")
     return AgentCommonsStore(database_path)
 
 
 @lru_cache(maxsize=1)
 def get_event_bus() -> AgentCommonsEventBus:
+    validate_runtime_backends()
     return AgentCommonsEventBus()
 
 
@@ -86,18 +126,15 @@ def get_supervisor() -> GovernedSupervisor:
     if mode == ADAPTER_MODE_MOCK:
         adapters = {
             "hermes": MockAgentAdapter(
-                "hermes",
-                ["orchestrate", "evidence"],
+                "hermes", ["orchestrate", "evidence"],
                 {"summary": "Hermes mock adapter", "decision": "hold"},
             ),
             "codex": MockAgentAdapter(
-                "codex",
-                ["code", "test"],
+                "codex", ["code", "test"],
                 {"summary": "Codex mock adapter", "decision": "hold"},
             ),
             "claude-code": MockAgentAdapter(
-                "claude-code",
-                ["review", "architecture"],
+                "claude-code", ["review", "architecture"],
                 {
                     "summary": "Claude mock adapter",
                     "approved": False,
@@ -105,8 +142,7 @@ def get_supervisor() -> GovernedSupervisor:
                 },
             ),
             "manus": MockAgentAdapter(
-                "manus",
-                ["research", "implement"],
+                "manus", ["research", "implement"],
                 {"summary": "Manus mock adapter", "decision": "hold"},
             ),
         }
@@ -151,10 +187,7 @@ async def list_agents(
     mode = get_adapter_mode()
     agents = []
     for agent_id, adapter in supervisor.adapters.items():
-        health, capabilities = await asyncio.gather(
-            adapter.health(),
-            adapter.capabilities(),
-        )
+        health, capabilities = await asyncio.gather(adapter.health(), adapter.capabilities())
         agents.append(
             {
                 "agent_id": agent_id,
@@ -165,6 +198,8 @@ async def list_agents(
     return {
         "tenant_id": user.tenant_id,
         "adapter_mode": mode,
+        "storage_mode": get_storage_mode(),
+        "event_backend": get_event_backend(),
         "operational": bool(agents) and mode != ADAPTER_MODE_DISABLED,
         "agents": agents,
     }
@@ -199,10 +234,7 @@ async def create_objective(
     except (KeyError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     payload = _run_payload(run)
-    await events.publish(
-        user.tenant_id,
-        {"type": "supervisor.run.updated", "data": payload},
-    )
+    await events.publish(user.tenant_id, {"type": "supervisor.run.updated", "data": payload})
     return payload
 
 
@@ -232,10 +264,7 @@ async def get_thread(
         "channel_id": channel_id,
         "thread_id": thread_id,
         "messages": store.get_thread(
-            user.tenant_id,
-            workspace_id,
-            channel_id,
-            thread_id,
+            user.tenant_id, workspace_id, channel_id, thread_id
         ),
     }
 
@@ -251,20 +280,11 @@ async def approve_run(
     run = supervisor.store.get_run(user.tenant_id, run_id)
     if run.status is not RunStatus.WAITING_APPROVAL or not run.approval_id:
         raise HTTPException(status_code=409, detail="run is not waiting for approval")
-    updated = supervisor.approve(
-        user.tenant_id,
-        run_id,
-        run.approval_id,
-        request.note,
-    )
+    updated = supervisor.approve(user.tenant_id, run_id, run.approval_id, request.note)
     payload = _run_payload(updated)
     await events.publish(
         user.tenant_id,
-        {
-            "type": "supervisor.run.approved",
-            "actor_id": user.user_id,
-            "data": payload,
-        },
+        {"type": "supervisor.run.approved", "actor_id": user.user_id, "data": payload},
     )
     return payload
 
@@ -280,20 +300,11 @@ async def reject_run(
     run = supervisor.store.get_run(user.tenant_id, run_id)
     if run.status is not RunStatus.WAITING_APPROVAL or not run.approval_id:
         raise HTTPException(status_code=409, detail="run is not waiting for approval")
-    updated = supervisor.reject(
-        user.tenant_id,
-        run_id,
-        run.approval_id,
-        request.note,
-    )
+    updated = supervisor.reject(user.tenant_id, run_id, run.approval_id, request.note)
     payload = _run_payload(updated)
     await events.publish(
         user.tenant_id,
-        {
-            "type": "supervisor.run.rejected",
-            "actor_id": user.user_id,
-            "data": payload,
-        },
+        {"type": "supervisor.run.rejected", "actor_id": user.user_id, "data": payload},
     )
     return payload
 
@@ -301,24 +312,22 @@ async def reject_run(
 @router.get("/events")
 async def stream_events(
     heartbeat_seconds: float = Query(default=15.0, ge=5.0, le=60.0),
-    user: CurrentUser = Depends(get_current_user),
+    user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_READ)),
     events: AgentCommonsEventBus = Depends(get_event_bus),
 ) -> StreamingResponse:
     async def event_stream():
-        iterator = events.subscribe(user.tenant_id).__aiter__()
+        subscription = await events.open_subscription(user.tenant_id)
         event_id = 0
-        while True:
-            try:
-                event = await asyncio.wait_for(
-                    iterator.__anext__(),
-                    timeout=heartbeat_seconds,
-                )
+        try:
+            while True:
+                event = await events.next_event(subscription, heartbeat_seconds)
+                if event is None:
+                    yield f": heartbeat\nretry: {SSE_RETRY_MILLISECONDS}\n\n"
+                    continue
                 event_id += 1
                 yield _encode_sse(event, event_id)
-            except TimeoutError:
-                yield f": heartbeat\nretry: {SSE_RETRY_MILLISECONDS}\n\n"
-            except StopAsyncIteration:
-                return
+        finally:
+            await events.close_subscription(subscription)
 
     return StreamingResponse(
         event_stream(),

--- a/portal/routers/agent_commons.py
+++ b/portal/routers/agent_commons.py
@@ -25,6 +25,10 @@ from portal.auth.rbac import (
 )
 
 router = APIRouter(prefix="/api/v1/agent-commons", tags=["agent-commons"])
+ADAPTER_MODE_DISABLED = "disabled"
+ADAPTER_MODE_MOCK = "mock"
+SUPPORTED_ADAPTER_MODES = {ADAPTER_MODE_DISABLED, ADAPTER_MODE_MOCK}
+SSE_RETRY_MILLISECONDS = 3_000
 
 
 class ObjectiveRequest(BaseModel):
@@ -54,6 +58,16 @@ class MessageRequest(BaseModel):
     )
 
 
+def get_adapter_mode() -> str:
+    mode = os.getenv("AGENT_COMMONS_ADAPTER_MODE", ADAPTER_MODE_DISABLED).strip().lower()
+    if mode not in SUPPORTED_ADAPTER_MODES:
+        raise RuntimeError(
+            "AGENT_COMMONS_ADAPTER_MODE must be one of: "
+            f"{', '.join(sorted(SUPPORTED_ADAPTER_MODES))}"
+        )
+    return mode
+
+
 @lru_cache(maxsize=1)
 def get_store() -> AgentCommonsStore:
     database_path = os.getenv("AGENT_COMMONS_DB_PATH", "data/agent_commons.sqlite3")
@@ -67,32 +81,35 @@ def get_event_bus() -> AgentCommonsEventBus:
 
 @lru_cache(maxsize=1)
 def get_supervisor() -> GovernedSupervisor:
-    adapters = {
-        "hermes": MockAgentAdapter(
-            "hermes",
-            ["orchestrate", "evidence"],
-            {"summary": "Hermes adapter not connected", "decision": "hold"},
-        ),
-        "codex": MockAgentAdapter(
-            "codex",
-            ["code", "test"],
-            {"summary": "Codex adapter not connected", "decision": "hold"},
-        ),
-        "claude-code": MockAgentAdapter(
-            "claude-code",
-            ["review", "architecture"],
-            {
-                "summary": "Claude adapter not connected",
-                "approved": False,
-                "material_disagreement": True,
-            },
-        ),
-        "manus": MockAgentAdapter(
-            "manus",
-            ["research", "implement"],
-            {"summary": "Manus adapter not connected", "decision": "hold"},
-        ),
-    }
+    mode = get_adapter_mode()
+    adapters = {}
+    if mode == ADAPTER_MODE_MOCK:
+        adapters = {
+            "hermes": MockAgentAdapter(
+                "hermes",
+                ["orchestrate", "evidence"],
+                {"summary": "Hermes mock adapter", "decision": "hold"},
+            ),
+            "codex": MockAgentAdapter(
+                "codex",
+                ["code", "test"],
+                {"summary": "Codex mock adapter", "decision": "hold"},
+            ),
+            "claude-code": MockAgentAdapter(
+                "claude-code",
+                ["review", "architecture"],
+                {
+                    "summary": "Claude mock adapter",
+                    "approved": False,
+                    "material_disagreement": True,
+                },
+            ),
+            "manus": MockAgentAdapter(
+                "manus",
+                ["research", "implement"],
+                {"summary": "Manus mock adapter", "decision": "hold"},
+            ),
+        }
     return GovernedSupervisor(get_store(), adapters)
 
 
@@ -117,11 +134,21 @@ def _run_payload(run: Any) -> dict[str, Any]:
     }
 
 
+def _encode_sse(event: dict[str, Any], event_id: int) -> str:
+    return (
+        f"id: {event_id}\n"
+        f"event: {event.get('type', 'message')}\n"
+        f"retry: {SSE_RETRY_MILLISECONDS}\n"
+        f"data: {json.dumps(event, default=str)}\n\n"
+    )
+
+
 @router.get("/agents")
 async def list_agents(
     user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_READ)),
     supervisor: GovernedSupervisor = Depends(get_supervisor),
 ) -> dict[str, Any]:
+    mode = get_adapter_mode()
     agents = []
     for agent_id, adapter in supervisor.adapters.items():
         health, capabilities = await asyncio.gather(
@@ -131,11 +158,16 @@ async def list_agents(
         agents.append(
             {
                 "agent_id": agent_id,
-                "health": health,
+                "health": {**health, "adapter_mode": mode},
                 "capabilities": capabilities,
             }
         )
-    return {"tenant_id": user.tenant_id, "agents": agents}
+    return {
+        "tenant_id": user.tenant_id,
+        "adapter_mode": mode,
+        "operational": bool(agents) and mode != ADAPTER_MODE_DISABLED,
+        "agents": agents,
+    }
 
 
 @router.post("/objectives", status_code=status.HTTP_202_ACCEPTED)
@@ -145,6 +177,11 @@ async def create_objective(
     supervisor: GovernedSupervisor = Depends(get_supervisor),
     events: AgentCommonsEventBus = Depends(get_event_bus),
 ) -> dict[str, Any]:
+    if get_adapter_mode() == ADAPTER_MODE_DISABLED:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Agent Commons adapters are disabled; configure an explicit adapter mode.",
+        )
     try:
         run = await supervisor.run_objective(
             tenant_id=user.tenant_id,
@@ -269,23 +306,26 @@ async def stream_events(
 ) -> StreamingResponse:
     async def event_stream():
         iterator = events.subscribe(user.tenant_id).__aiter__()
+        event_id = 0
         while True:
             try:
                 event = await asyncio.wait_for(
                     iterator.__anext__(),
                     timeout=heartbeat_seconds,
                 )
-                yield (
-                    f"event: {event.get('type', 'message')}\n"
-                    f"data: {json.dumps(event, default=str)}\n\n"
-                )
+                event_id += 1
+                yield _encode_sse(event, event_id)
             except TimeoutError:
-                yield ": heartbeat\n\n"
+                yield f": heartbeat\nretry: {SSE_RETRY_MILLISECONDS}\n\n"
             except StopAsyncIteration:
                 return
 
     return StreamingResponse(
         event_stream(),
         media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
     )

--- a/portal/routers/agent_commons.py
+++ b/portal/routers/agent_commons.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from functools import lru_cache
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+
+from agent_commons.adapters import MockAgentAdapter
+from agent_commons.events import AgentCommonsEventBus
+from agent_commons.models import RunStatus
+from agent_commons.store import AgentCommonsStore
+from agent_commons.supervisor import GovernedSupervisor
+from portal.auth.rbac import CurrentUser, Permission, Role, get_current_user, require_permissions, require_role
+
+router = APIRouter(prefix="/api/v1/agent-commons", tags=["agent-commons"])
+
+
+class ObjectiveRequest(BaseModel):
+    workspace_id: str = Field(min_length=1, max_length=120)
+    channel_id: str = Field(min_length=1, max_length=120)
+    thread_id: str = Field(min_length=1, max_length=160)
+    objective: str = Field(min_length=3, max_length=20_000)
+    builder_agent: str = Field(min_length=1, max_length=120)
+    reviewer_agent: str = Field(min_length=1, max_length=120)
+    acceptance_criteria: List[str] = Field(default_factory=list, max_length=50)
+    requested_actions: List[str] = Field(default_factory=list, max_length=25)
+    idempotency_key: str = Field(min_length=8, max_length=200)
+
+
+class ApprovalRequest(BaseModel):
+    note: str = Field(default="", max_length=4_000)
+
+
+class MessageRequest(BaseModel):
+    workspace_id: str = Field(min_length=1, max_length=120)
+    channel_id: str = Field(min_length=1, max_length=120)
+    thread_id: str = Field(min_length=1, max_length=160)
+    message: str = Field(min_length=1, max_length=20_000)
+    to_agents: List[str] = Field(default_factory=lambda: ["supervisor"], max_length=25)
+
+
+@lru_cache(maxsize=1)
+def get_store() -> AgentCommonsStore:
+    database_path = os.getenv("AGENT_COMMONS_DB_PATH", "data/agent_commons.sqlite3")
+    return AgentCommonsStore(database_path)
+
+
+@lru_cache(maxsize=1)
+def get_event_bus() -> AgentCommonsEventBus:
+    return AgentCommonsEventBus()
+
+
+@lru_cache(maxsize=1)
+def get_supervisor() -> GovernedSupervisor:
+    # Safe defaults keep the API bootable without external credentials.
+    # Production adapters are registered through the application composition layer.
+    adapters = {
+        "hermes": MockAgentAdapter("hermes", ["orchestrate", "evidence"], {"summary": "Hermes adapter not connected", "decision": "hold"}),
+        "codex": MockAgentAdapter("codex", ["code", "test"], {"summary": "Codex adapter not connected", "decision": "hold"}),
+        "claude-code": MockAgentAdapter("claude-code", ["review", "architecture"], {"summary": "Claude adapter not connected", "approved": False, "material_disagreement": True}),
+        "manus": MockAgentAdapter("manus", ["research", "implement"], {"summary": "Manus adapter not connected", "decision": "hold"}),
+    }
+    return GovernedSupervisor(get_store(), adapters)
+
+
+def _run_payload(run: Any) -> Dict[str, Any]:
+    return {
+        "run_id": run.run_id,
+        "task_id": run.task_id,
+        "tenant_id": run.tenant_id,
+        "workspace_id": run.workspace_id,
+        "channel_id": run.channel_id,
+        "thread_id": run.thread_id,
+        "objective": run.objective,
+        "status": run.status.value,
+        "builder_agent": run.builder_agent,
+        "reviewer_agent": run.reviewer_agent,
+        "builder_result": run.builder_result,
+        "review_result": run.review_result,
+        "reconciliation": run.reconciliation,
+        "approval_id": run.approval_id,
+        "created_at": run.created_at,
+        "updated_at": run.updated_at,
+    }
+
+
+@router.get("/agents")
+async def list_agents(
+    user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_READ)),
+    supervisor: GovernedSupervisor = Depends(get_supervisor),
+) -> Dict[str, Any]:
+    agents = []
+    for agent_id, adapter in supervisor.adapters.items():
+        health, capabilities = await asyncio.gather(adapter.health(), adapter.capabilities())
+        agents.append({"agent_id": agent_id, "health": health, "capabilities": capabilities})
+    return {"tenant_id": user.tenant_id, "agents": agents}
+
+
+@router.post("/objectives", status_code=status.HTTP_202_ACCEPTED)
+async def create_objective(
+    request: ObjectiveRequest,
+    user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_CREATE)),
+    supervisor: GovernedSupervisor = Depends(get_supervisor),
+    events: AgentCommonsEventBus = Depends(get_event_bus),
+) -> Dict[str, Any]:
+    try:
+        run = await supervisor.run_objective(
+            tenant_id=user.tenant_id,
+            workspace_id=request.workspace_id,
+            channel_id=request.channel_id,
+            thread_id=request.thread_id,
+            owner_agent=user.user_id,
+            objective=request.objective,
+            builder_agent=request.builder_agent,
+            reviewer_agent=request.reviewer_agent,
+            acceptance_criteria=request.acceptance_criteria,
+            idempotency_key=request.idempotency_key,
+            requested_actions=request.requested_actions,
+        )
+    except (KeyError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    payload = _run_payload(run)
+    await events.publish(user.tenant_id, {"type": "supervisor.run.updated", "data": payload})
+    return payload
+
+
+@router.get("/runs/{run_id}")
+async def get_run(
+    run_id: str,
+    user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_READ)),
+    store: AgentCommonsStore = Depends(get_store),
+) -> Dict[str, Any]:
+    try:
+        return _run_payload(store.get_run(user.tenant_id, run_id))
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="run not found") from exc
+
+
+@router.get("/threads/{workspace_id}/{channel_id}/{thread_id}")
+async def get_thread(
+    workspace_id: str,
+    channel_id: str,
+    thread_id: str,
+    user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_READ)),
+    store: AgentCommonsStore = Depends(get_store),
+) -> Dict[str, Any]:
+    return {
+        "tenant_id": user.tenant_id,
+        "workspace_id": workspace_id,
+        "channel_id": channel_id,
+        "thread_id": thread_id,
+        "messages": store.get_thread(user.tenant_id, workspace_id, channel_id, thread_id),
+    }
+
+
+@router.post("/runs/{run_id}/approve")
+async def approve_run(
+    run_id: str,
+    request: ApprovalRequest,
+    user: CurrentUser = Depends(require_role(Role.FIRM_ADMIN)),
+    supervisor: GovernedSupervisor = Depends(get_supervisor),
+    events: AgentCommonsEventBus = Depends(get_event_bus),
+) -> Dict[str, Any]:
+    run = supervisor.store.get_run(user.tenant_id, run_id)
+    if run.status is not RunStatus.WAITING_APPROVAL or not run.approval_id:
+        raise HTTPException(status_code=409, detail="run is not waiting for approval")
+    updated = supervisor.approve(user.tenant_id, run_id, run.approval_id, request.note)
+    payload = _run_payload(updated)
+    await events.publish(user.tenant_id, {"type": "supervisor.run.approved", "actor_id": user.user_id, "data": payload})
+    return payload
+
+
+@router.post("/runs/{run_id}/reject")
+async def reject_run(
+    run_id: str,
+    request: ApprovalRequest,
+    user: CurrentUser = Depends(require_role(Role.FIRM_ADMIN)),
+    supervisor: GovernedSupervisor = Depends(get_supervisor),
+    events: AgentCommonsEventBus = Depends(get_event_bus),
+) -> Dict[str, Any]:
+    run = supervisor.store.get_run(user.tenant_id, run_id)
+    if run.status is not RunStatus.WAITING_APPROVAL or not run.approval_id:
+        raise HTTPException(status_code=409, detail="run is not waiting for approval")
+    updated = supervisor.reject(user.tenant_id, run_id, run.approval_id, request.note)
+    payload = _run_payload(updated)
+    await events.publish(user.tenant_id, {"type": "supervisor.run.rejected", "actor_id": user.user_id, "data": payload})
+    return payload
+
+
+@router.get("/events")
+async def stream_events(
+    heartbeat_seconds: float = Query(default=15.0, ge=5.0, le=60.0),
+    user: CurrentUser = Depends(get_current_user),
+    events: AgentCommonsEventBus = Depends(get_event_bus),
+) -> StreamingResponse:
+    async def event_stream():
+        iterator = events.subscribe(user.tenant_id).__aiter__()
+        while True:
+            try:
+                event = await asyncio.wait_for(iterator.__anext__(), timeout=heartbeat_seconds)
+                yield f"event: {event.get('type', 'message')}\ndata: {json.dumps(event, default=str)}\n\n"
+            except asyncio.TimeoutError:
+                yield ": heartbeat\n\n"
+            except StopAsyncIteration:
+                return
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/portal/routers/agent_commons.py
+++ b/portal/routers/agent_commons.py
@@ -22,6 +22,7 @@ from portal.auth.rbac import (
     require_permissions,
     require_role,
 )
+from portal.config import get_settings
 
 router = APIRouter(prefix="/api/v1/agent-commons", tags=["agent-commons"])
 ADAPTER_MODE_DISABLED = "disabled"
@@ -61,8 +62,7 @@ def get_adapter_mode() -> str:
 
 
 def _is_production() -> bool:
-    value = os.getenv("APP_ENV", os.getenv("ENVIRONMENT", "development"))
-    return value.strip().lower() in {"prod", "production"}
+    return get_settings().ENVIRONMENT.strip().lower() in {"prod", "production"}
 
 
 def _worker_count() -> int:
@@ -238,6 +238,18 @@ async def create_objective(
     return payload
 
 
+@router.get("/runs")
+async def list_runs(
+    limit: int = Query(default=50, ge=1, le=200),
+    user: CurrentUser = Depends(require_permissions(Permission.MISSION_COMMAND_READ)),
+    store: AgentCommonsStore = Depends(get_store),
+) -> dict[str, Any]:
+    return {
+        "tenant_id": user.tenant_id,
+        "runs": [_run_payload(run) for run in store.list_runs(user.tenant_id, limit)],
+    }
+
+
 @router.get("/runs/{run_id}")
 async def get_run(
     run_id: str,
@@ -281,6 +293,15 @@ async def approve_run(
     if run.status is not RunStatus.WAITING_APPROVAL or not run.approval_id:
         raise HTTPException(status_code=409, detail="run is not waiting for approval")
     updated = supervisor.approve(user.tenant_id, run_id, run.approval_id, request.note)
+    if updated.builder_result is None and updated.reconciliation and updated.reconciliation.get("blocked_actions"):
+        updated.status = RunStatus.PENDING
+        updated.reconciliation = {
+            **updated.reconciliation,
+            "summary": "Owner approval recorded; supervised execution has not yet run.",
+            "authorization_recorded": True,
+            "execution_pending": True,
+        }
+        supervisor.store.update_run(updated)
     payload = _run_payload(updated)
     await events.publish(
         user.tenant_id,

--- a/portal/routers/agent_commons.py
+++ b/portal/routers/agent_commons.py
@@ -292,16 +292,23 @@ async def approve_run(
     run = supervisor.store.get_run(user.tenant_id, run_id)
     if run.status is not RunStatus.WAITING_APPROVAL or not run.approval_id:
         raise HTTPException(status_code=409, detail="run is not waiting for approval")
-    updated = supervisor.approve(user.tenant_id, run_id, run.approval_id, request.note)
-    if updated.builder_result is None and updated.reconciliation and updated.reconciliation.get("blocked_actions"):
-        updated.status = RunStatus.PENDING
-        updated.reconciliation = {
-            **updated.reconciliation,
-            "summary": "Owner approval recorded; supervised execution has not yet run.",
-            "authorization_recorded": True,
-            "execution_pending": True,
-        }
-        supervisor.store.update_run(updated)
+    is_pre_execution_gate = run.builder_result is None and bool(
+        run.reconciliation and run.reconciliation.get("blocked_actions")
+    )
+    if is_pre_execution_gate:
+        updated = supervisor.approve_pre_execution(
+            user.tenant_id,
+            run_id,
+            run.approval_id,
+            request.note,
+        )
+    else:
+        updated = supervisor.approve(
+            user.tenant_id,
+            run_id,
+            run.approval_id,
+            request.note,
+        )
     payload = _run_payload(updated)
     await events.publish(
         user.tenant_id,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import CaseManagement from './pages/CaseManagement';
 import DocumentVault from './pages/DocumentVault';
 import EntityGovernance from './pages/EntityGovernance';
 import AIParliament from './pages/AIParliament';
+import AgentCommons from './pages/AgentCommons';
 import CaseLawSearch from './pages/CaseLawSearch';
 import Settings from './pages/Settings';
 import OperationsFloor from './pages/OperationsFloor';
@@ -36,6 +37,7 @@ function AppContent() {
           <Route path="documents" element={<DocumentVault />} />
           <Route path="entities" element={<EntityGovernance />} />
           <Route path="ai-parliament" element={<AIParliament />} />
+          <Route path="agent-commons" element={<AgentCommons />} />
           <Route path="caselaw" element={<CaseLawSearch />} />
           <Route path="settings" element={<Settings />} />
           <Route path="mission-control" element={<MissionControlLayout />}>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Star,
   Monitor,
   RadioTower,
+  Network,
 } from 'lucide-react';
 import { useAppStore } from '../../store/appStore';
 import { clsx } from 'clsx';
@@ -31,6 +32,7 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   { path: '/mission-control', label: 'Mission Control', icon: RadioTower, badge: 'LIVE', badgeColor: 'green' },
+  { path: '/agent-commons', label: 'Agent Commons', icon: Network, badge: 'NEW', badgeColor: 'blue' },
   { path: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { path: '/legal', label: 'Legal Hub', icon: Scale, badge: '5', badgeColor: 'gold' },
   { path: '/financial', label: 'Financial Empire', icon: TrendingUp },
@@ -65,7 +67,6 @@ export default function Sidebar() {
         borderRight: '1px solid rgba(212,175,55,0.15)',
       }}
     >
-      {/* Logo */}
       <div className="flex items-center gap-3 px-4 py-5 border-b border-slate-800/50">
         <div
           className="flex-shrink-0 w-9 h-9 rounded-xl flex items-center justify-center"
@@ -82,16 +83,13 @@ export default function Sidebar() {
               transition={{ duration: 0.2 }}
               className="overflow-hidden"
             >
-              <div className="text-sm font-bold text-gold-gradient leading-tight whitespace-nowrap">
-                SintraPrime
-              </div>
+              <div className="text-sm font-bold text-gold-gradient leading-tight whitespace-nowrap">SintraPrime</div>
               <div className="text-[10px] text-slate-500 whitespace-nowrap">AI Law & Finance</div>
             </motion.div>
           )}
         </AnimatePresence>
       </div>
 
-      {/* Nav Items */}
       <nav className="flex-1 overflow-y-auto py-4 px-2 space-y-1">
         {navItems.map((item) => {
           const isActive = location.pathname === item.path ||
@@ -103,9 +101,7 @@ export default function Sidebar() {
               <motion.div
                 className={clsx(
                   'flex items-center gap-3 px-3 py-2.5 rounded-xl transition-all duration-200 cursor-pointer relative group',
-                  isActive
-                    ? 'bg-gold/10 text-gold'
-                    : 'text-slate-400 hover:bg-slate-800/60 hover:text-slate-200'
+                  isActive ? 'bg-gold/10 text-gold' : 'text-slate-400 hover:bg-slate-800/60 hover:text-slate-200'
                 )}
                 whileHover={{ x: sidebarCollapsed ? 0 : 2 }}
                 whileTap={{ scale: 0.98 }}
@@ -116,10 +112,7 @@ export default function Sidebar() {
                     className="absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-gold rounded-r-full"
                   />
                 )}
-                <div className={clsx(
-                  'flex-shrink-0 w-5 h-5',
-                  isActive ? 'text-gold' : ''
-                )}>
+                <div className={clsx('flex-shrink-0 w-5 h-5', isActive ? 'text-gold' : '')}>
                   <Icon className="w-5 h-5" />
                 </div>
 
@@ -133,10 +126,7 @@ export default function Sidebar() {
                     >
                       <span className="text-sm font-medium whitespace-nowrap">{item.label}</span>
                       {item.badge && (
-                        <span className={clsx(
-                          'text-[10px] font-semibold px-1.5 py-0.5 rounded-full',
-                          badgeStyles[item.badgeColor || 'gold']
-                        )}>
+                        <span className={clsx('text-[10px] font-semibold px-1.5 py-0.5 rounded-full', badgeStyles[item.badgeColor || 'gold'])}>
                           {item.badge}
                         </span>
                       )}
@@ -144,7 +134,6 @@ export default function Sidebar() {
                   )}
                 </AnimatePresence>
 
-                {/* Tooltip for collapsed state */}
                 {sidebarCollapsed && (
                   <div className="absolute left-full ml-2 px-2 py-1 bg-slate-800 text-slate-200 text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 border border-slate-700">
                     {item.label}
@@ -161,7 +150,6 @@ export default function Sidebar() {
         })}
       </nav>
 
-      {/* Status badges */}
       <AnimatePresence>
         {!sidebarCollapsed && (
           <motion.div
@@ -176,22 +164,17 @@ export default function Sidebar() {
             </div>
             <div className="flex items-center gap-2">
               <Star className="w-3.5 h-3.5 text-gold" />
-              <span className="text-[11px] text-slate-500">AI Parliament: Active</span>
+              <span className="text-[11px] text-slate-500">Agent Commons: Governed</span>
             </div>
           </motion.div>
         )}
       </AnimatePresence>
 
-      {/* Collapse toggle */}
       <button
         onClick={toggleSidebar}
         className="flex items-center justify-center h-10 border-t border-slate-800/50 text-slate-500 hover:text-gold transition-colors"
       >
-        {sidebarCollapsed ? (
-          <ChevronRight className="w-4 h-4" />
-        ) : (
-          <ChevronLeft className="w-4 h-4" />
-        )}
+        {sidebarCollapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
       </button>
     </motion.div>
   );

--- a/web/src/pages/AgentCommons.tsx
+++ b/web/src/pages/AgentCommons.tsx
@@ -1,160 +1,130 @@
-import { useMemo, useState } from 'react';
-import {
-  Activity,
-  AlertTriangle,
-  Bot,
-  BrainCircuit,
-  CheckCircle2,
-  ChevronRight,
-  CircleDot,
-  Clock3,
-  GitBranch,
-  MessageSquare,
-  Network,
-  PauseCircle,
-  Play,
-  Plus,
-  Radio,
-  Search,
-  Send,
-  ShieldCheck,
-  Sparkles,
-  Users,
-  XCircle,
-} from 'lucide-react';
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { Activity, Bot, CheckCircle2, MessageSquare, Network, Play, RefreshCw, Send, ShieldCheck, XCircle } from 'lucide-react';
 import { clsx } from 'clsx';
 
-type AgentState = 'online' | 'busy' | 'idle' | 'offline';
-type TaskState = 'running' | 'review' | 'approval' | 'complete';
+type AgentStatus = { agent_id: string; health: Record<string, unknown>; capabilities: string[] };
+type Run = { run_id: string; task_id: string; objective: string; status: string; builder_agent: string; reviewer_agent: string; approval_id?: string | null; reconciliation?: Record<string, unknown> | null };
+type StreamEvent = { type: string; data?: Run; actor_id?: string };
+const API = '/api/v1/agent-commons';
 
-interface AgentCard {
-  id: string;
-  name: string;
-  role: string;
-  model: string;
-  status: AgentState;
-  capabilities: string[];
-  currentTask?: string;
+function authHeaders(): HeadersInit {
+  const token = localStorage.getItem('access_token');
+  return { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) };
 }
 
-interface TaskCard {
-  id: string;
-  title: string;
-  owner: string;
-  reviewer: string;
-  state: TaskState;
-  updated: string;
-  risk: 'low' | 'medium' | 'high';
-}
-
-const agents: AgentCard[] = [
-  { id: 'supervisor', name: 'Supervisor', role: 'Governed coordinator', model: 'OpenAI adapter', status: 'online', capabilities: ['decompose', 'delegate', 'reconcile', 'escalate'], currentTask: 'Supervising Agent Commons Increment 1' },
-  { id: 'hermes', name: 'Hermes', role: 'Orchestrator', model: 'Hermes runtime', status: 'busy', capabilities: ['repository', 'evidence', 'workflow', 'review'], currentTask: 'Collecting implementation evidence' },
-  { id: 'codex', name: 'Codex', role: 'Builder', model: 'Coding agent', status: 'busy', capabilities: ['code', 'tests', 'refactor', 'debug'], currentTask: 'Building shared-thread API' },
-  { id: 'claude', name: 'Claude Code', role: 'Independent reviewer', model: 'Claude adapter', status: 'idle', capabilities: ['review', 'architecture', 'risk', 'documentation'] },
-  { id: 'manus', name: 'Manus', role: 'Implementation worker', model: 'Manus adapter', status: 'idle', capabilities: ['research', 'implementation', 'documents'] },
-  { id: 'watchtower', name: 'Watchtower', role: 'Observer', model: 'Monitoring service', status: 'online', capabilities: ['health', 'alerts', 'anomaly detection'] },
-];
-
-const tasks: TaskCard[] = [
-  { id: 'SPU-20260802-A1', title: 'Persist shared agent threads and provenance', owner: 'Codex', reviewer: 'Claude Code', state: 'running', updated: '2 minutes ago', risk: 'medium' },
-  { id: 'SPU-20260802-A2', title: 'Review supervisor policy and owner gates', owner: 'Hermes', reviewer: 'Watchtower', state: 'review', updated: '8 minutes ago', risk: 'high' },
-  { id: 'SPU-20260802-A3', title: 'Connect live OpenAI supervisor adapter', owner: 'Supervisor', reviewer: 'Isiah', state: 'approval', updated: '12 minutes ago', risk: 'high' },
-  { id: 'SPU-20260802-A4', title: 'Define adapter contract for external agents', owner: 'Manus', reviewer: 'Hermes', state: 'complete', updated: '31 minutes ago', risk: 'low' },
-];
-
-const channels = [
-  { name: 'command-center', count: 4, active: true },
-  { name: 'engineering', count: 7 },
-  { name: 'research', count: 3 },
-  { name: 'trust-operations', count: 2 },
-  { name: 'revenue-lab', count: 5 },
-  { name: 'incident-room', count: 0 },
-];
-
-const timeline = [
-  { agent: 'Supervisor', status: 'ASSIGNED', message: 'Assigned shared-thread persistence to Codex and an independent architecture review to Claude Code.', time: '9:42 AM' },
-  { agent: 'Codex', status: 'IN_PROGRESS', message: 'Created tenant-scoped storage and bounded context retrieval. Preparing API surface.', time: '9:45 AM' },
-  { agent: 'Hermes', status: 'RESULT', message: 'Governance check confirms merge, deployment, legal dispatch, and financial actions remain owner-controlled.', time: '9:49 AM' },
-  { agent: 'Claude Code', status: 'REVIEW', message: 'Review requested: verify tenant isolation, idempotency, loop prevention, and approval transitions.', time: '9:53 AM' },
-];
-
-const statusStyles: Record<AgentState, string> = {
-  online: 'bg-emerald-400',
-  busy: 'bg-amber-400',
-  idle: 'bg-blue-400',
-  offline: 'bg-slate-600',
-};
-
-const taskStateStyles: Record<TaskState, string> = {
-  running: 'border-blue-500/30 bg-blue-500/10 text-blue-300',
-  review: 'border-violet-500/30 bg-violet-500/10 text-violet-300',
-  approval: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
-  complete: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
-};
-
-function Metric({ label, value, detail, icon: Icon }: { label: string; value: string; detail: string; icon: React.ElementType }) {
-  return (
-    <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4 shadow-lg shadow-black/10">
-      <div className="flex items-start justify-between">
-        <div><p className="text-xs uppercase tracking-[0.18em] text-slate-500">{label}</p><p className="mt-2 text-2xl font-semibold text-white">{value}</p><p className="mt-1 text-xs text-slate-500">{detail}</p></div>
-        <div className="rounded-xl border border-gold/20 bg-gold/10 p-2 text-gold"><Icon className="h-5 w-5" /></div>
-      </div>
-    </div>
-  );
+async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API}${path}`, { ...init, headers: { ...authHeaders(), ...(init?.headers || {}) } });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({ detail: response.statusText }));
+    throw new Error(body.detail || 'Agent Commons request failed');
+  }
+  return response.json() as Promise<T>;
 }
 
 export default function AgentCommons() {
-  const [selectedAgent, setSelectedAgent] = useState('supervisor');
-  const [composer, setComposer] = useState('');
-  const [autoSupervise, setAutoSupervise] = useState(true);
-  const selected = useMemo(() => agents.find((agent) => agent.id === selectedAgent) ?? agents[0], [selectedAgent]);
+  const [agents, setAgents] = useState<AgentStatus[]>([]);
+  const [runs, setRuns] = useState<Run[]>([]);
+  const [objective, setObjective] = useState('');
+  const [builder, setBuilder] = useState('codex');
+  const [reviewer, setReviewer] = useState('claude-code');
+  const [connection, setConnection] = useState<'connecting' | 'live' | 'offline'>('connecting');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
 
-  return (
-    <div className="space-y-6 pb-10">
-      <section className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-        <div>
-          <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.22em] text-gold"><Network className="h-4 w-4" /> SintraPrime Agent Commons</div>
-          <h1 className="text-3xl font-semibold text-white">One command center for every agent</h1>
-          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">Shared context, supervised delegation, independent review, durable evidence, and owner approval gates in one governed workspace.</p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <span className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-blue-300"><Play className="h-3.5 w-3.5" /> Preview</span>
-          <button onClick={() => setAutoSupervise((value) => !value)} className={clsx('inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition', autoSupervise ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300' : 'border-slate-700 bg-slate-900 text-slate-400')}><Radio className="h-4 w-4" /> Auto-supervise {autoSupervise ? 'on' : 'off'}</button>
-          <button className="inline-flex items-center gap-2 rounded-xl bg-gold px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-yellow-300"><Plus className="h-4 w-4" /> New objective</button>
-        </div>
-      </section>
+  const loadAgents = useCallback(async () => {
+    try {
+      const result = await api<{ agents: AgentStatus[] }>('/agents');
+      setAgents(result.agents);
+      setError('');
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : 'Unable to load agents');
+    }
+  }, []);
 
-      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <Metric label="Agents connected" value="6" detail="4 active · 2 standing by" icon={Bot} />
-        <Metric label="Open tasks" value="4" detail="1 requires your approval" icon={Activity} />
-        <Metric label="Shared threads" value="21" detail="All tenant-scoped and traceable" icon={MessageSquare} />
-        <Metric label="Governance state" value="Protected" detail="External actions default-deny" icon={ShieldCheck} />
-      </section>
+  useEffect(() => { void loadAgents(); }, [loadAgents]);
 
-      <section className="grid min-h-[720px] gap-4 xl:grid-cols-[240px_minmax(0,1fr)_330px]">
-        <aside className="rounded-2xl border border-slate-800 bg-slate-900/70 p-3">
-          <div className="flex items-center justify-between px-2 py-2"><div><p className="text-xs uppercase tracking-[0.16em] text-slate-500">Workspace</p><p className="mt-1 text-sm font-semibold text-white">SintraPrime Unified</p></div><button className="rounded-lg p-2 text-slate-500 hover:bg-slate-800 hover:text-white"><Search className="h-4 w-4" /></button></div>
-          <div className="mt-4"><p className="px-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-600">Channels</p><div className="mt-2 space-y-1">{channels.map((channel) => <button key={channel.name} className={clsx('flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition', channel.active ? 'bg-gold/10 text-gold' : 'text-slate-400 hover:bg-slate-800/70 hover:text-white')}><span className="flex items-center gap-2"><MessageSquare className="h-4 w-4" />{channel.name}</span>{channel.count > 0 && <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[10px] text-slate-400">{channel.count}</span>}</button>)}</div></div>
-          <div className="mt-6"><div className="flex items-center justify-between px-2"><p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-600">Agents</p><span className="text-[10px] text-emerald-400">6 connected</span></div><div className="mt-2 space-y-1">{agents.map((agent) => <button key={agent.id} onClick={() => setSelectedAgent(agent.id)} className={clsx('flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left transition', selectedAgent === agent.id ? 'bg-slate-800 text-white' : 'text-slate-400 hover:bg-slate-800/60')}><div className="relative flex h-8 w-8 items-center justify-center rounded-lg bg-slate-800 text-slate-300"><Bot className="h-4 w-4" /><span className={clsx('absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-slate-900', statusStyles[agent.status])} /></div><div className="min-w-0 flex-1"><p className="truncate text-sm font-medium">{agent.name}</p><p className="truncate text-[11px] text-slate-600">{agent.role}</p></div></button>)}</div></div>
-        </aside>
+  useEffect(() => {
+    const controller = new AbortController();
+    const connect = async () => {
+      setConnection('connecting');
+      try {
+        const response = await fetch(`${API}/events`, { headers: authHeaders(), signal: controller.signal });
+        if (!response.ok || !response.body) throw new Error('Event stream unavailable');
+        setConnection('live');
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const frames = buffer.split('\n\n');
+          buffer = frames.pop() || '';
+          for (const frame of frames) {
+            const dataLine = frame.split('\n').find((line) => line.startsWith('data: '));
+            if (!dataLine) continue;
+            const event = JSON.parse(dataLine.slice(6)) as StreamEvent;
+            if (event.data) setRuns((current) => [event.data!, ...current.filter((run) => run.run_id !== event.data!.run_id)].slice(0, 50));
+          }
+        }
+      } catch (reason) {
+        if (!controller.signal.aborted) {
+          setConnection('offline');
+          setError(reason instanceof Error ? reason.message : 'Event stream disconnected');
+        }
+      }
+    };
+    void connect();
+    return () => controller.abort();
+  }, []);
 
-        <main className="flex min-w-0 flex-col rounded-2xl border border-slate-800 bg-slate-900/50">
-          <div className="flex flex-col gap-3 border-b border-slate-800 p-4 sm:flex-row sm:items-center sm:justify-between"><div><div className="flex items-center gap-2"><h2 className="text-lg font-semibold text-white"># command-center</h2><span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-300">live</span></div><p className="mt-1 text-xs text-slate-500">Supervisor, builders, reviewers, and owner decisions share one durable timeline.</p></div><div className="flex items-center gap-2"><button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><Users className="h-4 w-4" /></button><button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><GitBranch className="h-4 w-4" /></button><button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><Search className="h-4 w-4" /></button></div></div>
-          <div className="flex-1 space-y-4 overflow-y-auto p-4">
-            <div className="rounded-2xl border border-gold/20 bg-gradient-to-br from-gold/10 to-transparent p-4"><div className="flex items-start gap-3"><div className="rounded-xl bg-gold/15 p-2 text-gold"><BrainCircuit className="h-5 w-5" /></div><div><p className="text-sm font-semibold text-white">Current objective</p><p className="mt-1 text-sm leading-6 text-slate-300">Build a durable multi-agent workspace where the supervisor can delegate, agents can debate, evidence is preserved, and Isiah remains final authority.</p><div className="mt-3 flex flex-wrap gap-2 text-[11px]"><span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Owner: Isiah</span><span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Builder: Codex</span><span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Reviewer: Claude Code</span></div></div></div></div>
-            {timeline.map((item) => <div key={`${item.agent}-${item.time}`} className="flex gap-3"><div className="mt-1 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl border border-slate-700 bg-slate-800 text-slate-300"><Bot className="h-4 w-4" /></div><div className="min-w-0 flex-1 rounded-2xl border border-slate-800 bg-slate-950/40 p-4"><div className="flex flex-wrap items-center gap-2"><span className="text-sm font-semibold text-white">{item.agent}</span><span className="rounded-md border border-slate-700 bg-slate-900 px-2 py-0.5 text-[10px] font-semibold text-slate-400">{item.status}</span><span className="ml-auto text-[11px] text-slate-600">{item.time}</span></div><p className="mt-2 text-sm leading-6 text-slate-300">{item.message}</p></div></div>)}
-          </div>
-          <div className="border-t border-slate-800 p-4"><div className="rounded-2xl border border-slate-700 bg-slate-950/70 p-3 focus-within:border-gold/50"><textarea value={composer} onChange={(event) => setComposer(event.target.value)} placeholder="Give the supervisor an objective, tag an agent, or request an independent review…" className="min-h-20 w-full resize-none bg-transparent text-sm text-white outline-none placeholder:text-slate-600" /><div className="mt-2 flex items-center justify-between"><div className="flex gap-2 text-[11px] text-slate-500"><span className="rounded-md bg-slate-900 px-2 py-1">@ agent</span><span className="rounded-md bg-slate-900 px-2 py-1">/ review</span><span className="rounded-md bg-slate-900 px-2 py-1">/ approve</span></div><button disabled={!composer.trim()} className="inline-flex items-center gap-2 rounded-xl bg-gold px-3 py-2 text-xs font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40"><Send className="h-3.5 w-3.5" /> Send objective</button></div></div></div>
-        </main>
+  const pendingApprovals = useMemo(() => runs.filter((run) => run.status === 'waiting_approval'), [runs]);
 
-        <aside className="space-y-4">
-          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex items-center justify-between"><h3 className="text-sm font-semibold text-white">Selected agent</h3><span className={clsx('h-2.5 w-2.5 rounded-full', statusStyles[selected.status])} /></div><div className="mt-4 flex items-center gap-3"><div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gold/10 text-gold"><Bot className="h-6 w-6" /></div><div><p className="font-semibold text-white">{selected.name}</p><p className="text-xs text-slate-500">{selected.role}</p></div></div><dl className="mt-4 space-y-3 text-xs"><div className="flex justify-between gap-3"><dt className="text-slate-500">Runtime</dt><dd className="text-right text-slate-300">{selected.model}</dd></div><div className="flex justify-between gap-3"><dt className="text-slate-500">Status</dt><dd className="capitalize text-slate-300">{selected.status}</dd></div><div><dt className="text-slate-500">Capabilities</dt><dd className="mt-2 flex flex-wrap gap-1.5">{selected.capabilities.map((capability) => <span key={capability} className="rounded-md bg-slate-800 px-2 py-1 text-slate-300">{capability}</span>)}</dd></div></dl>{selected.currentTask && <div className="mt-4 rounded-xl border border-blue-500/20 bg-blue-500/10 p-3"><p className="text-[10px] uppercase tracking-[0.16em] text-blue-400">Current task</p><p className="mt-1 text-xs leading-5 text-blue-200">{selected.currentTask}</p></div>}</div>
-          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex items-center justify-between"><h3 className="text-sm font-semibold text-white">Task queue</h3><button className="text-xs text-gold hover:text-yellow-300">View all</button></div><div className="mt-3 space-y-3">{tasks.map((task) => <button key={task.id} className="w-full rounded-xl border border-slate-800 bg-slate-950/40 p-3 text-left transition hover:border-slate-700"><div className="flex items-start gap-2">{task.state === 'complete' ? <CheckCircle2 className="mt-0.5 h-4 w-4 text-emerald-400" /> : task.state === 'approval' ? <PauseCircle className="mt-0.5 h-4 w-4 text-amber-400" /> : <CircleDot className="mt-0.5 h-4 w-4 text-blue-400" />}<div className="min-w-0 flex-1"><p className="text-xs font-medium leading-5 text-slate-200">{task.title}</p><p className="mt-1 text-[10px] text-slate-600">{task.id} · {task.updated}</p></div></div><div className="mt-3 flex items-center justify-between"><span className={clsx('rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase', taskStateStyles[task.state])}>{task.state}</span><ChevronRight className="h-3.5 w-3.5 text-slate-600" /></div></button>)}</div></div>
-          <div className="rounded-2xl border border-amber-500/20 bg-amber-500/5 p-4"><div className="flex items-start gap-3"><AlertTriangle className="mt-0.5 h-5 w-5 text-amber-400" /><div><p className="text-sm font-semibold text-amber-200">Owner approval required</p><p className="mt-1 text-xs leading-5 text-amber-200/70">Connect the live OpenAI supervisor adapter and authorize its tool allowlist.</p><div className="mt-3 flex gap-2"><button className="inline-flex items-center gap-1 rounded-lg bg-emerald-500/15 px-2.5 py-1.5 text-[11px] font-semibold text-emerald-300"><CheckCircle2 className="h-3.5 w-3.5" /> Approve</button><button className="inline-flex items-center gap-1 rounded-lg bg-rose-500/15 px-2.5 py-1.5 text-[11px] font-semibold text-rose-300"><XCircle className="h-3.5 w-3.5" /> Reject</button></div></div></div></div>
-          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex items-center gap-2 text-sm font-semibold text-white"><Sparkles className="h-4 w-4 text-gold" /> Recommended automation</div><p className="mt-2 text-xs leading-5 text-slate-500">Have the supervisor produce an end-of-day agent recap with completed work, blockers, approvals, and tomorrow's priorities.</p><button className="mt-3 inline-flex items-center gap-2 rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:border-gold/40 hover:text-gold"><Clock3 className="h-3.5 w-3.5" /> Configure schedule</button></div>
-        </aside>
-      </section>
-    </div>
-  );
+  async function submitObjective(event: FormEvent) {
+    event.preventDefault();
+    if (!objective.trim()) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      const run = await api<Run>('/objectives', {
+        method: 'POST',
+        body: JSON.stringify({
+          workspace_id: 'sintraprime-unified', channel_id: 'command-center', thread_id: crypto.randomUUID(),
+          objective: objective.trim(), builder_agent: builder, reviewer_agent: reviewer,
+          acceptance_criteria: ['Provide evidence', 'Respect owner authority', 'Do not perform prohibited external actions'],
+          requested_actions: [], idempotency_key: crypto.randomUUID(),
+        }),
+      });
+      setRuns((current) => [run, ...current.filter((item) => item.run_id !== run.run_id)]);
+      setObjective('');
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : 'Unable to submit objective');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function decide(run: Run, approved: boolean) {
+    try {
+      const updated = await api<Run>(`/runs/${run.run_id}/${approved ? 'approve' : 'reject'}`, {
+        method: 'POST', body: JSON.stringify({ note: approved ? 'Approved in Agent Commons' : 'Rejected in Agent Commons' }),
+      });
+      setRuns((current) => [updated, ...current.filter((item) => item.run_id !== updated.run_id)]);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : 'Approval action failed');
+    }
+  }
+
+  return <div className="space-y-6 pb-10">
+    <section className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between"><div><div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.22em] text-gold"><Network className="h-4 w-4" /> SintraPrime Agent Commons</div><h1 className="text-3xl font-semibold text-white">Governed coordination for every agent</h1><p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">Live agent health, supervised delegation, independent review, durable traces, and authenticated owner decisions.</p></div><div className={clsx('inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-xs font-semibold uppercase tracking-wide', connection === 'live' ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300' : connection === 'connecting' ? 'border-amber-500/30 bg-amber-500/10 text-amber-300' : 'border-rose-500/30 bg-rose-500/10 text-rose-300')}><Play className="h-3.5 w-3.5" /> {connection}</div></section>
+    {error && <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-300">{error}</div>}
+    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"><Metric label="Agents registered" value={String(agents.length)} detail="Provider-neutral adapters" icon={Bot} /><Metric label="Supervisor runs" value={String(runs.length)} detail="Current browser session" icon={Activity} /><Metric label="Pending approvals" value={String(pendingApprovals.length)} detail="Firm-admin authentication required" icon={MessageSquare} /><Metric label="Governance" value="Protected" detail="External actions default-deny" icon={ShieldCheck} /></section>
+    <section className="grid gap-4 xl:grid-cols-[300px_minmax(0,1fr)]"><aside className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex items-center justify-between"><h2 className="font-semibold text-white">Connected agents</h2><button onClick={() => void loadAgents()} className="rounded-lg p-2 text-slate-500 hover:bg-slate-800 hover:text-white"><RefreshCw className="h-4 w-4" /></button></div><div className="mt-4 space-y-3">{agents.map((agent) => <div key={agent.agent_id} className="rounded-xl border border-slate-800 bg-slate-950/50 p-3"><div className="flex items-center gap-2"><span className="h-2.5 w-2.5 rounded-full bg-emerald-400" /><span className="text-sm font-semibold text-white">{agent.agent_id}</span></div><div className="mt-2 flex flex-wrap gap-1">{agent.capabilities.map((capability) => <span key={capability} className="rounded-md bg-slate-800 px-2 py-1 text-[10px] text-slate-400">{capability}</span>)}</div></div>)}</div></aside>
+      <main className="space-y-4"><form onSubmit={submitObjective} className="rounded-2xl border border-gold/20 bg-gradient-to-br from-gold/10 to-slate-900/70 p-5"><h2 className="text-lg font-semibold text-white">New supervised objective</h2><textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-4 min-h-28 w-full rounded-xl border border-slate-700 bg-slate-950/70 p-3 text-sm text-white outline-none focus:border-gold/50" placeholder="Describe the outcome. The supervisor will delegate to a builder and independent reviewer." /><div className="mt-3 grid gap-3 sm:grid-cols-2"><select value={builder} onChange={(event) => setBuilder(event.target.value)} className="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm text-white">{agents.map((agent) => <option key={agent.agent_id} value={agent.agent_id}>{agent.agent_id} — builder</option>)}</select><select value={reviewer} onChange={(event) => setReviewer(event.target.value)} className="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm text-white">{agents.map((agent) => <option key={agent.agent_id} value={agent.agent_id}>{agent.agent_id} — reviewer</option>)}</select></div><button disabled={submitting || !objective.trim() || builder === reviewer} className="mt-4 inline-flex items-center gap-2 rounded-xl bg-gold px-4 py-2 text-sm font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40"><Send className="h-4 w-4" /> {submitting ? 'Submitting…' : 'Start supervised run'}</button></form>
+        <div className="space-y-3">{runs.map((run) => <article key={run.run_id} className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex flex-wrap items-start justify-between gap-3"><div><div className="flex items-center gap-2"><span className="text-xs font-semibold uppercase tracking-wide text-gold">{run.task_id}</span><span className="rounded-full border border-slate-700 px-2 py-0.5 text-[10px] text-slate-400">{run.status}</span></div><h3 className="mt-2 font-semibold text-white">{run.objective}</h3><p className="mt-1 text-xs text-slate-500">Builder: {run.builder_agent} · Reviewer: {run.reviewer_agent}</p></div>{run.status === 'waiting_approval' && <div className="flex gap-2"><button onClick={() => void decide(run, true)} className="inline-flex items-center gap-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-300"><CheckCircle2 className="h-4 w-4" /> Approve</button><button onClick={() => void decide(run, false)} className="inline-flex items-center gap-1 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs font-semibold text-rose-300"><XCircle className="h-4 w-4" /> Reject</button></div>}</div>{run.reconciliation && <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-950/70 p-3 text-xs text-slate-400">{JSON.stringify(run.reconciliation, null, 2)}</pre>}</article>)}</div></main></section>
+  </div>;
+}
+
+function Metric({ label, value, detail, icon: Icon }: { label: string; value: string; detail: string; icon: React.ElementType }) {
+  return <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex items-start justify-between"><div><p className="text-xs uppercase tracking-[0.18em] text-slate-500">{label}</p><p className="mt-2 text-2xl font-semibold text-white">{value}</p><p className="mt-1 text-xs text-slate-500">{detail}</p></div><div className="rounded-xl border border-gold/20 bg-gold/10 p-2 text-gold"><Icon className="h-5 w-5" /></div></div></div>;
 }

--- a/web/src/pages/AgentCommons.tsx
+++ b/web/src/pages/AgentCommons.tsx
@@ -48,96 +48,19 @@ interface TaskCard {
 }
 
 const agents: AgentCard[] = [
-  {
-    id: 'supervisor',
-    name: 'Supervisor',
-    role: 'Governed coordinator',
-    model: 'OpenAI adapter',
-    status: 'online',
-    capabilities: ['decompose', 'delegate', 'reconcile', 'escalate'],
-    currentTask: 'Supervising Agent Commons Increment 1',
-  },
-  {
-    id: 'hermes',
-    name: 'Hermes',
-    role: 'Orchestrator',
-    model: 'Hermes runtime',
-    status: 'busy',
-    capabilities: ['repository', 'evidence', 'workflow', 'review'],
-    currentTask: 'Collecting implementation evidence',
-  },
-  {
-    id: 'codex',
-    name: 'Codex',
-    role: 'Builder',
-    model: 'Coding agent',
-    status: 'busy',
-    capabilities: ['code', 'tests', 'refactor', 'debug'],
-    currentTask: 'Building shared-thread API',
-  },
-  {
-    id: 'claude',
-    name: 'Claude Code',
-    role: 'Independent reviewer',
-    model: 'Claude adapter',
-    status: 'idle',
-    capabilities: ['review', 'architecture', 'risk', 'documentation'],
-  },
-  {
-    id: 'manus',
-    name: 'Manus',
-    role: 'Implementation worker',
-    model: 'Manus adapter',
-    status: 'idle',
-    capabilities: ['research', 'implementation', 'documents'],
-  },
-  {
-    id: 'watchtower',
-    name: 'Watchtower',
-    role: 'Observer',
-    model: 'Monitoring service',
-    status: 'online',
-    capabilities: ['health', 'alerts', 'anomaly detection'],
-  },
+  { id: 'supervisor', name: 'Supervisor', role: 'Governed coordinator', model: 'OpenAI adapter', status: 'online', capabilities: ['decompose', 'delegate', 'reconcile', 'escalate'], currentTask: 'Supervising Agent Commons Increment 1' },
+  { id: 'hermes', name: 'Hermes', role: 'Orchestrator', model: 'Hermes runtime', status: 'busy', capabilities: ['repository', 'evidence', 'workflow', 'review'], currentTask: 'Collecting implementation evidence' },
+  { id: 'codex', name: 'Codex', role: 'Builder', model: 'Coding agent', status: 'busy', capabilities: ['code', 'tests', 'refactor', 'debug'], currentTask: 'Building shared-thread API' },
+  { id: 'claude', name: 'Claude Code', role: 'Independent reviewer', model: 'Claude adapter', status: 'idle', capabilities: ['review', 'architecture', 'risk', 'documentation'] },
+  { id: 'manus', name: 'Manus', role: 'Implementation worker', model: 'Manus adapter', status: 'idle', capabilities: ['research', 'implementation', 'documents'] },
+  { id: 'watchtower', name: 'Watchtower', role: 'Observer', model: 'Monitoring service', status: 'online', capabilities: ['health', 'alerts', 'anomaly detection'] },
 ];
 
 const tasks: TaskCard[] = [
-  {
-    id: 'SPU-20260802-A1',
-    title: 'Persist shared agent threads and provenance',
-    owner: 'Codex',
-    reviewer: 'Claude Code',
-    state: 'running',
-    updated: '2 minutes ago',
-    risk: 'medium',
-  },
-  {
-    id: 'SPU-20260802-A2',
-    title: 'Review supervisor policy and owner gates',
-    owner: 'Hermes',
-    reviewer: 'Watchtower',
-    state: 'review',
-    updated: '8 minutes ago',
-    risk: 'high',
-  },
-  {
-    id: 'SPU-20260802-A3',
-    title: 'Connect live OpenAI supervisor adapter',
-    owner: 'Supervisor',
-    reviewer: 'Isiah',
-    state: 'approval',
-    updated: '12 minutes ago',
-    risk: 'high',
-  },
-  {
-    id: 'SPU-20260802-A4',
-    title: 'Define adapter contract for external agents',
-    owner: 'Manus',
-    reviewer: 'Hermes',
-    state: 'complete',
-    updated: '31 minutes ago',
-    risk: 'low',
-  },
+  { id: 'SPU-20260802-A1', title: 'Persist shared agent threads and provenance', owner: 'Codex', reviewer: 'Claude Code', state: 'running', updated: '2 minutes ago', risk: 'medium' },
+  { id: 'SPU-20260802-A2', title: 'Review supervisor policy and owner gates', owner: 'Hermes', reviewer: 'Watchtower', state: 'review', updated: '8 minutes ago', risk: 'high' },
+  { id: 'SPU-20260802-A3', title: 'Connect live OpenAI supervisor adapter', owner: 'Supervisor', reviewer: 'Isiah', state: 'approval', updated: '12 minutes ago', risk: 'high' },
+  { id: 'SPU-20260802-A4', title: 'Define adapter contract for external agents', owner: 'Manus', reviewer: 'Hermes', state: 'complete', updated: '31 minutes ago', risk: 'low' },
 ];
 
 const channels = [
@@ -150,30 +73,10 @@ const channels = [
 ];
 
 const timeline = [
-  {
-    agent: 'Supervisor',
-    status: 'ASSIGNED',
-    message: 'Assigned shared-thread persistence to Codex and an independent architecture review to Claude Code.',
-    time: '9:42 AM',
-  },
-  {
-    agent: 'Codex',
-    status: 'IN_PROGRESS',
-    message: 'Created tenant-scoped storage and bounded context retrieval. Preparing API surface.',
-    time: '9:45 AM',
-  },
-  {
-    agent: 'Hermes',
-    status: 'RESULT',
-    message: 'Governance check confirms merge, deployment, legal dispatch, and financial actions remain owner-controlled.',
-    time: '9:49 AM',
-  },
-  {
-    agent: 'Claude Code',
-    status: 'REVIEW',
-    message: 'Review requested: verify tenant isolation, idempotency, loop prevention, and approval transitions.',
-    time: '9:53 AM',
-  },
+  { agent: 'Supervisor', status: 'ASSIGNED', message: 'Assigned shared-thread persistence to Codex and an independent architecture review to Claude Code.', time: '9:42 AM' },
+  { agent: 'Codex', status: 'IN_PROGRESS', message: 'Created tenant-scoped storage and bounded context retrieval. Preparing API surface.', time: '9:45 AM' },
+  { agent: 'Hermes', status: 'RESULT', message: 'Governance check confirms merge, deployment, legal dispatch, and financial actions remain owner-controlled.', time: '9:49 AM' },
+  { agent: 'Claude Code', status: 'REVIEW', message: 'Review requested: verify tenant isolation, idempotency, loop prevention, and approval transitions.', time: '9:53 AM' },
 ];
 
 const statusStyles: Record<AgentState, string> = {
@@ -194,14 +97,8 @@ function Metric({ label, value, detail, icon: Icon }: { label: string; value: st
   return (
     <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4 shadow-lg shadow-black/10">
       <div className="flex items-start justify-between">
-        <div>
-          <p className="text-xs uppercase tracking-[0.18em] text-slate-500">{label}</p>
-          <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
-          <p className="mt-1 text-xs text-slate-500">{detail}</p>
-        </div>
-        <div className="rounded-xl border border-gold/20 bg-gold/10 p-2 text-gold">
-          <Icon className="h-5 w-5" />
-        </div>
+        <div><p className="text-xs uppercase tracking-[0.18em] text-slate-500">{label}</p><p className="mt-2 text-2xl font-semibold text-white">{value}</p><p className="mt-1 text-xs text-slate-500">{detail}</p></div>
+        <div className="rounded-xl border border-gold/20 bg-gold/10 p-2 text-gold"><Icon className="h-5 w-5" /></div>
       </div>
     </div>
   );
@@ -217,32 +114,14 @@ export default function AgentCommons() {
     <div className="space-y-6 pb-10">
       <section className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
-          <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.22em] text-gold">
-            <Network className="h-4 w-4" />
-            SintraPrime Agent Commons
-          </div>
+          <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.22em] text-gold"><Network className="h-4 w-4" /> SintraPrime Agent Commons</div>
           <h1 className="text-3xl font-semibold text-white">One command center for every agent</h1>
-          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">
-            Shared context, supervised delegation, independent review, durable evidence, and owner approval gates in one governed workspace.
-          </p>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">Shared context, supervised delegation, independent review, durable evidence, and owner approval gates in one governed workspace.</p>
         </div>
         <div className="flex flex-wrap gap-2">
-          <button
-            onClick={() => setAutoSupervise((value) => !value)}
-            className={clsx(
-              'inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition',
-              autoSupervise
-                ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300'
-                : 'border-slate-700 bg-slate-900 text-slate-400'
-            )}
-          >
-            <Radio className="h-4 w-4" />
-            Auto-supervise {autoSupervise ? 'on' : 'off'}
-          </button>
-          <button className="inline-flex items-center gap-2 rounded-xl bg-gold px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-yellow-300">
-            <Plus className="h-4 w-4" />
-            New objective
-          </button>
+          <span className="inline-flex items-center gap-2 rounded-xl border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-blue-300"><Play className="h-3.5 w-3.5" /> Preview</span>
+          <button onClick={() => setAutoSupervise((value) => !value)} className={clsx('inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition', autoSupervise ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300' : 'border-slate-700 bg-slate-900 text-slate-400')}><Radio className="h-4 w-4" /> Auto-supervise {autoSupervise ? 'on' : 'off'}</button>
+          <button className="inline-flex items-center gap-2 rounded-xl bg-gold px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-yellow-300"><Plus className="h-4 w-4" /> New objective</button>
         </div>
       </section>
 
@@ -255,214 +134,25 @@ export default function AgentCommons() {
 
       <section className="grid min-h-[720px] gap-4 xl:grid-cols-[240px_minmax(0,1fr)_330px]">
         <aside className="rounded-2xl border border-slate-800 bg-slate-900/70 p-3">
-          <div className="flex items-center justify-between px-2 py-2">
-            <div>
-              <p className="text-xs uppercase tracking-[0.16em] text-slate-500">Workspace</p>
-              <p className="mt-1 text-sm font-semibold text-white">SintraPrime Unified</p>
-            </div>
-            <button className="rounded-lg p-2 text-slate-500 hover:bg-slate-800 hover:text-white">
-              <Search className="h-4 w-4" />
-            </button>
-          </div>
-
-          <div className="mt-4">
-            <p className="px-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-600">Channels</p>
-            <div className="mt-2 space-y-1">
-              {channels.map((channel) => (
-                <button
-                  key={channel.name}
-                  className={clsx(
-                    'flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition',
-                    channel.active ? 'bg-gold/10 text-gold' : 'text-slate-400 hover:bg-slate-800/70 hover:text-white'
-                  )}
-                >
-                  <span className="flex items-center gap-2">
-                    <MessageSquare className="h-4 w-4" />
-                    {channel.name}
-                  </span>
-                  {channel.count > 0 && (
-                    <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[10px] text-slate-400">{channel.count}</span>
-                  )}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div className="mt-6">
-            <div className="flex items-center justify-between px-2">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-600">Agents</p>
-              <span className="text-[10px] text-emerald-400">6 connected</span>
-            </div>
-            <div className="mt-2 space-y-1">
-              {agents.map((agent) => (
-                <button
-                  key={agent.id}
-                  onClick={() => setSelectedAgent(agent.id)}
-                  className={clsx(
-                    'flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left transition',
-                    selectedAgent === agent.id ? 'bg-slate-800 text-white' : 'text-slate-400 hover:bg-slate-800/60'
-                  )}
-                >
-                  <div className="relative flex h-8 w-8 items-center justify-center rounded-lg bg-slate-800 text-slate-300">
-                    <Bot className="h-4 w-4" />
-                    <span className={clsx('absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-slate-900', statusStyles[agent.status])} />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium">{agent.name}</p>
-                    <p className="truncate text-[11px] text-slate-600">{agent.role}</p>
-                  </div>
-                </button>
-              ))}
-            </div>
-          </div>
+          <div className="flex items-center justify-between px-2 py-2"><div><p className="text-xs uppercase tracking-[0.16em] text-slate-500">Workspace</p><p className="mt-1 text-sm font-semibold text-white">SintraPrime Unified</p></div><button className="rounded-lg p-2 text-slate-500 hover:bg-slate-800 hover:text-white"><Search className="h-4 w-4" /></button></div>
+          <div className="mt-4"><p className="px-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-600">Channels</p><div className="mt-2 space-y-1">{channels.map((channel) => <button key={channel.name} className={clsx('flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition', channel.active ? 'bg-gold/10 text-gold' : 'text-slate-400 hover:bg-slate-800/70 hover:text-white')}><span className="flex items-center gap-2"><MessageSquare className="h-4 w-4" />{channel.name}</span>{channel.count > 0 && <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[10px] text-slate-400">{channel.count}</span>}</button>)}</div></div>
+          <div className="mt-6"><div className="flex items-center justify-between px-2"><p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-600">Agents</p><span className="text-[10px] text-emerald-400">6 connected</span></div><div className="mt-2 space-y-1">{agents.map((agent) => <button key={agent.id} onClick={() => setSelectedAgent(agent.id)} className={clsx('flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left transition', selectedAgent === agent.id ? 'bg-slate-800 text-white' : 'text-slate-400 hover:bg-slate-800/60')}><div className="relative flex h-8 w-8 items-center justify-center rounded-lg bg-slate-800 text-slate-300"><Bot className="h-4 w-4" /><span className={clsx('absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-slate-900', statusStyles[agent.status])} /></div><div className="min-w-0 flex-1"><p className="truncate text-sm font-medium">{agent.name}</p><p className="truncate text-[11px] text-slate-600">{agent.role}</p></div></button>)}</div></div>
         </aside>
 
         <main className="flex min-w-0 flex-col rounded-2xl border border-slate-800 bg-slate-900/50">
-          <div className="flex flex-col gap-3 border-b border-slate-800 p-4 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <div className="flex items-center gap-2">
-                <h2 className="text-lg font-semibold text-white"># command-center</h2>
-                <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-300">live</span>
-              </div>
-              <p className="mt-1 text-xs text-slate-500">Supervisor, builders, reviewers, and owner decisions share one durable timeline.</p>
-            </div>
-            <div className="flex items-center gap-2">
-              <button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><Users className="h-4 w-4" /></button>
-              <button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><GitBranch className="h-4 w-4" /></button>
-              <button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><Search className="h-4 w-4" /></button>
-            </div>
-          </div>
-
+          <div className="flex flex-col gap-3 border-b border-slate-800 p-4 sm:flex-row sm:items-center sm:justify-between"><div><div className="flex items-center gap-2"><h2 className="text-lg font-semibold text-white"># command-center</h2><span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-300">live</span></div><p className="mt-1 text-xs text-slate-500">Supervisor, builders, reviewers, and owner decisions share one durable timeline.</p></div><div className="flex items-center gap-2"><button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><Users className="h-4 w-4" /></button><button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><GitBranch className="h-4 w-4" /></button><button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><Search className="h-4 w-4" /></button></div></div>
           <div className="flex-1 space-y-4 overflow-y-auto p-4">
-            <div className="rounded-2xl border border-gold/20 bg-gradient-to-br from-gold/10 to-transparent p-4">
-              <div className="flex items-start gap-3">
-                <div className="rounded-xl bg-gold/15 p-2 text-gold"><BrainCircuit className="h-5 w-5" /></div>
-                <div>
-                  <p className="text-sm font-semibold text-white">Current objective</p>
-                  <p className="mt-1 text-sm leading-6 text-slate-300">
-                    Build a durable multi-agent workspace where the supervisor can delegate, agents can debate, evidence is preserved, and Isiah remains final authority.
-                  </p>
-                  <div className="mt-3 flex flex-wrap gap-2 text-[11px]">
-                    <span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Owner: Isiah</span>
-                    <span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Builder: Codex</span>
-                    <span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Reviewer: Claude Code</span>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {timeline.map((item) => (
-              <div key={`${item.agent}-${item.time}`} className="flex gap-3">
-                <div className="mt-1 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl border border-slate-700 bg-slate-800 text-slate-300">
-                  <Bot className="h-4 w-4" />
-                </div>
-                <div className="min-w-0 flex-1 rounded-2xl border border-slate-800 bg-slate-950/40 p-4">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-semibold text-white">{item.agent}</span>
-                    <span className="rounded-md border border-slate-700 bg-slate-900 px-2 py-0.5 text-[10px] font-semibold text-slate-400">{item.status}</span>
-                    <span className="ml-auto text-[11px] text-slate-600">{item.time}</span>
-                  </div>
-                  <p className="mt-2 text-sm leading-6 text-slate-300">{item.message}</p>
-                </div>
-              </div>
-            ))}
+            <div className="rounded-2xl border border-gold/20 bg-gradient-to-br from-gold/10 to-transparent p-4"><div className="flex items-start gap-3"><div className="rounded-xl bg-gold/15 p-2 text-gold"><BrainCircuit className="h-5 w-5" /></div><div><p className="text-sm font-semibold text-white">Current objective</p><p className="mt-1 text-sm leading-6 text-slate-300">Build a durable multi-agent workspace where the supervisor can delegate, agents can debate, evidence is preserved, and Isiah remains final authority.</p><div className="mt-3 flex flex-wrap gap-2 text-[11px]"><span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Owner: Isiah</span><span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Builder: Codex</span><span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Reviewer: Claude Code</span></div></div></div></div>
+            {timeline.map((item) => <div key={`${item.agent}-${item.time}`} className="flex gap-3"><div className="mt-1 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl border border-slate-700 bg-slate-800 text-slate-300"><Bot className="h-4 w-4" /></div><div className="min-w-0 flex-1 rounded-2xl border border-slate-800 bg-slate-950/40 p-4"><div className="flex flex-wrap items-center gap-2"><span className="text-sm font-semibold text-white">{item.agent}</span><span className="rounded-md border border-slate-700 bg-slate-900 px-2 py-0.5 text-[10px] font-semibold text-slate-400">{item.status}</span><span className="ml-auto text-[11px] text-slate-600">{item.time}</span></div><p className="mt-2 text-sm leading-6 text-slate-300">{item.message}</p></div></div>)}
           </div>
-
-          <div className="border-t border-slate-800 p-4">
-            <div className="rounded-2xl border border-slate-700 bg-slate-950/70 p-3 focus-within:border-gold/50">
-              <textarea
-                value={composer}
-                onChange={(event) => setComposer(event.target.value)}
-                placeholder="Give the supervisor an objective, tag an agent, or request an independent review…"
-                className="min-h-20 w-full resize-none bg-transparent text-sm text-white outline-none placeholder:text-slate-600"
-              />
-              <div className="mt-2 flex items-center justify-between">
-                <div className="flex gap-2 text-[11px] text-slate-500">
-                  <span className="rounded-md bg-slate-900 px-2 py-1">@ agent</span>
-                  <span className="rounded-md bg-slate-900 px-2 py-1">/ review</span>
-                  <span className="rounded-md bg-slate-900 px-2 py-1">/ approve</span>
-                </div>
-                <button
-                  disabled={!composer.trim()}
-                  className="inline-flex items-center gap-2 rounded-xl bg-gold px-3 py-2 text-xs font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  <Send className="h-3.5 w-3.5" />
-                  Send objective
-                </button>
-              </div>
-            </div>
-          </div>
+          <div className="border-t border-slate-800 p-4"><div className="rounded-2xl border border-slate-700 bg-slate-950/70 p-3 focus-within:border-gold/50"><textarea value={composer} onChange={(event) => setComposer(event.target.value)} placeholder="Give the supervisor an objective, tag an agent, or request an independent review…" className="min-h-20 w-full resize-none bg-transparent text-sm text-white outline-none placeholder:text-slate-600" /><div className="mt-2 flex items-center justify-between"><div className="flex gap-2 text-[11px] text-slate-500"><span className="rounded-md bg-slate-900 px-2 py-1">@ agent</span><span className="rounded-md bg-slate-900 px-2 py-1">/ review</span><span className="rounded-md bg-slate-900 px-2 py-1">/ approve</span></div><button disabled={!composer.trim()} className="inline-flex items-center gap-2 rounded-xl bg-gold px-3 py-2 text-xs font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40"><Send className="h-3.5 w-3.5" /> Send objective</button></div></div></div>
         </main>
 
         <aside className="space-y-4">
-          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
-            <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-white">Selected agent</h3>
-              <span className={clsx('h-2.5 w-2.5 rounded-full', statusStyles[selected.status])} />
-            </div>
-            <div className="mt-4 flex items-center gap-3">
-              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gold/10 text-gold"><Bot className="h-6 w-6" /></div>
-              <div>
-                <p className="font-semibold text-white">{selected.name}</p>
-                <p className="text-xs text-slate-500">{selected.role}</p>
-              </div>
-            </div>
-            <dl className="mt-4 space-y-3 text-xs">
-              <div className="flex justify-between gap-3"><dt className="text-slate-500">Runtime</dt><dd className="text-right text-slate-300">{selected.model}</dd></div>
-              <div className="flex justify-between gap-3"><dt className="text-slate-500">Status</dt><dd className="capitalize text-slate-300">{selected.status}</dd></div>
-              <div><dt className="text-slate-500">Capabilities</dt><dd className="mt-2 flex flex-wrap gap-1.5">{selected.capabilities.map((capability) => <span key={capability} className="rounded-md bg-slate-800 px-2 py-1 text-slate-300">{capability}</span>)}</dd></div>
-            </dl>
-            {selected.currentTask && (
-              <div className="mt-4 rounded-xl border border-blue-500/20 bg-blue-500/10 p-3">
-                <p className="text-[10px] uppercase tracking-[0.16em] text-blue-400">Current task</p>
-                <p className="mt-1 text-xs leading-5 text-blue-200">{selected.currentTask}</p>
-              </div>
-            )}
-          </div>
-
-          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
-            <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-white">Task queue</h3>
-              <button className="text-xs text-gold hover:text-yellow-300">View all</button>
-            </div>
-            <div className="mt-3 space-y-3">
-              {tasks.map((task) => (
-                <button key={task.id} className="w-full rounded-xl border border-slate-800 bg-slate-950/40 p-3 text-left transition hover:border-slate-700">
-                  <div className="flex items-start gap-2">
-                    {task.state === 'complete' ? <CheckCircle2 className="mt-0.5 h-4 w-4 text-emerald-400" /> : task.state === 'approval' ? <PauseCircle className="mt-0.5 h-4 w-4 text-amber-400" /> : <CircleDot className="mt-0.5 h-4 w-4 text-blue-400" />}
-                    <div className="min-w-0 flex-1">
-                      <p className="text-xs font-medium leading-5 text-slate-200">{task.title}</p>
-                      <p className="mt-1 text-[10px] text-slate-600">{task.id} · {task.updated}</p>
-                    </div>
-                  </div>
-                  <div className="mt-3 flex items-center justify-between">
-                    <span className={clsx('rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase', taskStateStyles[task.state])}>{task.state}</span>
-                    <ChevronRight className="h-3.5 w-3.5 text-slate-600" />
-                  </div>
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div className="rounded-2xl border border-amber-500/20 bg-amber-500/5 p-4">
-            <div className="flex items-start gap-3">
-              <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-400" />
-              <div>
-                <p className="text-sm font-semibold text-amber-200">Owner approval required</p>
-                <p className="mt-1 text-xs leading-5 text-amber-200/70">Connect the live OpenAI supervisor adapter and authorize its tool allowlist.</p>
-                <div className="mt-3 flex gap-2">
-                  <button className="inline-flex items-center gap-1 rounded-lg bg-emerald-500/15 px-2.5 py-1.5 text-[11px] font-semibold text-emerald-300"><CheckCircle2 className="h-3.5 w-3.5" /> Approve</button>
-                  <button className="inline-flex items-center gap-1 rounded-lg bg-rose-500/15 px-2.5 py-1.5 text-[11px] font-semibold text-rose-300"><XCircle className="h-3.5 w-3.5" /> Reject</button>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
-            <div className="flex items-center gap-2 text-sm font-semibold text-white"><Sparkles className="h-4 w-4 text-gold" /> Recommended automation</div>
-            <p className="mt-2 text-xs leading-5 text-slate-500">Have the supervisor produce an end-of-day agent recap with completed work, blockers, approvals, and tomorrow's priorities.</p>
-            <button className="mt-3 inline-flex items-center gap-2 rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:border-gold/40 hover:text-gold"><Clock3 className="h-3.5 w-3.5" /> Configure schedule</button>
-          </div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex items-center justify-between"><h3 className="text-sm font-semibold text-white">Selected agent</h3><span className={clsx('h-2.5 w-2.5 rounded-full', statusStyles[selected.status])} /></div><div className="mt-4 flex items-center gap-3"><div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gold/10 text-gold"><Bot className="h-6 w-6" /></div><div><p className="font-semibold text-white">{selected.name}</p><p className="text-xs text-slate-500">{selected.role}</p></div></div><dl className="mt-4 space-y-3 text-xs"><div className="flex justify-between gap-3"><dt className="text-slate-500">Runtime</dt><dd className="text-right text-slate-300">{selected.model}</dd></div><div className="flex justify-between gap-3"><dt className="text-slate-500">Status</dt><dd className="capitalize text-slate-300">{selected.status}</dd></div><div><dt className="text-slate-500">Capabilities</dt><dd className="mt-2 flex flex-wrap gap-1.5">{selected.capabilities.map((capability) => <span key={capability} className="rounded-md bg-slate-800 px-2 py-1 text-slate-300">{capability}</span>)}</dd></div></dl>{selected.currentTask && <div className="mt-4 rounded-xl border border-blue-500/20 bg-blue-500/10 p-3"><p className="text-[10px] uppercase tracking-[0.16em] text-blue-400">Current task</p><p className="mt-1 text-xs leading-5 text-blue-200">{selected.currentTask}</p></div>}</div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex items-center justify-between"><h3 className="text-sm font-semibold text-white">Task queue</h3><button className="text-xs text-gold hover:text-yellow-300">View all</button></div><div className="mt-3 space-y-3">{tasks.map((task) => <button key={task.id} className="w-full rounded-xl border border-slate-800 bg-slate-950/40 p-3 text-left transition hover:border-slate-700"><div className="flex items-start gap-2">{task.state === 'complete' ? <CheckCircle2 className="mt-0.5 h-4 w-4 text-emerald-400" /> : task.state === 'approval' ? <PauseCircle className="mt-0.5 h-4 w-4 text-amber-400" /> : <CircleDot className="mt-0.5 h-4 w-4 text-blue-400" />}<div className="min-w-0 flex-1"><p className="text-xs font-medium leading-5 text-slate-200">{task.title}</p><p className="mt-1 text-[10px] text-slate-600">{task.id} · {task.updated}</p></div></div><div className="mt-3 flex items-center justify-between"><span className={clsx('rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase', taskStateStyles[task.state])}>{task.state}</span><ChevronRight className="h-3.5 w-3.5 text-slate-600" /></div></button>)}</div></div>
+          <div className="rounded-2xl border border-amber-500/20 bg-amber-500/5 p-4"><div className="flex items-start gap-3"><AlertTriangle className="mt-0.5 h-5 w-5 text-amber-400" /><div><p className="text-sm font-semibold text-amber-200">Owner approval required</p><p className="mt-1 text-xs leading-5 text-amber-200/70">Connect the live OpenAI supervisor adapter and authorize its tool allowlist.</p><div className="mt-3 flex gap-2"><button className="inline-flex items-center gap-1 rounded-lg bg-emerald-500/15 px-2.5 py-1.5 text-[11px] font-semibold text-emerald-300"><CheckCircle2 className="h-3.5 w-3.5" /> Approve</button><button className="inline-flex items-center gap-1 rounded-lg bg-rose-500/15 px-2.5 py-1.5 text-[11px] font-semibold text-rose-300"><XCircle className="h-3.5 w-3.5" /> Reject</button></div></div></div></div>
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex items-center gap-2 text-sm font-semibold text-white"><Sparkles className="h-4 w-4 text-gold" /> Recommended automation</div><p className="mt-2 text-xs leading-5 text-slate-500">Have the supervisor produce an end-of-day agent recap with completed work, blockers, approvals, and tomorrow's priorities.</p><button className="mt-3 inline-flex items-center gap-2 rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:border-gold/40 hover:text-gold"><Clock3 className="h-3.5 w-3.5" /> Configure schedule</button></div>
         </aside>
       </section>
     </div>

--- a/web/src/pages/AgentCommons.tsx
+++ b/web/src/pages/AgentCommons.tsx
@@ -3,9 +3,12 @@ import { Activity, Bot, CheckCircle2, MessageSquare, Network, Play, RefreshCw, S
 import { clsx } from 'clsx';
 
 type AgentStatus = { agent_id: string; health: Record<string, unknown>; capabilities: string[] };
+type AgentsResponse = { agents: AgentStatus[]; adapter_mode: string; operational: boolean };
 type Run = { run_id: string; task_id: string; objective: string; status: string; builder_agent: string; reviewer_agent: string; approval_id?: string | null; reconciliation?: Record<string, unknown> | null };
 type StreamEvent = { type: string; data?: Run; actor_id?: string };
 const API = '/api/v1/agent-commons';
+const INITIAL_RECONNECT_DELAY_MS = 1000;
+const MAX_RECONNECT_DELAY_MS = 15000;
 
 function authHeaders(): HeadersInit {
   const token = localStorage.getItem('access_token');
@@ -21,20 +24,36 @@ async function api<T>(path: string, init?: RequestInit): Promise<T> {
   return response.json() as Promise<T>;
 }
 
+function delay(milliseconds: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = window.setTimeout(resolve, milliseconds);
+    signal.addEventListener('abort', () => {
+      window.clearTimeout(timer);
+      reject(new DOMException('Aborted', 'AbortError'));
+    }, { once: true });
+  });
+}
+
 export default function AgentCommons() {
   const [agents, setAgents] = useState<AgentStatus[]>([]);
+  const [adapterMode, setAdapterMode] = useState('unknown');
+  const [operational, setOperational] = useState(false);
   const [runs, setRuns] = useState<Run[]>([]);
   const [objective, setObjective] = useState('');
-  const [builder, setBuilder] = useState('codex');
-  const [reviewer, setReviewer] = useState('claude-code');
+  const [builder, setBuilder] = useState('');
+  const [reviewer, setReviewer] = useState('');
   const [connection, setConnection] = useState<'connecting' | 'live' | 'offline'>('connecting');
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
   const loadAgents = useCallback(async () => {
     try {
-      const result = await api<{ agents: AgentStatus[] }>('/agents');
+      const result = await api<AgentsResponse>('/agents');
       setAgents(result.agents);
+      setAdapterMode(result.adapter_mode);
+      setOperational(result.operational);
+      setBuilder((current) => current || result.agents[0]?.agent_id || '');
+      setReviewer((current) => current || result.agents[1]?.agent_id || '');
       setError('');
     } catch (reason) {
       setError(reason instanceof Error ? reason.message : 'Unable to load agents');
@@ -46,31 +65,53 @@ export default function AgentCommons() {
   useEffect(() => {
     const controller = new AbortController();
     const connect = async () => {
-      setConnection('connecting');
-      try {
-        const response = await fetch(`${API}/events`, { headers: authHeaders(), signal: controller.signal });
-        if (!response.ok || !response.body) throw new Error('Event stream unavailable');
-        setConnection('live');
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const frames = buffer.split('\n\n');
-          buffer = frames.pop() || '';
-          for (const frame of frames) {
-            const dataLine = frame.split('\n').find((line) => line.startsWith('data: '));
-            if (!dataLine) continue;
-            const event = JSON.parse(dataLine.slice(6)) as StreamEvent;
-            if (event.data) setRuns((current) => [event.data!, ...current.filter((run) => run.run_id !== event.data!.run_id)].slice(0, 50));
+      let reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+      let lastEventId = '';
+      while (!controller.signal.aborted) {
+        setConnection('connecting');
+        try {
+          const headers = authHeaders();
+          if (lastEventId) {
+            (headers as Record<string, string>)['Last-Event-ID'] = lastEventId;
           }
-        }
-      } catch (reason) {
-        if (!controller.signal.aborted) {
+          const response = await fetch(`${API}/events`, {
+            headers,
+            signal: controller.signal,
+            cache: 'no-store',
+          });
+          if (!response.ok || !response.body) throw new Error('Event stream unavailable');
+          setConnection('live');
+          setError('');
+          reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+          while (!controller.signal.aborted) {
+            const { value, done } = await reader.read();
+            if (done) throw new Error('Event stream closed');
+            buffer += decoder.decode(value, { stream: true });
+            const frames = buffer.split('\n\n');
+            buffer = frames.pop() || '';
+            for (const frame of frames) {
+              const lines = frame.split('\n');
+              const idLine = lines.find((line) => line.startsWith('id: '));
+              if (idLine) lastEventId = idLine.slice(4);
+              const dataLine = lines.find((line) => line.startsWith('data: '));
+              if (!dataLine) continue;
+              const event = JSON.parse(dataLine.slice(6)) as StreamEvent;
+              if (event.data) setRuns((current) => [event.data!, ...current.filter((run) => run.run_id !== event.data!.run_id)].slice(0, 50));
+            }
+          }
+        } catch (reason) {
+          if (controller.signal.aborted) return;
           setConnection('offline');
-          setError(reason instanceof Error ? reason.message : 'Event stream disconnected');
+          setError(reason instanceof Error ? `${reason.message}; reconnecting…` : 'Event stream disconnected; reconnecting…');
+          try {
+            await delay(reconnectDelay, controller.signal);
+          } catch {
+            return;
+          }
+          reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY_MS);
         }
       }
     };
@@ -82,7 +123,7 @@ export default function AgentCommons() {
 
   async function submitObjective(event: FormEvent) {
     event.preventDefault();
-    if (!objective.trim()) return;
+    if (!objective.trim() || !operational) return;
     setSubmitting(true);
     setError('');
     try {
@@ -118,9 +159,10 @@ export default function AgentCommons() {
   return <div className="space-y-6 pb-10">
     <section className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between"><div><div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.22em] text-gold"><Network className="h-4 w-4" /> SintraPrime Agent Commons</div><h1 className="text-3xl font-semibold text-white">Governed coordination for every agent</h1><p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">Live agent health, supervised delegation, independent review, durable traces, and authenticated owner decisions.</p></div><div className={clsx('inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-xs font-semibold uppercase tracking-wide', connection === 'live' ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300' : connection === 'connecting' ? 'border-amber-500/30 bg-amber-500/10 text-amber-300' : 'border-rose-500/30 bg-rose-500/10 text-rose-300')}><Play className="h-3.5 w-3.5" /> {connection}</div></section>
     {error && <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-300">{error}</div>}
-    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"><Metric label="Agents registered" value={String(agents.length)} detail="Provider-neutral adapters" icon={Bot} /><Metric label="Supervisor runs" value={String(runs.length)} detail="Current browser session" icon={Activity} /><Metric label="Pending approvals" value={String(pendingApprovals.length)} detail="Firm-admin authentication required" icon={MessageSquare} /><Metric label="Governance" value="Protected" detail="External actions default-deny" icon={ShieldCheck} /></section>
+    {!operational && <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">Agent execution is disabled. Current adapter mode: <strong>{adapterMode}</strong>. Configure an explicit provider mode before submitting objectives.</div>}
+    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"><Metric label="Agents registered" value={String(agents.length)} detail={`Adapter mode: ${adapterMode}`} icon={Bot} /><Metric label="Supervisor runs" value={String(runs.length)} detail="Current browser session" icon={Activity} /><Metric label="Pending approvals" value={String(pendingApprovals.length)} detail="Firm-admin authentication required" icon={MessageSquare} /><Metric label="Governance" value="Protected" detail="External actions default-deny" icon={ShieldCheck} /></section>
     <section className="grid gap-4 xl:grid-cols-[300px_minmax(0,1fr)]"><aside className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex items-center justify-between"><h2 className="font-semibold text-white">Connected agents</h2><button onClick={() => void loadAgents()} className="rounded-lg p-2 text-slate-500 hover:bg-slate-800 hover:text-white"><RefreshCw className="h-4 w-4" /></button></div><div className="mt-4 space-y-3">{agents.map((agent) => <div key={agent.agent_id} className="rounded-xl border border-slate-800 bg-slate-950/50 p-3"><div className="flex items-center gap-2"><span className="h-2.5 w-2.5 rounded-full bg-emerald-400" /><span className="text-sm font-semibold text-white">{agent.agent_id}</span></div><div className="mt-2 flex flex-wrap gap-1">{agent.capabilities.map((capability) => <span key={capability} className="rounded-md bg-slate-800 px-2 py-1 text-[10px] text-slate-400">{capability}</span>)}</div></div>)}</div></aside>
-      <main className="space-y-4"><form onSubmit={submitObjective} className="rounded-2xl border border-gold/20 bg-gradient-to-br from-gold/10 to-slate-900/70 p-5"><h2 className="text-lg font-semibold text-white">New supervised objective</h2><textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-4 min-h-28 w-full rounded-xl border border-slate-700 bg-slate-950/70 p-3 text-sm text-white outline-none focus:border-gold/50" placeholder="Describe the outcome. The supervisor will delegate to a builder and independent reviewer." /><div className="mt-3 grid gap-3 sm:grid-cols-2"><select value={builder} onChange={(event) => setBuilder(event.target.value)} className="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm text-white">{agents.map((agent) => <option key={agent.agent_id} value={agent.agent_id}>{agent.agent_id} — builder</option>)}</select><select value={reviewer} onChange={(event) => setReviewer(event.target.value)} className="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm text-white">{agents.map((agent) => <option key={agent.agent_id} value={agent.agent_id}>{agent.agent_id} — reviewer</option>)}</select></div><button disabled={submitting || !objective.trim() || builder === reviewer} className="mt-4 inline-flex items-center gap-2 rounded-xl bg-gold px-4 py-2 text-sm font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40"><Send className="h-4 w-4" /> {submitting ? 'Submitting…' : 'Start supervised run'}</button></form>
+      <main className="space-y-4"><form onSubmit={submitObjective} className="rounded-2xl border border-gold/20 bg-gradient-to-br from-gold/10 to-slate-900/70 p-5"><h2 className="text-lg font-semibold text-white">New supervised objective</h2><textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-4 min-h-28 w-full rounded-xl border border-slate-700 bg-slate-950/70 p-3 text-sm text-white outline-none focus:border-gold/50" placeholder="Describe the outcome. The supervisor will delegate to a builder and independent reviewer." /><div className="mt-3 grid gap-3 sm:grid-cols-2"><select value={builder} onChange={(event) => setBuilder(event.target.value)} className="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm text-white">{agents.map((agent) => <option key={agent.agent_id} value={agent.agent_id}>{agent.agent_id} — builder</option>)}</select><select value={reviewer} onChange={(event) => setReviewer(event.target.value)} className="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm text-white">{agents.map((agent) => <option key={agent.agent_id} value={agent.agent_id}>{agent.agent_id} — reviewer</option>)}</select></div><button disabled={submitting || !operational || !objective.trim() || !builder || !reviewer || builder === reviewer} className="mt-4 inline-flex items-center gap-2 rounded-xl bg-gold px-4 py-2 text-sm font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40"><Send className="h-4 w-4" /> {submitting ? 'Submitting…' : 'Start supervised run'}</button></form>
         <div className="space-y-3">{runs.map((run) => <article key={run.run_id} className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex flex-wrap items-start justify-between gap-3"><div><div className="flex items-center gap-2"><span className="text-xs font-semibold uppercase tracking-wide text-gold">{run.task_id}</span><span className="rounded-full border border-slate-700 px-2 py-0.5 text-[10px] text-slate-400">{run.status}</span></div><h3 className="mt-2 font-semibold text-white">{run.objective}</h3><p className="mt-1 text-xs text-slate-500">Builder: {run.builder_agent} · Reviewer: {run.reviewer_agent}</p></div>{run.status === 'waiting_approval' && <div className="flex gap-2"><button onClick={() => void decide(run, true)} className="inline-flex items-center gap-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-300"><CheckCircle2 className="h-4 w-4" /> Approve</button><button onClick={() => void decide(run, false)} className="inline-flex items-center gap-1 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs font-semibold text-rose-300"><XCircle className="h-4 w-4" /> Reject</button></div>}</div>{run.reconciliation && <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-950/70 p-3 text-xs text-slate-400">{JSON.stringify(run.reconciliation, null, 2)}</pre>}</article>)}</div></main></section>
   </div>;
 }

--- a/web/src/pages/AgentCommons.tsx
+++ b/web/src/pages/AgentCommons.tsx
@@ -1,0 +1,470 @@
+import { useMemo, useState } from 'react';
+import {
+  Activity,
+  AlertTriangle,
+  Bot,
+  BrainCircuit,
+  CheckCircle2,
+  ChevronRight,
+  CircleDot,
+  Clock3,
+  GitBranch,
+  MessageSquare,
+  Network,
+  PauseCircle,
+  Play,
+  Plus,
+  Radio,
+  Search,
+  Send,
+  ShieldCheck,
+  Sparkles,
+  Users,
+  XCircle,
+} from 'lucide-react';
+import { clsx } from 'clsx';
+
+type AgentState = 'online' | 'busy' | 'idle' | 'offline';
+type TaskState = 'running' | 'review' | 'approval' | 'complete';
+
+interface AgentCard {
+  id: string;
+  name: string;
+  role: string;
+  model: string;
+  status: AgentState;
+  capabilities: string[];
+  currentTask?: string;
+}
+
+interface TaskCard {
+  id: string;
+  title: string;
+  owner: string;
+  reviewer: string;
+  state: TaskState;
+  updated: string;
+  risk: 'low' | 'medium' | 'high';
+}
+
+const agents: AgentCard[] = [
+  {
+    id: 'supervisor',
+    name: 'Supervisor',
+    role: 'Governed coordinator',
+    model: 'OpenAI adapter',
+    status: 'online',
+    capabilities: ['decompose', 'delegate', 'reconcile', 'escalate'],
+    currentTask: 'Supervising Agent Commons Increment 1',
+  },
+  {
+    id: 'hermes',
+    name: 'Hermes',
+    role: 'Orchestrator',
+    model: 'Hermes runtime',
+    status: 'busy',
+    capabilities: ['repository', 'evidence', 'workflow', 'review'],
+    currentTask: 'Collecting implementation evidence',
+  },
+  {
+    id: 'codex',
+    name: 'Codex',
+    role: 'Builder',
+    model: 'Coding agent',
+    status: 'busy',
+    capabilities: ['code', 'tests', 'refactor', 'debug'],
+    currentTask: 'Building shared-thread API',
+  },
+  {
+    id: 'claude',
+    name: 'Claude Code',
+    role: 'Independent reviewer',
+    model: 'Claude adapter',
+    status: 'idle',
+    capabilities: ['review', 'architecture', 'risk', 'documentation'],
+  },
+  {
+    id: 'manus',
+    name: 'Manus',
+    role: 'Implementation worker',
+    model: 'Manus adapter',
+    status: 'idle',
+    capabilities: ['research', 'implementation', 'documents'],
+  },
+  {
+    id: 'watchtower',
+    name: 'Watchtower',
+    role: 'Observer',
+    model: 'Monitoring service',
+    status: 'online',
+    capabilities: ['health', 'alerts', 'anomaly detection'],
+  },
+];
+
+const tasks: TaskCard[] = [
+  {
+    id: 'SPU-20260802-A1',
+    title: 'Persist shared agent threads and provenance',
+    owner: 'Codex',
+    reviewer: 'Claude Code',
+    state: 'running',
+    updated: '2 minutes ago',
+    risk: 'medium',
+  },
+  {
+    id: 'SPU-20260802-A2',
+    title: 'Review supervisor policy and owner gates',
+    owner: 'Hermes',
+    reviewer: 'Watchtower',
+    state: 'review',
+    updated: '8 minutes ago',
+    risk: 'high',
+  },
+  {
+    id: 'SPU-20260802-A3',
+    title: 'Connect live OpenAI supervisor adapter',
+    owner: 'Supervisor',
+    reviewer: 'Isiah',
+    state: 'approval',
+    updated: '12 minutes ago',
+    risk: 'high',
+  },
+  {
+    id: 'SPU-20260802-A4',
+    title: 'Define adapter contract for external agents',
+    owner: 'Manus',
+    reviewer: 'Hermes',
+    state: 'complete',
+    updated: '31 minutes ago',
+    risk: 'low',
+  },
+];
+
+const channels = [
+  { name: 'command-center', count: 4, active: true },
+  { name: 'engineering', count: 7 },
+  { name: 'research', count: 3 },
+  { name: 'trust-operations', count: 2 },
+  { name: 'revenue-lab', count: 5 },
+  { name: 'incident-room', count: 0 },
+];
+
+const timeline = [
+  {
+    agent: 'Supervisor',
+    status: 'ASSIGNED',
+    message: 'Assigned shared-thread persistence to Codex and an independent architecture review to Claude Code.',
+    time: '9:42 AM',
+  },
+  {
+    agent: 'Codex',
+    status: 'IN_PROGRESS',
+    message: 'Created tenant-scoped storage and bounded context retrieval. Preparing API surface.',
+    time: '9:45 AM',
+  },
+  {
+    agent: 'Hermes',
+    status: 'RESULT',
+    message: 'Governance check confirms merge, deployment, legal dispatch, and financial actions remain owner-controlled.',
+    time: '9:49 AM',
+  },
+  {
+    agent: 'Claude Code',
+    status: 'REVIEW',
+    message: 'Review requested: verify tenant isolation, idempotency, loop prevention, and approval transitions.',
+    time: '9:53 AM',
+  },
+];
+
+const statusStyles: Record<AgentState, string> = {
+  online: 'bg-emerald-400',
+  busy: 'bg-amber-400',
+  idle: 'bg-blue-400',
+  offline: 'bg-slate-600',
+};
+
+const taskStateStyles: Record<TaskState, string> = {
+  running: 'border-blue-500/30 bg-blue-500/10 text-blue-300',
+  review: 'border-violet-500/30 bg-violet-500/10 text-violet-300',
+  approval: 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+  complete: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+};
+
+function Metric({ label, value, detail, icon: Icon }: { label: string; value: string; detail: string; icon: React.ElementType }) {
+  return (
+    <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4 shadow-lg shadow-black/10">
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.18em] text-slate-500">{label}</p>
+          <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
+          <p className="mt-1 text-xs text-slate-500">{detail}</p>
+        </div>
+        <div className="rounded-xl border border-gold/20 bg-gold/10 p-2 text-gold">
+          <Icon className="h-5 w-5" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AgentCommons() {
+  const [selectedAgent, setSelectedAgent] = useState('supervisor');
+  const [composer, setComposer] = useState('');
+  const [autoSupervise, setAutoSupervise] = useState(true);
+  const selected = useMemo(() => agents.find((agent) => agent.id === selectedAgent) ?? agents[0], [selectedAgent]);
+
+  return (
+    <div className="space-y-6 pb-10">
+      <section className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.22em] text-gold">
+            <Network className="h-4 w-4" />
+            SintraPrime Agent Commons
+          </div>
+          <h1 className="text-3xl font-semibold text-white">One command center for every agent</h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">
+            Shared context, supervised delegation, independent review, durable evidence, and owner approval gates in one governed workspace.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={() => setAutoSupervise((value) => !value)}
+            className={clsx(
+              'inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-medium transition',
+              autoSupervise
+                ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300'
+                : 'border-slate-700 bg-slate-900 text-slate-400'
+            )}
+          >
+            <Radio className="h-4 w-4" />
+            Auto-supervise {autoSupervise ? 'on' : 'off'}
+          </button>
+          <button className="inline-flex items-center gap-2 rounded-xl bg-gold px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-yellow-300">
+            <Plus className="h-4 w-4" />
+            New objective
+          </button>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <Metric label="Agents connected" value="6" detail="4 active · 2 standing by" icon={Bot} />
+        <Metric label="Open tasks" value="4" detail="1 requires your approval" icon={Activity} />
+        <Metric label="Shared threads" value="21" detail="All tenant-scoped and traceable" icon={MessageSquare} />
+        <Metric label="Governance state" value="Protected" detail="External actions default-deny" icon={ShieldCheck} />
+      </section>
+
+      <section className="grid min-h-[720px] gap-4 xl:grid-cols-[240px_minmax(0,1fr)_330px]">
+        <aside className="rounded-2xl border border-slate-800 bg-slate-900/70 p-3">
+          <div className="flex items-center justify-between px-2 py-2">
+            <div>
+              <p className="text-xs uppercase tracking-[0.16em] text-slate-500">Workspace</p>
+              <p className="mt-1 text-sm font-semibold text-white">SintraPrime Unified</p>
+            </div>
+            <button className="rounded-lg p-2 text-slate-500 hover:bg-slate-800 hover:text-white">
+              <Search className="h-4 w-4" />
+            </button>
+          </div>
+
+          <div className="mt-4">
+            <p className="px-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-600">Channels</p>
+            <div className="mt-2 space-y-1">
+              {channels.map((channel) => (
+                <button
+                  key={channel.name}
+                  className={clsx(
+                    'flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition',
+                    channel.active ? 'bg-gold/10 text-gold' : 'text-slate-400 hover:bg-slate-800/70 hover:text-white'
+                  )}
+                >
+                  <span className="flex items-center gap-2">
+                    <MessageSquare className="h-4 w-4" />
+                    {channel.name}
+                  </span>
+                  {channel.count > 0 && (
+                    <span className="rounded-full bg-slate-800 px-2 py-0.5 text-[10px] text-slate-400">{channel.count}</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <div className="flex items-center justify-between px-2">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-600">Agents</p>
+              <span className="text-[10px] text-emerald-400">6 connected</span>
+            </div>
+            <div className="mt-2 space-y-1">
+              {agents.map((agent) => (
+                <button
+                  key={agent.id}
+                  onClick={() => setSelectedAgent(agent.id)}
+                  className={clsx(
+                    'flex w-full items-center gap-3 rounded-xl px-3 py-2 text-left transition',
+                    selectedAgent === agent.id ? 'bg-slate-800 text-white' : 'text-slate-400 hover:bg-slate-800/60'
+                  )}
+                >
+                  <div className="relative flex h-8 w-8 items-center justify-center rounded-lg bg-slate-800 text-slate-300">
+                    <Bot className="h-4 w-4" />
+                    <span className={clsx('absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-slate-900', statusStyles[agent.status])} />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{agent.name}</p>
+                    <p className="truncate text-[11px] text-slate-600">{agent.role}</p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        </aside>
+
+        <main className="flex min-w-0 flex-col rounded-2xl border border-slate-800 bg-slate-900/50">
+          <div className="flex flex-col gap-3 border-b border-slate-800 p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="flex items-center gap-2">
+                <h2 className="text-lg font-semibold text-white"># command-center</h2>
+                <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-300">live</span>
+              </div>
+              <p className="mt-1 text-xs text-slate-500">Supervisor, builders, reviewers, and owner decisions share one durable timeline.</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><Users className="h-4 w-4" /></button>
+              <button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><GitBranch className="h-4 w-4" /></button>
+              <button className="rounded-lg border border-slate-700 bg-slate-900 p-2 text-slate-400 hover:text-white"><Search className="h-4 w-4" /></button>
+            </div>
+          </div>
+
+          <div className="flex-1 space-y-4 overflow-y-auto p-4">
+            <div className="rounded-2xl border border-gold/20 bg-gradient-to-br from-gold/10 to-transparent p-4">
+              <div className="flex items-start gap-3">
+                <div className="rounded-xl bg-gold/15 p-2 text-gold"><BrainCircuit className="h-5 w-5" /></div>
+                <div>
+                  <p className="text-sm font-semibold text-white">Current objective</p>
+                  <p className="mt-1 text-sm leading-6 text-slate-300">
+                    Build a durable multi-agent workspace where the supervisor can delegate, agents can debate, evidence is preserved, and Isiah remains final authority.
+                  </p>
+                  <div className="mt-3 flex flex-wrap gap-2 text-[11px]">
+                    <span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Owner: Isiah</span>
+                    <span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Builder: Codex</span>
+                    <span className="rounded-full bg-slate-950/60 px-2.5 py-1 text-slate-400">Reviewer: Claude Code</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {timeline.map((item) => (
+              <div key={`${item.agent}-${item.time}`} className="flex gap-3">
+                <div className="mt-1 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-xl border border-slate-700 bg-slate-800 text-slate-300">
+                  <Bot className="h-4 w-4" />
+                </div>
+                <div className="min-w-0 flex-1 rounded-2xl border border-slate-800 bg-slate-950/40 p-4">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-semibold text-white">{item.agent}</span>
+                    <span className="rounded-md border border-slate-700 bg-slate-900 px-2 py-0.5 text-[10px] font-semibold text-slate-400">{item.status}</span>
+                    <span className="ml-auto text-[11px] text-slate-600">{item.time}</span>
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-slate-300">{item.message}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="border-t border-slate-800 p-4">
+            <div className="rounded-2xl border border-slate-700 bg-slate-950/70 p-3 focus-within:border-gold/50">
+              <textarea
+                value={composer}
+                onChange={(event) => setComposer(event.target.value)}
+                placeholder="Give the supervisor an objective, tag an agent, or request an independent review…"
+                className="min-h-20 w-full resize-none bg-transparent text-sm text-white outline-none placeholder:text-slate-600"
+              />
+              <div className="mt-2 flex items-center justify-between">
+                <div className="flex gap-2 text-[11px] text-slate-500">
+                  <span className="rounded-md bg-slate-900 px-2 py-1">@ agent</span>
+                  <span className="rounded-md bg-slate-900 px-2 py-1">/ review</span>
+                  <span className="rounded-md bg-slate-900 px-2 py-1">/ approve</span>
+                </div>
+                <button
+                  disabled={!composer.trim()}
+                  className="inline-flex items-center gap-2 rounded-xl bg-gold px-3 py-2 text-xs font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <Send className="h-3.5 w-3.5" />
+                  Send objective
+                </button>
+              </div>
+            </div>
+          </div>
+        </main>
+
+        <aside className="space-y-4">
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-white">Selected agent</h3>
+              <span className={clsx('h-2.5 w-2.5 rounded-full', statusStyles[selected.status])} />
+            </div>
+            <div className="mt-4 flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gold/10 text-gold"><Bot className="h-6 w-6" /></div>
+              <div>
+                <p className="font-semibold text-white">{selected.name}</p>
+                <p className="text-xs text-slate-500">{selected.role}</p>
+              </div>
+            </div>
+            <dl className="mt-4 space-y-3 text-xs">
+              <div className="flex justify-between gap-3"><dt className="text-slate-500">Runtime</dt><dd className="text-right text-slate-300">{selected.model}</dd></div>
+              <div className="flex justify-between gap-3"><dt className="text-slate-500">Status</dt><dd className="capitalize text-slate-300">{selected.status}</dd></div>
+              <div><dt className="text-slate-500">Capabilities</dt><dd className="mt-2 flex flex-wrap gap-1.5">{selected.capabilities.map((capability) => <span key={capability} className="rounded-md bg-slate-800 px-2 py-1 text-slate-300">{capability}</span>)}</dd></div>
+            </dl>
+            {selected.currentTask && (
+              <div className="mt-4 rounded-xl border border-blue-500/20 bg-blue-500/10 p-3">
+                <p className="text-[10px] uppercase tracking-[0.16em] text-blue-400">Current task</p>
+                <p className="mt-1 text-xs leading-5 text-blue-200">{selected.currentTask}</p>
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-white">Task queue</h3>
+              <button className="text-xs text-gold hover:text-yellow-300">View all</button>
+            </div>
+            <div className="mt-3 space-y-3">
+              {tasks.map((task) => (
+                <button key={task.id} className="w-full rounded-xl border border-slate-800 bg-slate-950/40 p-3 text-left transition hover:border-slate-700">
+                  <div className="flex items-start gap-2">
+                    {task.state === 'complete' ? <CheckCircle2 className="mt-0.5 h-4 w-4 text-emerald-400" /> : task.state === 'approval' ? <PauseCircle className="mt-0.5 h-4 w-4 text-amber-400" /> : <CircleDot className="mt-0.5 h-4 w-4 text-blue-400" />}
+                    <div className="min-w-0 flex-1">
+                      <p className="text-xs font-medium leading-5 text-slate-200">{task.title}</p>
+                      <p className="mt-1 text-[10px] text-slate-600">{task.id} · {task.updated}</p>
+                    </div>
+                  </div>
+                  <div className="mt-3 flex items-center justify-between">
+                    <span className={clsx('rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase', taskStateStyles[task.state])}>{task.state}</span>
+                    <ChevronRight className="h-3.5 w-3.5 text-slate-600" />
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-amber-500/20 bg-amber-500/5 p-4">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-400" />
+              <div>
+                <p className="text-sm font-semibold text-amber-200">Owner approval required</p>
+                <p className="mt-1 text-xs leading-5 text-amber-200/70">Connect the live OpenAI supervisor adapter and authorize its tool allowlist.</p>
+                <div className="mt-3 flex gap-2">
+                  <button className="inline-flex items-center gap-1 rounded-lg bg-emerald-500/15 px-2.5 py-1.5 text-[11px] font-semibold text-emerald-300"><CheckCircle2 className="h-3.5 w-3.5" /> Approve</button>
+                  <button className="inline-flex items-center gap-1 rounded-lg bg-rose-500/15 px-2.5 py-1.5 text-[11px] font-semibold text-rose-300"><XCircle className="h-3.5 w-3.5" /> Reject</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-white"><Sparkles className="h-4 w-4 text-gold" /> Recommended automation</div>
+            <p className="mt-2 text-xs leading-5 text-slate-500">Have the supervisor produce an end-of-day agent recap with completed work, blockers, approvals, and tomorrow's priorities.</p>
+            <button className="mt-3 inline-flex items-center gap-2 rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-300 hover:border-gold/40 hover:text-gold"><Clock3 className="h-3.5 w-3.5" /> Configure schedule</button>
+          </div>
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/web/src/pages/AgentCommons.tsx
+++ b/web/src/pages/AgentCommons.tsx
@@ -11,7 +11,7 @@ const INITIAL_RECONNECT_DELAY_MS = 1000;
 const MAX_RECONNECT_DELAY_MS = 15000;
 
 function authHeaders(): HeadersInit {
-  const token = localStorage.getItem('access_token');
+  const token = localStorage.getItem('sintraprime_token');
   return { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) };
 }
 
@@ -47,35 +47,35 @@ export default function AgentCommons() {
   const [submitting, setSubmitting] = useState(false);
 
   const loadAgents = useCallback(async () => {
-    try {
-      const result = await api<AgentsResponse>('/agents');
-      setAgents(result.agents);
-      setAdapterMode(result.adapter_mode);
-      setOperational(result.operational);
-      setBuilder((current) => current || result.agents[0]?.agent_id || '');
-      setReviewer((current) => current || result.agents[1]?.agent_id || '');
-      setError('');
-    } catch (reason) {
-      setError(reason instanceof Error ? reason.message : 'Unable to load agents');
-    }
+    const result = await api<AgentsResponse>('/agents');
+    setAgents(result.agents);
+    setAdapterMode(result.adapter_mode);
+    setOperational(result.operational);
+    setBuilder((current) => current || result.agents[0]?.agent_id || '');
+    setReviewer((current) => current || result.agents[1]?.agent_id || '');
   }, []);
 
-  useEffect(() => { void loadAgents(); }, [loadAgents]);
+  const loadRuns = useCallback(async () => {
+    const result = await api<{ runs: Run[] }>('/runs?limit=50');
+    setRuns(result.runs);
+  }, []);
+
+  useEffect(() => {
+    void Promise.all([loadAgents(), loadRuns()]).catch((reason) => {
+      setError(reason instanceof Error ? reason.message : 'Unable to load Agent Commons');
+    });
+  }, [loadAgents, loadRuns]);
 
   useEffect(() => {
     const controller = new AbortController();
     const connect = async () => {
       let reconnectDelay = INITIAL_RECONNECT_DELAY_MS;
-      let lastEventId = '';
       while (!controller.signal.aborted) {
         setConnection('connecting');
         try {
-          const headers = authHeaders();
-          if (lastEventId) {
-            (headers as Record<string, string>)['Last-Event-ID'] = lastEventId;
-          }
+          await loadRuns();
           const response = await fetch(`${API}/events`, {
-            headers,
+            headers: authHeaders(),
             signal: controller.signal,
             cache: 'no-store',
           });
@@ -93,13 +93,12 @@ export default function AgentCommons() {
             const frames = buffer.split('\n\n');
             buffer = frames.pop() || '';
             for (const frame of frames) {
-              const lines = frame.split('\n');
-              const idLine = lines.find((line) => line.startsWith('id: '));
-              if (idLine) lastEventId = idLine.slice(4);
-              const dataLine = lines.find((line) => line.startsWith('data: '));
+              const dataLine = frame.split('\n').find((line) => line.startsWith('data: '));
               if (!dataLine) continue;
               const event = JSON.parse(dataLine.slice(6)) as StreamEvent;
-              if (event.data) setRuns((current) => [event.data!, ...current.filter((run) => run.run_id !== event.data!.run_id)].slice(0, 50));
+              if (event.data) {
+                setRuns((current) => [event.data!, ...current.filter((run) => run.run_id !== event.data!.run_id)].slice(0, 50));
+              }
             }
           }
         } catch (reason) {
@@ -117,7 +116,7 @@ export default function AgentCommons() {
     };
     void connect();
     return () => controller.abort();
-  }, []);
+  }, [loadRuns]);
 
   const pendingApprovals = useMemo(() => runs.filter((run) => run.status === 'waiting_approval'), [runs]);
 
@@ -159,11 +158,11 @@ export default function AgentCommons() {
   return <div className="space-y-6 pb-10">
     <section className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between"><div><div className="mb-2 flex items-center gap-2 text-xs uppercase tracking-[0.22em] text-gold"><Network className="h-4 w-4" /> SintraPrime Agent Commons</div><h1 className="text-3xl font-semibold text-white">Governed coordination for every agent</h1><p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">Live agent health, supervised delegation, independent review, durable traces, and authenticated owner decisions.</p></div><div className={clsx('inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-xs font-semibold uppercase tracking-wide', connection === 'live' ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300' : connection === 'connecting' ? 'border-amber-500/30 bg-amber-500/10 text-amber-300' : 'border-rose-500/30 bg-rose-500/10 text-rose-300')}><Play className="h-3.5 w-3.5" /> {connection}</div></section>
     {error && <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-300">{error}</div>}
-    {!operational && <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">Agent execution is disabled. Current adapter mode: <strong>{adapterMode}</strong>. Configure an explicit provider mode before submitting objectives.</div>}
-    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"><Metric label="Agents registered" value={String(agents.length)} detail={`Adapter mode: ${adapterMode}`} icon={Bot} /><Metric label="Supervisor runs" value={String(runs.length)} detail="Current browser session" icon={Activity} /><Metric label="Pending approvals" value={String(pendingApprovals.length)} detail="Firm-admin authentication required" icon={MessageSquare} /><Metric label="Governance" value="Protected" detail="External actions default-deny" icon={ShieldCheck} /></section>
-    <section className="grid gap-4 xl:grid-cols-[300px_minmax(0,1fr)]"><aside className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex items-center justify-between"><h2 className="font-semibold text-white">Connected agents</h2><button onClick={() => void loadAgents()} className="rounded-lg p-2 text-slate-500 hover:bg-slate-800 hover:text-white"><RefreshCw className="h-4 w-4" /></button></div><div className="mt-4 space-y-3">{agents.map((agent) => <div key={agent.agent_id} className="rounded-xl border border-slate-800 bg-slate-950/50 p-3"><div className="flex items-center gap-2"><span className="h-2.5 w-2.5 rounded-full bg-emerald-400" /><span className="text-sm font-semibold text-white">{agent.agent_id}</span></div><div className="mt-2 flex flex-wrap gap-1">{agent.capabilities.map((capability) => <span key={capability} className="rounded-md bg-slate-800 px-2 py-1 text-[10px] text-slate-400">{capability}</span>)}</div></div>)}</div></aside>
-      <main className="space-y-4"><form onSubmit={submitObjective} className="rounded-2xl border border-gold/20 bg-gradient-to-br from-gold/10 to-slate-900/70 p-5"><h2 className="text-lg font-semibold text-white">New supervised objective</h2><textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-4 min-h-28 w-full rounded-xl border border-slate-700 bg-slate-950/70 p-3 text-sm text-white outline-none focus:border-gold/50" placeholder="Describe the outcome. The supervisor will delegate to a builder and independent reviewer." /><div className="mt-3 grid gap-3 sm:grid-cols-2"><select value={builder} onChange={(event) => setBuilder(event.target.value)} className="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm text-white">{agents.map((agent) => <option key={agent.agent_id} value={agent.agent_id}>{agent.agent_id} — builder</option>)}</select><select value={reviewer} onChange={(event) => setReviewer(event.target.value)} className="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm text-white">{agents.map((agent) => <option key={agent.agent_id} value={agent.agent_id}>{agent.agent_id} — reviewer</option>)}</select></div><button disabled={submitting || !operational || !objective.trim() || !builder || !reviewer || builder === reviewer} className="mt-4 inline-flex items-center gap-2 rounded-xl bg-gold px-4 py-2 text-sm font-semibold text-slate-950 disabled:cursor-not-allowed disabled:opacity-40"><Send className="h-4 w-4" /> {submitting ? 'Submitting…' : 'Start supervised run'}</button></form>
-        <div className="space-y-3">{runs.map((run) => <article key={run.run_id} className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex flex-wrap items-start justify-between gap-3"><div><div className="flex items-center gap-2"><span className="text-xs font-semibold uppercase tracking-wide text-gold">{run.task_id}</span><span className="rounded-full border border-slate-700 px-2 py-0.5 text-[10px] text-slate-400">{run.status}</span></div><h3 className="mt-2 font-semibold text-white">{run.objective}</h3><p className="mt-1 text-xs text-slate-500">Builder: {run.builder_agent} · Reviewer: {run.reviewer_agent}</p></div>{run.status === 'waiting_approval' && <div className="flex gap-2"><button onClick={() => void decide(run, true)} className="inline-flex items-center gap-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-300"><CheckCircle2 className="h-4 w-4" /> Approve</button><button onClick={() => void decide(run, false)} className="inline-flex items-center gap-1 rounded-lg border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs font-semibold text-rose-300"><XCircle className="h-4 w-4" /> Reject</button></div>}</div>{run.reconciliation && <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-950/70 p-3 text-xs text-slate-400">{JSON.stringify(run.reconciliation, null, 2)}</pre>}</article>)}</div></main></section>
+    {!operational && <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">Agent execution is disabled. Current adapter mode: <strong>{adapterMode}</strong>.</div>}
+    <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"><Metric label="Agents registered" value={String(agents.length)} detail={`Adapter mode: ${adapterMode}`} icon={Bot} /><Metric label="Supervisor runs" value={String(runs.length)} detail="Authoritative tenant state" icon={Activity} /><Metric label="Pending approvals" value={String(pendingApprovals.length)} detail="Firm-admin authentication required" icon={MessageSquare} /><Metric label="Governance" value="Protected" detail="External actions default-deny" icon={ShieldCheck} /></section>
+    <section className="grid gap-4 xl:grid-cols-[300px_minmax(0,1fr)]"><aside className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex items-center justify-between"><h2 className="font-semibold text-white">Connected agents</h2><button onClick={() => void loadAgents()} className="rounded-lg p-2 text-slate-500 hover:bg-slate-800 hover:text-white"><RefreshCw className="h-4 w-4" /></button></div><div className="mt-4 space-y-3">{agents.map((agent) => <div key={agent.agent_id} className="rounded-xl border border-slate-800 bg-slate-950/50 p-3"><div className="flex items-center gap-2"><span className="h-2.5 w-2.5 rounded-full bg-emerald-400" /><span className="text-sm font-semibold text-white">{agent.agent_id}</span></div></div>)}</div></aside>
+      <main className="space-y-4"><form onSubmit={submitObjective} className="rounded-2xl border border-gold/20 bg-gradient-to-br from-gold/10 to-slate-900/70 p-5"><h2 className="text-lg font-semibold text-white">New supervised objective</h2><textarea value={objective} onChange={(event) => setObjective(event.target.value)} className="mt-4 min-h-28 w-full rounded-xl border border-slate-700 bg-slate-950/70 p-3 text-sm text-white" /><div className="mt-3 grid gap-3 sm:grid-cols-2"><select value={builder} onChange={(event) => setBuilder(event.target.value)} className="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm text-white">{agents.map((agent) => <option key={agent.agent_id} value={agent.agent_id}>{agent.agent_id} — builder</option>)}</select><select value={reviewer} onChange={(event) => setReviewer(event.target.value)} className="rounded-xl border border-slate-700 bg-slate-950 p-3 text-sm text-white">{agents.map((agent) => <option key={agent.agent_id} value={agent.agent_id}>{agent.agent_id} — reviewer</option>)}</select></div><button disabled={submitting || !operational || !objective.trim() || !builder || !reviewer || builder === reviewer} className="mt-4 inline-flex items-center gap-2 rounded-xl bg-gold px-4 py-2 text-sm font-semibold text-slate-950 disabled:opacity-40"><Send className="h-4 w-4" /> {submitting ? 'Submitting…' : 'Start supervised run'}</button></form>
+        <div className="space-y-3">{runs.map((run) => <article key={run.run_id} className="rounded-2xl border border-slate-800 bg-slate-900/70 p-4"><div className="flex flex-wrap items-start justify-between gap-3"><div><span className="text-xs font-semibold uppercase tracking-wide text-gold">{run.task_id}</span><h3 className="mt-2 font-semibold text-white">{run.objective}</h3><p className="mt-1 text-xs text-slate-500">{run.status} · Builder: {run.builder_agent} · Reviewer: {run.reviewer_agent}</p></div>{run.status === 'waiting_approval' && <div className="flex gap-2"><button onClick={() => void decide(run, true)} className="inline-flex items-center gap-1 rounded-lg border border-emerald-500/30 px-3 py-2 text-xs text-emerald-300"><CheckCircle2 className="h-4 w-4" /> Approve</button><button onClick={() => void decide(run, false)} className="inline-flex items-center gap-1 rounded-lg border border-rose-500/30 px-3 py-2 text-xs text-rose-300"><XCircle className="h-4 w-4" /> Reject</button></div>}</div>{run.reconciliation && <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-950/70 p-3 text-xs text-slate-400">{JSON.stringify(run.reconciliation, null, 2)}</pre>}</article>)}</div></main></section>
   </div>;
 }
 


### PR DESCRIPTION
## What changed

Implements the first governed Agent Commons runtime and live control-surface slice for Issue #243:

- Adds tenant-scoped SQLite persistence for shared threads, supervisor runs, approvals, evidence, and trace metadata.
- Adds a provider-neutral `AgentAdapter` contract plus callable adapters for Hermes, Codex, Claude Code, Manus, local runtimes, and future providers.
- Adds an OpenAI Responses API supervisor adapter behind dependency injection, with no import-time SDK or credential requirement.
- Adds a governed supervisor that delegates to an independent builder and reviewer, reconciles results, and escalates material disagreement to the owner.
- Adds explicit owner gates for merge, deploy, legal, financial, government, funds-transfer, and other unapproved external actions.
- Adds idempotent objective execution and bounded thread context with provenance labels.
- Adds tenant-isolated server-sent event streaming with heartbeats and bounded subscriber queues.
- Registers authenticated `/api/v1/agent-commons` endpoints in the Portal.
- Uses existing JWT-derived tenant and RBAC dependencies; approvals require `FIRM_ADMIN` or higher.
- Connects the Agent Commons React page to live agent health, objective submission, SSE updates, and authenticated approve/reject actions.
- Adds tests for normal completion, adversarial disagreement, prohibited-action blocking, idempotency, tenant isolation, event isolation, adapter events, and provider timeouts.

## API surface

- `GET /api/v1/agent-commons/agents`
- `POST /api/v1/agent-commons/objectives`
- `GET /api/v1/agent-commons/runs/{run_id}`
- `GET /api/v1/agent-commons/threads/{workspace_id}/{channel_id}/{thread_id}`
- `POST /api/v1/agent-commons/runs/{run_id}/approve`
- `POST /api/v1/agent-commons/runs/{run_id}/reject`
- `GET /api/v1/agent-commons/events`

## Governance boundary

- Ready for human review; no merge or deployment is authorized by this transition.
- No production provider credentials added.
- No consumer ChatGPT-session control assumed.
- Provider adapters remain dependency-injected and default to safe disconnected placeholders until configured.
- Shared GPU compute remains deferred.
- No hidden chain-of-thought is stored or streamed; only observable events, concise rationale, evidence, and decisions are persisted.

## Validation

All exact-head workflows passed for `30236a168cf025a329ce2dad0d9eded8b6801a7b`: SintraPrime CI #745, Sigma Gate #670, IssueVerifier CI #631, Smoke #56, and Docker Image Build Verification #32. Review threads: 0. Submitted reviews: 0.

Implements the first live slice of #243; does not close it.