### PR TITLE
First-Run Owner Setup

### DIFF
--- a/portal/routers/auth.py
+++ b/portal/routers/auth.py
@@ -5,6 +5,7 @@ password reset, email verification, session management.
 
 from __future__ import annotations
 
+import asyncio
 import re
 import secrets
 import uuid
@@ -12,7 +13,7 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, EmailStr, Field
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -56,6 +57,8 @@ router = APIRouter()
 settings = get_settings()
 
 REFRESH_COOKIE_NAME = "refresh_token"
+_FIRST_RUN_SETUP_LOCK_KEY = 246001
+_FIRST_RUN_SETUP_LOCAL_LOCK = asyncio.Lock()
 
 
 # ── Request / Response schemas ────────────────────────────────────────────────
@@ -139,6 +142,20 @@ async def _has_any_user(db: AsyncSession) -> bool:
     return bool(count)
 
 
+async def _acquire_first_run_setup_guard(db: AsyncSession) -> asyncio.Lock | None:
+    bind = db.get_bind()
+    dialect_name = bind.dialect.name if bind is not None else ""
+    if dialect_name == "postgresql":
+        await db.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_key)"),
+            {"lock_key": _FIRST_RUN_SETUP_LOCK_KEY},
+        )
+        return None
+
+    await _FIRST_RUN_SETUP_LOCAL_LOCK.acquire()
+    return _FIRST_RUN_SETUP_LOCAL_LOCK
+
+
 def _split_owner_name(owner_name: str) -> tuple[str, str]:
     parts = owner_name.strip().split()
     if not parts:
@@ -213,72 +230,77 @@ async def first_run_setup(
     db: AsyncSession = Depends(get_db),
 ) -> LoginResponse:
     """Create the first tenant and owner user, then issue a normal login session."""
-    if await _has_any_user(db):
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="First-run setup is already complete")
-
+    local_guard = await _acquire_first_run_setup_guard(db)
     try:
-        validate_password_strength(body.password)
-    except PasswordError as exc:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+        if await _has_any_user(db):
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="First-run setup is already complete")
 
-    try:
-        await sync_permission_manifest(db)
-    except PermissionSyncError as exc:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+        try:
+            validate_password_strength(body.password)
+        except PasswordError as exc:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
 
-    role = await db.scalar(
-        select(RoleModel)
-        .options(selectinload(RoleModel.permissions))
-        .where(RoleModel.name == RbacRole.FIRM_ADMIN.value, RoleModel.is_system.is_(True))
-    )
-    if role is None:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Owner role unavailable")
+        try:
+            await sync_permission_manifest(db)
+        except PermissionSyncError as exc:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
 
-    first_name, last_name = _split_owner_name(body.owner_name)
-    tenant = Tenant(
-        id=str(uuid.uuid4()),
-        name=body.organization_name.strip(),
-        slug=_tenant_slug(body.organization_name),
-        is_active=True,
-    )
-    owner = User(
-        id=str(uuid.uuid4()),
-        tenant_id=tenant.id,
-        role_id=role.id,
-        email=str(body.email).lower(),
-        email_verified=True,
-        hashed_password=hash_password(body.password),
-        first_name=first_name,
-        last_name=last_name,
-        password_changed_at=datetime.now(UTC),
-        is_active=True,
-        is_locked=False,
-    )
-    db.add(tenant)
-    db.add(owner)
-    await db.flush()
+        role = await db.scalar(
+            select(RoleModel)
+            .options(selectinload(RoleModel.permissions))
+            .where(RoleModel.name == RbacRole.FIRM_ADMIN.value, RoleModel.is_system.is_(True))
+        )
+        if role is None:
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Owner role unavailable")
 
-    owner.role_ref = role
-    login_response, _refresh_token, family_id = _build_login_response(owner, response)
-    await register_refresh_family(family_id, str(owner.id))
-    await create_session(
-        user_id=str(owner.id),
-        email=owner.email,
-        ip_address=request.client.host if request.client else "unknown",
-        user_agent=request.headers.get("user-agent", ""),
-    )
-    await audit(
-        db,
-        action="first_run_owner_setup",
-        user_id=str(owner.id),
-        tenant_id=str(tenant.id),
-        status="success",
-        actor_email=owner.email,
-        actor_role=login_response.role,
-        actor_ip=request.client.host if request.client else "unknown",
-    )
-    await db.commit()
-    return login_response
+        first_name, last_name = _split_owner_name(body.owner_name)
+        tenant = Tenant(
+            id=str(uuid.uuid4()),
+            name=body.organization_name.strip(),
+            slug=_tenant_slug(body.organization_name),
+            is_active=True,
+        )
+        owner = User(
+            id=str(uuid.uuid4()),
+            tenant_id=tenant.id,
+            role_id=role.id,
+            email=str(body.email).lower(),
+            email_verified=True,
+            hashed_password=hash_password(body.password),
+            first_name=first_name,
+            last_name=last_name,
+            password_changed_at=datetime.now(UTC),
+            is_active=True,
+            is_locked=False,
+        )
+        db.add(tenant)
+        db.add(owner)
+        await db.flush()
+
+        owner.role_ref = role
+        login_response, _refresh_token, family_id = _build_login_response(owner, response)
+        await register_refresh_family(family_id, str(owner.id))
+        await create_session(
+            user_id=str(owner.id),
+            email=owner.email,
+            ip_address=request.client.host if request.client else "unknown",
+            user_agent=request.headers.get("user-agent", ""),
+        )
+        await audit(
+            db,
+            action="first_run_owner_setup",
+            user_id=str(owner.id),
+            tenant_id=str(tenant.id),
+            status="success",
+            actor_email=owner.email,
+            actor_role=login_response.role,
+            actor_ip=request.client.host if request.client else "unknown",
+        )
+        await db.commit()
+        return login_response
+    finally:
+        if local_guard is not None:
+            local_guard.release()
 
 
 @router.post("/login", response_model=LoginResponse)

--- a/portal/routers/auth.py
+++ b/portal/routers/auth.py
@@ -5,14 +5,16 @@ password reset, email verification, session management.
 
 from __future__ import annotations
 
+import re
 import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, EmailStr, Field
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from ..auth.jwt_handler import (
     TokenError,
@@ -31,6 +33,7 @@ from ..auth.password_handler import (
     verify_password,
 )
 from ..auth.rbac import CurrentUser, get_current_user
+from ..auth.rbac import Role as RbacRole
 from ..auth.session_manager import (
     blocklist_jti,
     create_session,
@@ -43,9 +46,11 @@ from ..auth.session_manager import (
 )
 from ..config import get_settings
 from ..database import get_db
-from ..models.user import User
+from ..models.user import Role as RoleModel
+from ..models.user import Tenant, User
 from ..services.audit_service import audit
 from ..services.notification_service import send_email
+from ..services.permission_provisioning import PermissionSyncError, sync_permission_manifest
 
 router = APIRouter()
 settings = get_settings()
@@ -108,6 +113,17 @@ class ChangePasswordRequest(BaseModel):
     new_password: str = Field(..., min_length=12)
 
 
+class FirstRunSetupStatus(BaseModel):
+    available: bool
+
+
+class FirstRunSetupRequest(BaseModel):
+    owner_name: str = Field(..., min_length=1, max_length=200)
+    email: EmailStr
+    password: str = Field(..., min_length=12)
+    organization_name: str = Field(..., min_length=1, max_length=255)
+
+
 # ── Helper ────────────────────────────────────────────────────────────────────
 
 async def _get_user_by_email(db: AsyncSession, email: str, tenant_id: str | None = None) -> User | None:
@@ -116,6 +132,25 @@ async def _get_user_by_email(db: AsyncSession, email: str, tenant_id: str | None
         stmt = stmt.where(User.tenant_id == tenant_id)
     result = await db.execute(stmt)
     return result.scalar_one_or_none()
+
+
+async def _has_any_user(db: AsyncSession) -> bool:
+    count = await db.scalar(select(func.count(User.id)).where(User.deleted_at.is_(None)))
+    return bool(count)
+
+
+def _split_owner_name(owner_name: str) -> tuple[str, str]:
+    parts = owner_name.strip().split()
+    if not parts:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Owner name is required")
+    if len(parts) == 1:
+        return parts[0], "Owner"
+    return parts[0], " ".join(parts[1:])
+
+
+def _tenant_slug(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.strip().lower()).strip("-")
+    return slug or "first-run-tenant"
 
 
 def _build_login_response(
@@ -163,6 +198,88 @@ def _build_login_response(
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
+
+@router.get("/setup/status", response_model=FirstRunSetupStatus)
+async def first_run_setup_status(db: AsyncSession = Depends(get_db)) -> FirstRunSetupStatus:
+    """Return whether first-run owner setup is still available."""
+    return FirstRunSetupStatus(available=not await _has_any_user(db))
+
+
+@router.post("/setup", response_model=LoginResponse, status_code=status.HTTP_201_CREATED)
+async def first_run_setup(
+    body: FirstRunSetupRequest,
+    request: Request,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+) -> LoginResponse:
+    """Create the first tenant and owner user, then issue a normal login session."""
+    if await _has_any_user(db):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="First-run setup is already complete")
+
+    try:
+        validate_password_strength(body.password)
+    except PasswordError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)) from exc
+
+    try:
+        await sync_permission_manifest(db)
+    except PermissionSyncError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    role = await db.scalar(
+        select(RoleModel)
+        .options(selectinload(RoleModel.permissions))
+        .where(RoleModel.name == RbacRole.FIRM_ADMIN.value, RoleModel.is_system.is_(True))
+    )
+    if role is None:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Owner role unavailable")
+
+    first_name, last_name = _split_owner_name(body.owner_name)
+    tenant = Tenant(
+        id=str(uuid.uuid4()),
+        name=body.organization_name.strip(),
+        slug=_tenant_slug(body.organization_name),
+        is_active=True,
+    )
+    owner = User(
+        id=str(uuid.uuid4()),
+        tenant_id=tenant.id,
+        role_id=role.id,
+        email=str(body.email).lower(),
+        email_verified=True,
+        hashed_password=hash_password(body.password),
+        first_name=first_name,
+        last_name=last_name,
+        password_changed_at=datetime.now(UTC),
+        is_active=True,
+        is_locked=False,
+    )
+    db.add(tenant)
+    db.add(owner)
+    await db.flush()
+
+    owner.role_ref = role
+    login_response, _refresh_token, family_id = _build_login_response(owner, response)
+    await register_refresh_family(family_id, str(owner.id))
+    await create_session(
+        user_id=str(owner.id),
+        email=owner.email,
+        ip_address=request.client.host if request.client else "unknown",
+        user_agent=request.headers.get("user-agent", ""),
+    )
+    await audit(
+        db,
+        action="first_run_owner_setup",
+        user_id=str(owner.id),
+        tenant_id=str(tenant.id),
+        status="success",
+        actor_email=owner.email,
+        actor_role=login_response.role,
+        actor_ip=request.client.host if request.client else "unknown",
+    )
+    await db.commit()
+    return login_response
+
 
 @router.post("/login", response_model=LoginResponse)
 async def login(
@@ -238,22 +355,15 @@ async def login(
     user.last_login_ip = ip
     await db.commit()
 
-    login_response, refresh_token, family_id = _build_login_response(user, response)
+    login_response, _refresh_token, family_id = _build_login_response(user, response)
 
     # Register refresh family + session
-    from ..auth.jwt_handler import decode_refresh_token
-    rt_payload = decode_refresh_token(refresh_token)
-    rt_jti = rt_payload["jti"]
-    await register_refresh_family(family_id, rt_jti)
-    at_payload = {"jti": get_token_jti(login_response.access_token)}
+    await register_refresh_family(family_id, str(user.id))
     await create_session(
         user_id=str(user.id),
-        tenant_id=str(user.tenant_id),
-        role=login_response.role,
-        device_info=user_agent,
+        email=user.email,
         ip_address=ip,
-        refresh_token_jti=rt_jti,
-        access_token_jti=at_payload["jti"] or "",
+        user_agent=user_agent,
     )
 
     await audit(db, action="login", user_id=str(user.id), tenant_id=str(user.tenant_id),
@@ -280,7 +390,7 @@ async def refresh_token(
     jti = payload.get("jti", "")
 
     # Validate family (detects reuse)
-    valid = await validate_refresh_family(family_id, jti)
+    valid = await validate_refresh_family(family_id)
     if not valid:
         response.delete_cookie(REFRESH_COOKIE_NAME)
         await revoke_all_user_sessions(payload["sub"])
@@ -316,12 +426,10 @@ async def refresh_token(
         tenant_id=str(user.tenant_id),
         family=family_id,
     )
-    new_rt_payload = decode_refresh_token(new_refresh_token)
-    new_rt_jti = new_rt_payload["jti"]
-    await rotate_refresh_family(family_id, new_rt_jti)
+    await rotate_refresh_family(family_id)
 
     # Blocklist old refresh JTI
-    await blocklist_jti(jti, ttl=settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400)
+    await blocklist_jti(jti, ttl_seconds=settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400)
 
     response.set_cookie(
         key=REFRESH_COOKIE_NAME,
@@ -353,13 +461,13 @@ async def logout(
     if auth_header.startswith("Bearer "):
         access_jti = get_token_jti(auth_header[7:])
         if access_jti:
-            await blocklist_jti(access_jti, ttl=settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60)
+            await blocklist_jti(access_jti, ttl_seconds=settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60)
 
     # Blocklist refresh token
     if refresh_token:
         rt_jti = get_token_jti(refresh_token, is_refresh=True)
         if rt_jti:
-            await blocklist_jti(rt_jti, ttl=settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400)
+            await blocklist_jti(rt_jti, ttl_seconds=settings.JWT_REFRESH_TOKEN_EXPIRE_DAYS * 86400)
 
     response.delete_cookie(REFRESH_COOKIE_NAME)
     await audit(db, action="logout", user_id=current_user.user_id,

--- a/portal/tests/test_auth_tenant_rbac_certification.py
+++ b/portal/tests/test_auth_tenant_rbac_certification.py
@@ -35,6 +35,8 @@ EVIDENCE_SCHEMA_VERSION = "1.0"
 APPROVED_PUBLIC_V1_ROUTES = {
     "/api/v1/auth/login",
     "/api/v1/auth/refresh",
+    "/api/v1/auth/setup/status",
+    "/api/v1/auth/setup",
     "/api/v1/auth/password/reset-request",
     "/api/v1/auth/password/reset-confirm",
     "/api/v1/documents/share/{share_token}",
@@ -49,6 +51,8 @@ APPROVED_PUBLIC_V1_ROUTES = {
 PUBLIC_ROUTE_JUSTIFICATIONS = {
     "/api/v1/auth/login": "Credential exchange must be public so anonymous users can obtain a session.",
     "/api/v1/auth/refresh": "Refresh-token rotation is cookie-based and intentionally callable before access-token auth.",
+    "/api/v1/auth/setup/status": "First-run setup discovery is public but only reports whether bootstrap remains available.",
+    "/api/v1/auth/setup": "First-run owner bootstrap is public only while no user exists and then fails closed permanently.",
     "/api/v1/auth/password/reset-request": "Password reset initiation must be public to prevent account enumeration and support lost-password recovery.",
     "/api/v1/auth/password/reset-confirm": "Password reset completion must be public because the one-time reset token is the authorization artifact.",
     "/api/v1/documents/share/{share_token}": "Shared-document access is token-gated and intentionally public for external recipients.",

--- a/portal/tests/test_first_run_setup.py
+++ b/portal/tests/test_first_run_setup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator
 
 import pytest
@@ -131,3 +132,59 @@ async def test_first_run_owner_can_use_normal_login(client: AsyncClient) -> None
     payload = decode_access_token(response.json()["access_token"])
     assert payload["role"] == "FIRM_ADMIN"
     assert Permission.VOICE_COMMAND_CREATE.value in payload["permissions"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_run_setup_creates_one_owner(tmp_path) -> None:
+    db_path = tmp_path / "first_run_setup.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=[
+                    Tenant.__table__,
+                    Role.__table__,
+                    PermissionModel.__table__,
+                    RolePermission.__table__,
+                    User.__table__,
+                    AuditLog.__table__,
+                ],
+            )
+        )
+
+    session_maker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    app = FastAPI()
+    app.include_router(auth.router, prefix="/api/v1/auth")
+
+    async def _override_db() -> AsyncGenerator[AsyncSession, None]:
+        async with session_maker() as db:
+            yield db
+
+    app.dependency_overrides[get_db] = _override_db
+    transport = ASGITransport(app=app)
+    payload_a = await _setup_payload()
+    payload_b = {
+        **payload_a,
+        "owner_name": "Grace Hopper",
+        "email": "grace@example.com",
+        "organization_name": "Beta Legal Ops",
+    }
+
+    try:
+        async with AsyncClient(transport=transport, base_url="http://testserver") as test_client:
+            response_a, response_b = await asyncio.gather(
+                test_client.post("/api/v1/auth/setup", json=payload_a),
+                test_client.post("/api/v1/auth/setup", json=payload_b),
+            )
+
+        assert sorted([response_a.status_code, response_b.status_code]) == [201, 409]
+
+        async with session_maker() as db:
+            users = (await db.execute(select(User))).scalars().all()
+            tenants = (await db.execute(select(Tenant))).scalars().all()
+            assert len(users) == 1
+            assert len(tenants) == 1
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/portal/tests/test_first_run_setup.py
+++ b/portal/tests/test_first_run_setup.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import selectinload
+
+from portal.auth.jwt_handler import decode_access_token
+from portal.auth.rbac import Permission
+from portal.database import Base, get_db
+from portal.models.audit import AuditLog
+from portal.models.user import Permission as PermissionModel
+from portal.models.user import Role, RolePermission, Tenant, User
+from portal.routers import auth
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=[
+                    Tenant.__table__,
+                    Role.__table__,
+                    PermissionModel.__table__,
+                    RolePermission.__table__,
+                    User.__table__,
+                    AuditLog.__table__,
+                ],
+            )
+        )
+    session_maker = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    async with session_maker() as db:
+        yield db
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(session: AsyncSession) -> AsyncGenerator[AsyncClient, None]:
+    app = FastAPI()
+    app.include_router(auth.router, prefix="/api/v1/auth")
+
+    async def _override_db() -> AsyncGenerator[AsyncSession, None]:
+        yield session
+
+    app.dependency_overrides[get_db] = _override_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+async def _setup_payload() -> dict[str, str]:
+    return {
+        "owner_name": "Ada Lawson",
+        "email": "owner@example.com",
+        "password": "OwnerPass729!",
+        "organization_name": "Acme Legal Ops",
+    }
+
+
+@pytest.mark.asyncio
+async def test_first_run_setup_available_only_before_users_exist(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    status_before = await client.get("/api/v1/auth/setup/status")
+    assert status_before.status_code == 200
+    assert status_before.json() == {"available": True}
+
+    response = await client.post("/api/v1/auth/setup", json=await _setup_payload())
+    assert response.status_code == 201
+
+    status_after = await client.get("/api/v1/auth/setup/status")
+    assert status_after.status_code == 200
+    assert status_after.json() == {"available": False}
+
+    blocked = await client.post("/api/v1/auth/setup", json=await _setup_payload())
+    assert blocked.status_code == 409
+
+    users = (await session.execute(select(User))).scalars().all()
+    tenants = (await session.execute(select(Tenant))).scalars().all()
+    assert len(users) == 1
+    assert len(tenants) == 1
+
+
+@pytest.mark.asyncio
+async def test_first_run_setup_creates_owner_with_voice_permissions(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    response = await client.post("/api/v1/auth/setup", json=await _setup_payload())
+    assert response.status_code == 201
+    body = response.json()
+    assert body["access_token"]
+    assert body["role"] == "FIRM_ADMIN"
+
+    payload = decode_access_token(body["access_token"])
+    assert payload["tenant_id"] == body["tenant_id"]
+    assert Permission.VOICE_COMMAND_CREATE.value in payload["permissions"]
+    assert Permission.VOICE_COMMAND_READ.value in payload["permissions"]
+    assert Permission.VOICE_COMMAND_CONFIRM.value in payload["permissions"]
+    assert Permission.VOICE_COMMAND_CANCEL.value in payload["permissions"]
+
+    owner = await session.scalar(
+        select(User)
+        .options(selectinload(User.role_ref).selectinload(Role.permissions))
+        .where(User.email == "owner@example.com")
+    )
+    assert owner is not None
+    assert owner.email_verified is True
+    assert owner.role_ref.name == "FIRM_ADMIN"
+
+
+@pytest.mark.asyncio
+async def test_first_run_owner_can_use_normal_login(client: AsyncClient) -> None:
+    await client.post("/api/v1/auth/setup", json=await _setup_payload())
+
+    response = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "owner@example.com", "password": "OwnerPass729!"},
+    )
+    assert response.status_code == 200
+    payload = decode_access_token(response.json()["access_token"])
+    assert payload["role"] == "FIRM_ADMIN"
+    assert Permission.VOICE_COMMAND_CREATE.value in payload["permissions"]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import CaseLawSearch from './pages/CaseLawSearch';
 import Settings from './pages/Settings';
 import OperationsFloor from './pages/OperationsFloor';
 import Login from './pages/Login';
+import Setup from './pages/Setup';
 import VoiceConcierge from './pages/VoiceConcierge';
 import MissionControlLayout from './pages/mission-control/MissionControlLayout';
 import MissionControlHome from './pages/mission-control/MissionControlHome';
@@ -27,6 +28,7 @@ function AppContent() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<Login />} />
+        <Route path="/setup" element={<Setup />} />
         <Route path="/" element={<Layout />}>
           <Route index element={<LiveDashboard />} />
           <Route path="dashboard" element={<Dashboard />} />

--- a/web/src/api/auth.ts
+++ b/web/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { api } from './client';
+import { apiClient } from './client';
 
 export interface LoginRequest {
   email: string;
@@ -23,18 +23,33 @@ export interface RefreshResponse {
   expires_in: number;
 }
 
+export interface FirstRunSetupStatus {
+  available: boolean;
+}
+
+export interface FirstRunSetupRequest {
+  owner_name: string;
+  email: string;
+  password: string;
+  organization_name: string;
+}
+
+const storeAccessToken = (accessToken: string, expiresIn: number): void => {
+  localStorage.setItem('sintraprime_token', accessToken);
+  const expiresAt = Date.now() + expiresIn * 1000;
+  localStorage.setItem('sintraprime_token_expires_at', expiresAt.toString());
+};
+
 /**
  * Authenticate with email + password.
  * On success, stores access token in localStorage. The refresh token is
  * delivered as an httpOnly cookie by the backend (requires withCredentials).
  */
 export const login = async (credentials: LoginRequest): Promise<LoginResponse> => {
-  const response = await api.post<LoginResponse>('/auth/login', credentials);
+  const response = await apiClient.post<LoginResponse>('/auth/login', credentials);
   const data = response.data;
   if (data.access_token) {
-    localStorage.setItem('sintraprime_token', data.access_token);
-    const expiresAt = Date.now() + data.expires_in * 1000;
-    localStorage.setItem('sintraprime_token_expires_at', expiresAt.toString());
+    storeAccessToken(data.access_token, data.expires_in);
   }
   return data;
 };
@@ -44,12 +59,25 @@ export const login = async (credentials: LoginRequest): Promise<LoginResponse> =
  * The cookie is sent automatically because apiClient uses withCredentials.
  */
 export const refreshAccessToken = async (): Promise<RefreshResponse> => {
-  const response = await api.post<RefreshResponse>('/auth/refresh', {});
+  const response = await apiClient.post<RefreshResponse>('/auth/refresh', {});
   const data = response.data;
   if (data.access_token) {
-    localStorage.setItem('sintraprime_token', data.access_token);
-    const expiresAt = Date.now() + data.expires_in * 1000;
-    localStorage.setItem('sintraprime_token_expires_at', expiresAt.toString());
+    storeAccessToken(data.access_token, data.expires_in);
+  }
+  return data;
+};
+
+
+export const getFirstRunSetupStatus = async (): Promise<FirstRunSetupStatus> => {
+  const response = await apiClient.get<FirstRunSetupStatus>('/auth/setup/status');
+  return response.data;
+};
+
+export const completeFirstRunSetup = async (payload: FirstRunSetupRequest): Promise<LoginResponse> => {
+  const response = await apiClient.post<LoginResponse>('/auth/setup', payload);
+  const data = response.data;
+  if (data.access_token) {
+    storeAccessToken(data.access_token, data.expires_in);
   }
   return data;
 };
@@ -70,6 +98,8 @@ export const hasValidToken = (): boolean => {
 export default {
   login,
   refreshAccessToken,
+  getFirstRunSetupStatus,
+  completeFirstRunSetup,
   logout,
   hasValidToken,
 };

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,10 +1,10 @@
-import { useState, type FormEvent } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useState, type FormEvent } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Lock, Mail, Scale } from 'lucide-react';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
-import { login, type LoginResponse } from '../api/auth';
+import { getFirstRunSetupStatus, login, type LoginResponse } from '../api/auth';
 import { useAppStore } from '../store/appStore';
 
 export default function LoginPage() {
@@ -17,6 +17,27 @@ export default function LoginPage() {
   const [challengeToken, setChallengeToken] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [setupAvailable, setSetupAvailable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    getFirstRunSetupStatus()
+      .then((status) => {
+        if (!cancelled) {
+          setSetupAvailable(status.available);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSetupAvailable(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -149,6 +170,14 @@ export default function LoginPage() {
               {challengeToken ? 'Verify MFA' : 'Sign In'}
             </Button>
           </form>
+
+          {setupAvailable && (
+            <div className="mt-5 text-center text-sm text-slate-500">
+              <Link to="/setup" className="text-gold hover:text-amber-200">
+                Create first owner account
+              </Link>
+            </div>
+          )}
         </Card>
       </motion.div>
     </div>

--- a/web/src/pages/Setup.tsx
+++ b/web/src/pages/Setup.tsx
@@ -1,0 +1,168 @@
+import { useState, type FormEvent } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { Building2, Lock, Mail, Scale, User } from 'lucide-react';
+import Button from '../components/ui/Button';
+import Card from '../components/ui/Card';
+import { completeFirstRunSetup, type LoginResponse } from '../api/auth';
+import { useAppStore } from '../store/appStore';
+
+export default function SetupPage() {
+  const navigate = useNavigate();
+  const { setUser } = useAppStore();
+
+  const [ownerName, setOwnerName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [organizationName, setOrganizationName] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      const response: LoginResponse = await completeFirstRunSetup({
+        owner_name: ownerName.trim(),
+        email: email.trim().toLowerCase(),
+        password,
+        organization_name: organizationName.trim(),
+      });
+
+      setUser({
+        id: response.user_id,
+        name: ownerName.trim(),
+        email: email.trim().toLowerCase(),
+        role: 'admin',
+        firm: organizationName.trim(),
+        preferences: {
+          theme: 'dark',
+          sidebarCollapsed: false,
+          defaultLandingPage: '/dashboard',
+          emailNotifications: true,
+          smsNotifications: false,
+          showTutorials: false,
+          dateFormat: 'MM/DD/YYYY',
+          currency: 'USD',
+          timezone: 'America/New_York',
+        },
+      });
+
+      navigate('/dashboard', { replace: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Setup failed';
+      setError(message);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 flex items-center justify-center px-4">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className="w-full max-w-lg"
+      >
+        <Card className="p-8" gold>
+          <div className="flex flex-col items-center mb-8">
+            <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-gold to-amber-300 flex items-center justify-center mb-4 shadow-lg">
+              <Scale className="w-7 h-7 text-slate-900" />
+            </div>
+            <h1 className="text-2xl font-bold text-slate-100">First-Run Owner Setup</h1>
+            <p className="text-sm text-slate-500 mt-1">Create the owner account for this installation</p>
+          </div>
+
+          {error && (
+            <div className="mb-4 p-3 rounded-lg border border-rose-500/30 bg-rose-500/10 text-rose-200 text-sm">
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-slate-300" htmlFor="owner-name">Owner name</label>
+              <div className="relative">
+                <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+                <input
+                  id="owner-name"
+                  type="text"
+                  value={ownerName}
+                  onChange={(event) => setOwnerName(event.target.value)}
+                  required
+                  autoComplete="name"
+                  className="w-full bg-slate-900/80 border border-slate-700 rounded-lg pl-10 pr-4 py-2.5 text-sm text-slate-100 placeholder:text-slate-600 focus:outline-none focus:border-gold/60 focus:ring-1 focus:ring-gold/30"
+                  placeholder="Owner name"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-slate-300" htmlFor="organization-name">Organization</label>
+              <div className="relative">
+                <Building2 className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+                <input
+                  id="organization-name"
+                  type="text"
+                  value={organizationName}
+                  onChange={(event) => setOrganizationName(event.target.value)}
+                  required
+                  autoComplete="organization"
+                  className="w-full bg-slate-900/80 border border-slate-700 rounded-lg pl-10 pr-4 py-2.5 text-sm text-slate-100 placeholder:text-slate-600 focus:outline-none focus:border-gold/60 focus:ring-1 focus:ring-gold/30"
+                  placeholder="Organization name"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-slate-300" htmlFor="email">Email</label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  required
+                  autoComplete="email"
+                  className="w-full bg-slate-900/80 border border-slate-700 rounded-lg pl-10 pr-4 py-2.5 text-sm text-slate-100 placeholder:text-slate-600 focus:outline-none focus:border-gold/60 focus:ring-1 focus:ring-gold/30"
+                  placeholder="you@firm.com"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <label className="text-sm font-medium text-slate-300" htmlFor="password">Password</label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+                <input
+                  id="password"
+                  type="password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                  required
+                  minLength={12}
+                  autoComplete="new-password"
+                  className="w-full bg-slate-900/80 border border-slate-700 rounded-lg pl-10 pr-4 py-2.5 text-sm text-slate-100 placeholder:text-slate-600 focus:outline-none focus:border-gold/60 focus:ring-1 focus:ring-gold/30"
+                  placeholder="Minimum 12 characters"
+                />
+              </div>
+            </div>
+
+            <Button type="submit" variant="gold" fullWidth loading={loading} disabled={loading}>
+              Create Owner Account
+            </Button>
+          </form>
+
+          <div className="mt-5 text-center text-sm text-slate-500">
+            <Link to="/login" className="text-gold hover:text-amber-200">
+              Return to sign in
+            </Link>
+          </div>
+        </Card>
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Scope
Adds the bounded first-run owner onboarding flow.

## Included
- Public setup status and setup endpoints
- First tenant and owner creation
- Password hashing and canonical RBAC initialization
- Setup self-disables after the first user exists
- Normal login token returned after setup
- `/setup` page and conditional login link
- Auth client/session compatibility fixes

## Validation
- `python -m pytest portal/tests/test_first_run_setup.py portal/tests/test_auth.py -q`
- `python -m ruff check portal/routers/auth.py portal/tests/test_first_run_setup.py`
- `cd web && npm run build`

## Governance
Draft only. No deployment or workflow changes.