### PR TITLE
Browser Voice I/O for Voice Concierge

### DIFF
--- a/portal/tests/test_voice_concierge_browser_io.py
+++ b/portal/tests/test_voice_concierge_browser_io.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+VOICE_PAGE = ROOT / "web" / "src" / "pages" / "VoiceConcierge.tsx"
+VOICE_API = ROOT / "web" / "src" / "api" / "voice.ts"
+
+
+def _voice_page_source() -> str:
+    return VOICE_PAGE.read_text(encoding="utf-8")
+
+
+def test_browser_voice_io_is_transcript_only_and_uses_governed_submit() -> None:
+    source = _voice_page_source()
+
+    assert "navigator.mediaDevices.getUserMedia({ audio: true })" in source
+    assert "SpeechRecognition" in source
+    assert "SpeechSynthesisUtterance" in source
+    assert "speechSynthesis.speak" in source
+    assert "voiceApi.submit({ raw_transcript: rawTranscript, source: captureMode as VoiceSource })" in source
+    assert "FormData" not in source
+    assert "MediaRecorder" not in source
+    assert "fetch(" not in source
+    assert "mock_providers" not in source
+    assert "executeProvider" not in source
+
+
+def test_voice_ui_requires_explicit_submit_or_cancel_after_capture() -> None:
+    source = _voice_page_source()
+
+    assert "Nothing is classified or recorded until Submit is pressed" in source
+    assert "cancelTranscript" in source
+    assert "onClick={submit}" in source
+    assert "setTranscript((current) => `${current} ${finalText}`.trim())" in source
+
+
+def test_voice_source_type_matches_backend_enum() -> None:
+    source = VOICE_API.read_text(encoding="utf-8")
+
+    assert "export type VoiceSource = 'desktop_voice' | 'remote_voice' | 'transcript_import';" in source
+    assert "mobile_voice" not in source
+    assert "telephony" not in source
+    assert "text_fallback" not in source

--- a/portal/tests/test_voice_concierge_browser_io.py
+++ b/portal/tests/test_voice_concierge_browser_io.py
@@ -42,3 +42,14 @@ def test_voice_source_type_matches_backend_enum() -> None:
     assert "mobile_voice" not in source
     assert "telephony" not in source
     assert "text_fallback" not in source
+
+
+def test_command_state_speech_is_deduplicated() -> None:
+    source = _voice_page_source()
+
+    assert "function commandAnnouncementKey(command: VoiceCommandResponse): string" in source
+    assert "const announceCommand = useCallback" in source
+    assert "announcedStatesRef.current.add(key);" in source
+    assert "announceCommand(result);" in source
+    assert "const announcement = buildResultAnnouncement(result);" not in source
+    assert "if (announcement) speak(announcement);" not in source

--- a/web/src/api/voice.ts
+++ b/web/src/api/voice.ts
@@ -11,7 +11,7 @@ import { apiClient } from './client';
  * drives the governed mock ledger.
  */
 
-export type VoiceSource = 'desktop_voice' | 'mobile_voice' | 'telephony' | 'text_fallback';
+export type VoiceSource = 'desktop_voice' | 'remote_voice' | 'transcript_import';
 
 export interface VoiceCommandResponse {
   command_id: string;

--- a/web/src/pages/VoiceConcierge.tsx
+++ b/web/src/pages/VoiceConcierge.tsx
@@ -130,6 +130,10 @@ function buildConfirmationPrompt(command: VoiceCommandResponse): string {
   return `Confirmation required. ${command.resolved_capability} is classified as ${command.risk_class}${target}. Review the ledger, then confirm, deny, or cancel.`;
 }
 
+function commandAnnouncementKey(command: VoiceCommandResponse): string {
+  return `${command.command_id}:${command.session_state}:${command.provider_resource_id ?? ''}`;
+}
+
 function buildResultAnnouncement(command: VoiceCommandResponse): string | null {
   if (command.session_state === 'awaiting_confirmation') return buildConfirmationPrompt(command);
   if (command.session_state === 'completed') {
@@ -196,20 +200,28 @@ export default function VoiceConcierge() {
     };
   }, [ttsSupported]);
 
+  const announceCommand = useCallback(
+    (command: VoiceCommandResponse) => {
+      const announcement = buildResultAnnouncement(command);
+      if (!announcement) return false;
+
+      const key = commandAnnouncementKey(command);
+      if (announcedStatesRef.current.has(key)) return false;
+
+      announcedStatesRef.current.add(key);
+      speak(announcement);
+      return true;
+    },
+    [speak],
+  );
+
   const handleCommandsChanged = useCallback(
     (nextCommands: VoiceCommandResponse[]) => {
       for (const command of nextCommands) {
-        const key = `${command.command_id}:${command.session_state}:${command.provider_resource_id ?? ''}`;
-        if (announcedStatesRef.current.has(key)) continue;
-        const announcement = buildResultAnnouncement(command);
-        if (announcement) {
-          announcedStatesRef.current.add(key);
-          speak(announcement);
-          break;
-        }
+        if (announceCommand(command)) break;
       }
     },
-    [speak],
+    [announceCommand],
   );
 
   useEffect(() => {
@@ -318,8 +330,7 @@ export default function VoiceConcierge() {
       setInterimTranscript('');
       const next = [result, ...commands.filter((command) => command.command_id !== result.command_id)];
       setCommands(next);
-      const announcement = buildResultAnnouncement(result);
-      if (announcement) speak(announcement);
+      announceCommand(result);
       await refresh();
     } catch {
       setError('Unable to submit the voice command. It was not recorded.');
@@ -333,8 +344,7 @@ export default function VoiceConcierge() {
     setBusyId(commandId);
     try {
       const result = await voiceApi.confirm(commandId, { utterance });
-      const announcement = buildResultAnnouncement(result);
-      if (announcement) speak(announcement);
+      announceCommand(result);
       await refresh();
     } catch {
       setError(`Unable to resolve confirmation for ${commandId}.`);
@@ -348,8 +358,7 @@ export default function VoiceConcierge() {
     setBusyId(commandId);
     try {
       const result = await voiceApi.cancel(commandId);
-      const announcement = buildResultAnnouncement(result);
-      if (announcement) speak(announcement);
+      announceCommand(result);
       await refresh();
     } catch {
       setError(`Unable to cancel ${commandId}.`);

--- a/web/src/pages/VoiceConcierge.tsx
+++ b/web/src/pages/VoiceConcierge.tsx
@@ -1,6 +1,19 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Mic, ShieldCheck, RefreshCw, Send, XCircle, CheckCircle2, Clock, AlertTriangle } from 'lucide-react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  Mic,
+  MicOff,
+  RefreshCw,
+  Send,
+  ShieldCheck,
+  Square,
+  Volume2,
+  VolumeX,
+  XCircle,
+} from 'lucide-react';
 import Card, { CardHeader } from '../components/ui/Card';
 import Badge, { BadgeVariant } from '../components/ui/Badge';
 import Button from '../components/ui/Button';
@@ -11,10 +24,69 @@ import { voiceApi, VoiceCommandResponse, VoiceSource } from '../api/voice';
  *
  * Mock/sandbox only: every command submitted here is classified, policy
  * checked, and (if allowed) executed against a mock provider — never a real
- * phone, calendar, messaging, filing, or payment backend. Voice requests and
- * coordinates; existing SintraPrime policy decides, records, approves,
- * executes, or refuses.
+ * phone, calendar, messaging, filing, or payment backend. Browser microphone
+ * input only creates a transcript preview; existing SintraPrime policy decides,
+ * records, approves, executes, or refuses after explicit submission.
  */
+
+type CaptureMode = 'desktop_voice' | 'remote_voice' | 'transcript_import';
+type SpeechStatus = 'idle' | 'requesting_permission' | 'listening' | 'processing' | 'unsupported' | 'denied' | 'error';
+
+type SpeechRecognitionErrorCode =
+  | 'aborted'
+  | 'audio-capture'
+  | 'bad-grammar'
+  | 'language-not-supported'
+  | 'network'
+  | 'no-speech'
+  | 'not-allowed'
+  | 'phrases-not-supported'
+  | 'service-not-allowed';
+
+interface SpeechRecognitionAlternative {
+  transcript: string;
+}
+
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean;
+  readonly length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: SpeechRecognitionErrorCode;
+  readonly message: string;
+}
+
+interface BrowserSpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onstart: (() => void) | null;
+  onend: (() => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  abort(): void;
+  start(): void;
+  stop(): void;
+}
+
+interface SpeechRecognitionWindow extends Window {
+  SpeechRecognition?: new () => BrowserSpeechRecognition;
+  webkitSpeechRecognition?: new () => BrowserSpeechRecognition;
+}
 
 const STATE_BADGE: Record<string, BadgeVariant> = {
   planning: 'blue',
@@ -33,6 +105,12 @@ const RESULT_ICON: Record<string, React.ElementType> = {
   failed: AlertTriangle,
 };
 
+const CAPTURE_OPTIONS: Array<{ value: CaptureMode; label: string; description: string }> = [
+  { value: 'desktop_voice', label: 'Desktop voice', description: 'Browser microphone transcript' },
+  { value: 'remote_voice', label: 'Telephony mock', description: 'Remote transcript simulation' },
+  { value: 'transcript_import', label: 'Text fallback', description: 'Typed transcript import' },
+];
+
 function StateBadge({ state }: { state: string }) {
   return (
     <Badge variant={STATE_BADGE[state] ?? 'slate'} size="sm">
@@ -41,13 +119,59 @@ function StateBadge({ state }: { state: string }) {
   );
 }
 
+function getSpeechRecognitionConstructor() {
+  if (typeof window === 'undefined') return undefined;
+  const speechWindow = window as SpeechRecognitionWindow;
+  return speechWindow.SpeechRecognition ?? speechWindow.webkitSpeechRecognition;
+}
+
+function buildConfirmationPrompt(command: VoiceCommandResponse): string {
+  const target = command.target_resource ? ` for ${command.target_resource}` : '';
+  return `Confirmation required. ${command.resolved_capability} is classified as ${command.risk_class}${target}. Review the ledger, then confirm, deny, or cancel.`;
+}
+
+function buildResultAnnouncement(command: VoiceCommandResponse): string | null {
+  if (command.session_state === 'awaiting_confirmation') return buildConfirmationPrompt(command);
+  if (command.session_state === 'completed') {
+    const resource = command.provider_resource_id ? ` Receipt ${command.provider_resource_id}.` : '';
+    return `Mock command completed.${resource}`;
+  }
+  if (command.session_state === 'refused') return `Command refused. ${command.reason ?? 'Policy did not allow execution.'}`;
+  if (command.session_state === 'cancelled') return 'Command cancelled.';
+  if (command.session_state === 'failed') return `Command failed. ${command.reason ?? 'Review the ledger for details.'}`;
+  return null;
+}
+
 export default function VoiceConcierge() {
   const [transcript, setTranscript] = useState('');
-  const [source, setSource] = useState<VoiceSource>('desktop_voice');
+  const [interimTranscript, setInterimTranscript] = useState('');
+  const [captureMode, setCaptureMode] = useState<CaptureMode>('desktop_voice');
   const [commands, setCommands] = useState<VoiceCommandResponse[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [speechStatus, setSpeechStatus] = useState<SpeechStatus>('idle');
+  const [speechMessage, setSpeechMessage] = useState('');
+  const [ttsEnabled, setTtsEnabled] = useState(true);
+  const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
+  const shouldStopRef = useRef(false);
+  const announcedStatesRef = useRef<Set<string>>(new Set());
+
+  const speechSupported = useMemo(() => Boolean(getSpeechRecognitionConstructor()), []);
+  const ttsSupported = typeof window !== 'undefined' && 'speechSynthesis' in window;
+  const transcriptPreview = `${transcript}${interimTranscript ? ` ${interimTranscript}` : ''}`.trim();
+
+  const speak = useCallback(
+    (message: string) => {
+      if (!ttsEnabled || !ttsSupported || !message.trim()) return;
+      window.speechSynthesis.cancel();
+      const utterance = new SpeechSynthesisUtterance(message);
+      utterance.rate = 0.95;
+      utterance.pitch = 1;
+      window.speechSynthesis.speak(utterance);
+    },
+    [ttsEnabled, ttsSupported],
+  );
 
   const refresh = useCallback(async () => {
     try {
@@ -65,16 +189,141 @@ export default function VoiceConcierge() {
     return () => window.clearInterval(timer);
   }, [refresh]);
 
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.abort();
+      if (ttsSupported) window.speechSynthesis.cancel();
+    };
+  }, [ttsSupported]);
+
+  const handleCommandsChanged = useCallback(
+    (nextCommands: VoiceCommandResponse[]) => {
+      for (const command of nextCommands) {
+        const key = `${command.command_id}:${command.session_state}:${command.provider_resource_id ?? ''}`;
+        if (announcedStatesRef.current.has(key)) continue;
+        const announcement = buildResultAnnouncement(command);
+        if (announcement) {
+          announcedStatesRef.current.add(key);
+          speak(announcement);
+          break;
+        }
+      }
+    },
+    [speak],
+  );
+
+  useEffect(() => {
+    handleCommandsChanged(commands);
+  }, [commands, handleCommandsChanged]);
+
+  const startListening = async () => {
+    const Recognition = getSpeechRecognitionConstructor();
+    if (!Recognition) {
+      setSpeechStatus('unsupported');
+      setSpeechMessage('Browser speech recognition is not available. Use text fallback.');
+      return;
+    }
+
+    recognitionRef.current?.abort();
+    shouldStopRef.current = false;
+    setError('');
+    setSpeechStatus('requesting_permission');
+    setSpeechMessage('Requesting microphone permission. Audio stays in the browser speech service; only transcript text is submitted.');
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      stream.getTracks().forEach((track) => track.stop());
+    } catch {
+      setSpeechStatus('denied');
+      setSpeechMessage('Microphone permission was denied or unavailable. Use text fallback or allow microphone access.');
+      return;
+    }
+
+    const recognition = new Recognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = 'en-US';
+    recognition.onstart = () => {
+      setSpeechStatus('listening');
+      setSpeechMessage('Listening. Release stop, then review the transcript before submitting.');
+    };
+    recognition.onresult = (event) => {
+      let finalText = '';
+      let interimText = '';
+      for (let index = event.resultIndex; index < event.results.length; index += 1) {
+        const result = event.results[index];
+        const phrase = result[0]?.transcript ?? '';
+        if (result.isFinal) {
+          finalText += phrase;
+        } else {
+          interimText += phrase;
+        }
+      }
+      if (finalText.trim()) {
+        setTranscript((current) => `${current} ${finalText}`.trim());
+      }
+      setInterimTranscript(interimText.trim());
+    };
+    recognition.onerror = (event) => {
+      const permissionError = event.error === 'not-allowed' || event.error === 'service-not-allowed';
+      setSpeechStatus(permissionError ? 'denied' : 'error');
+      setSpeechMessage(event.message || `Speech recognition error: ${event.error}`);
+      setInterimTranscript('');
+    };
+    recognition.onend = () => {
+      recognitionRef.current = null;
+      setInterimTranscript('');
+      if (shouldStopRef.current) {
+        setSpeechStatus('idle');
+        setSpeechMessage('Transcript captured. Review it, then submit or cancel.');
+      } else {
+        setSpeechStatus((current) => (current === 'denied' || current === 'error' ? current : 'idle'));
+      }
+    };
+
+    recognitionRef.current = recognition;
+    try {
+      recognition.start();
+    } catch {
+      recognitionRef.current = null;
+      setSpeechStatus('error');
+      setSpeechMessage('Unable to start speech recognition. Use text fallback.');
+    }
+  };
+
+  const stopListening = () => {
+    shouldStopRef.current = true;
+    setSpeechStatus('processing');
+    setSpeechMessage('Finalizing transcript.');
+    recognitionRef.current?.stop();
+  };
+
+  const cancelTranscript = () => {
+    shouldStopRef.current = true;
+    recognitionRef.current?.abort();
+    setTranscript('');
+    setInterimTranscript('');
+    setSpeechStatus('idle');
+    setSpeechMessage('Transcript cleared. No command was submitted.');
+  };
+
   const submit = async () => {
-    if (!transcript.trim()) return;
+    const rawTranscript = transcript.trim();
+    if (!rawTranscript) return;
     setSubmitting(true);
     setError('');
     try {
-      await voiceApi.submit({ raw_transcript: transcript.trim(), source });
+      const result = await voiceApi.submit({ raw_transcript: rawTranscript, source: captureMode as VoiceSource });
       setTranscript('');
+      setInterimTranscript('');
+      const next = [result, ...commands.filter((command) => command.command_id !== result.command_id)];
+      setCommands(next);
+      const announcement = buildResultAnnouncement(result);
+      if (announcement) speak(announcement);
       await refresh();
     } catch {
       setError('Unable to submit the voice command. It was not recorded.');
+      speak('Unable to submit the voice command. It was not recorded.');
     } finally {
       setSubmitting(false);
     }
@@ -83,10 +332,13 @@ export default function VoiceConcierge() {
   const confirm = async (commandId: string, utterance: string) => {
     setBusyId(commandId);
     try {
-      await voiceApi.confirm(commandId, { utterance });
+      const result = await voiceApi.confirm(commandId, { utterance });
+      const announcement = buildResultAnnouncement(result);
+      if (announcement) speak(announcement);
       await refresh();
     } catch {
       setError(`Unable to resolve confirmation for ${commandId}.`);
+      speak('Unable to resolve confirmation.');
     } finally {
       setBusyId(null);
     }
@@ -95,10 +347,13 @@ export default function VoiceConcierge() {
   const cancel = async (commandId: string) => {
     setBusyId(commandId);
     try {
-      await voiceApi.cancel(commandId);
+      const result = await voiceApi.cancel(commandId);
+      const announcement = buildResultAnnouncement(result);
+      if (announcement) speak(announcement);
       await refresh();
     } catch {
       setError(`Unable to cancel ${commandId}.`);
+      speak('Unable to cancel the command.');
     } finally {
       setBusyId(null);
     }
@@ -106,20 +361,25 @@ export default function VoiceConcierge() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} className="space-y-6 p-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <h1 className="flex items-center gap-2 text-xl font-semibold text-slate-100">
             <Mic className="h-5 w-5 text-gold" /> Voice Concierge
           </h1>
-          <p className="mt-1 text-sm text-slate-400">
-            SP-VOICE-001 — governed, mock-first voice operations. All actions below execute against
-            sandboxed mock providers only; nothing here places a real call, sends a real message,
-            books a real calendar event, files a real document, or moves real money.
+          <p className="mt-1 max-w-4xl text-sm text-slate-400">
+            SP-VOICE-001 — governed, mock-first voice operations. Browser speech only creates a transcript preview.
+            Classification, policy, confirmation, tenant isolation, RBAC, ledger persistence, and mock providers remain authoritative.
           </p>
         </div>
-        <Badge variant="green" dot>
-          <ShieldCheck className="h-3 w-3" /> Mock / sandbox only
-        </Badge>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="green" dot>
+            <ShieldCheck className="h-3 w-3" /> Mock / sandbox only
+          </Badge>
+          <Badge variant={ttsEnabled ? 'blue' : 'slate'}>
+            {ttsEnabled ? <Volume2 className="h-3 w-3" /> : <VolumeX className="h-3 w-3" />}
+            Speech output {ttsEnabled ? 'on' : 'off'}
+          </Badge>
+        </div>
       </div>
 
       {error && (
@@ -130,32 +390,80 @@ export default function VoiceConcierge() {
 
       <Card>
         <CardHeader
-          title="Submit a voice command"
-          subtitle="Simulates a transcribed utterance. Governed by risk classification, policy, and confirmation rules."
-        />
-        <div className="flex flex-col gap-3 sm:flex-row">
-          <textarea
-            value={transcript}
-            onChange={(e) => setTranscript(e.target.value)}
-            placeholder="e.g. schedule a mock follow-up call with the client"
-            maxLength={8000}
-            rows={2}
-            className="flex-1 rounded-lg border border-slate-700 bg-slate-900/60 p-3 text-sm text-slate-200 placeholder:text-slate-500 focus:border-gold/50 focus:outline-none"
-          />
-          <div className="flex flex-col gap-2 sm:w-48">
-            <select
-              value={source}
-              onChange={(e) => setSource(e.target.value as VoiceSource)}
-              className="rounded-lg border border-slate-700 bg-slate-900/60 p-2 text-sm text-slate-200 focus:border-gold/50 focus:outline-none"
+          title="Capture transcript"
+          subtitle="Push-to-talk only prepares editable text. Nothing is classified or recorded until Submit is pressed."
+          action={
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={ttsEnabled ? Volume2 : VolumeX}
+              onClick={() => {
+                const next = !ttsEnabled;
+                setTtsEnabled(next);
+                if (!next && ttsSupported) window.speechSynthesis.cancel();
+              }}
             >
-              <option value="desktop_voice">Desktop voice</option>
-              <option value="mobile_voice">Mobile voice</option>
-              <option value="telephony">Telephony (mock)</option>
-              <option value="text_fallback">Text fallback</option>
+              {ttsEnabled ? 'Mute' : 'Unmute'}
+            </Button>
+          }
+        />
+
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_220px]">
+          <div className="space-y-3">
+            <textarea
+              value={transcriptPreview}
+              onChange={(event) => {
+                setTranscript(event.target.value);
+                setInterimTranscript('');
+              }}
+              placeholder="e.g. schedule a mock follow-up call with the client"
+              maxLength={8000}
+              rows={4}
+              className="min-h-28 w-full resize-y rounded-lg border border-slate-700 bg-slate-900/60 p-3 text-sm text-slate-200 placeholder:text-slate-500 focus:border-gold/50 focus:outline-none"
+            />
+
+            <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+              <Badge variant={speechStatus === 'listening' ? 'green' : speechStatus === 'denied' || speechStatus === 'error' ? 'red' : 'slate'} size="sm">
+                {speechStatus.replace(/_/g, ' ')}
+              </Badge>
+              <span>{speechMessage || 'Ready for push-to-talk or text fallback.'}</span>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <select
+              value={captureMode}
+              onChange={(event) => setCaptureMode(event.target.value as CaptureMode)}
+              className="w-full rounded-lg border border-slate-700 bg-slate-900/60 p-2 text-sm text-slate-200 focus:border-gold/50 focus:outline-none"
+            >
+              {CAPTURE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
             </select>
-            <Button icon={Send} onClick={submit} loading={submitting} disabled={!transcript.trim()}>
+
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                icon={speechStatus === 'listening' ? Square : Mic}
+                variant={speechStatus === 'listening' ? 'danger' : 'outline'}
+                onClick={speechStatus === 'listening' ? stopListening : startListening}
+                disabled={!speechSupported || captureMode === 'transcript_import' || submitting}
+              >
+                {speechStatus === 'listening' ? 'Stop' : 'Talk'}
+              </Button>
+              <Button icon={MicOff} variant="ghost" onClick={cancelTranscript} disabled={!transcriptPreview && speechStatus !== 'listening'}>
+                Cancel
+              </Button>
+            </div>
+
+            <Button icon={Send} onClick={submit} loading={submitting} disabled={!transcript.trim() || speechStatus === 'listening'} fullWidth>
               Submit
             </Button>
+
+            <div className="rounded-lg border border-slate-800 bg-slate-950/40 p-3 text-xs text-slate-500">
+              {CAPTURE_OPTIONS.find((option) => option.value === captureMode)?.description}
+            </div>
           </div>
         </div>
       </Card>
@@ -163,7 +471,7 @@ export default function VoiceConcierge() {
       <Card>
         <CardHeader
           title="Command ledger"
-          subtitle="Tenant-scoped, hash-chained lifecycle of every submitted voice command."
+          subtitle="Tenant-scoped, hash-chained lifecycle of every submitted voice command. Confirmation controls remain explicit."
           action={
             <Button variant="ghost" size="sm" icon={RefreshCw} onClick={refresh}>
               Refresh
@@ -178,10 +486,7 @@ export default function VoiceConcierge() {
               const ResultIcon = RESULT_ICON[cmd.session_state] ?? Clock;
               const awaiting = cmd.session_state === 'awaiting_confirmation';
               return (
-                <div
-                  key={cmd.command_id}
-                  className="rounded-lg border border-slate-800 bg-slate-900/40 p-4"
-                >
+                <div key={cmd.command_id} className="rounded-lg border border-slate-800 bg-slate-900/40 p-4">
                   <div className="flex items-start justify-between gap-4">
                     <div className="min-w-0">
                       <p className="truncate text-sm font-medium text-slate-200">{cmd.normalized_intent}</p>
@@ -206,41 +511,24 @@ export default function VoiceConcierge() {
 
                   {awaiting && (
                     <div className="mt-3 flex flex-wrap gap-2">
-                      <Button
-                        size="sm"
-                        variant="success"
-                        loading={busyId === cmd.command_id}
-                        onClick={() => confirm(cmd.command_id, 'yes')}
-                      >
+                      <Button size="sm" variant="success" loading={busyId === cmd.command_id} onClick={() => confirm(cmd.command_id, 'yes')}>
                         Confirm
                       </Button>
-                      <Button
-                        size="sm"
-                        variant="danger"
-                        loading={busyId === cmd.command_id}
-                        onClick={() => confirm(cmd.command_id, 'no')}
-                      >
+                      <Button size="sm" variant="danger" loading={busyId === cmd.command_id} onClick={() => confirm(cmd.command_id, 'no')}>
                         Deny
                       </Button>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        loading={busyId === cmd.command_id}
-                        onClick={() => cancel(cmd.command_id)}
-                      >
+                      <Button size="sm" variant="ghost" loading={busyId === cmd.command_id} onClick={() => cancel(cmd.command_id)}>
                         Cancel
+                      </Button>
+                      <Button size="sm" variant="ghost" icon={Volume2} onClick={() => speak(buildConfirmationPrompt(cmd))}>
+                        Prompt
                       </Button>
                     </div>
                   )}
 
                   {!awaiting && !['completed', 'refused', 'cancelled', 'failed'].includes(cmd.session_state) && (
                     <div className="mt-3">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        loading={busyId === cmd.command_id}
-                        onClick={() => cancel(cmd.command_id)}
-                      >
+                      <Button size="sm" variant="ghost" loading={busyId === cmd.command_id} onClick={() => cancel(cmd.command_id)}>
                         Cancel
                       </Button>
                     </div>


### PR DESCRIPTION
## Scope
Adds browser microphone input and speech output to Voice Concierge while preserving the existing governed command path.

## Included
- Push-to-talk browser microphone capture
- Transcript preview with explicit submit/cancel
- Permission, unsupported-browser, and error states
- Spoken confirmation prompts and terminal results
- Backend-supported voice source values
- Static regression coverage proving microphone input remains transcript-only and submission still uses the governed API

## Validation
- `python -m pytest portal/tests/test_voice_concierge_browser_io.py portal/tests/test_voice_commands.py -q`
- `python -m ruff check portal/tests/test_voice_concierge_browser_io.py`
- `cd web && npm run build`
- `git diff --check`

## Governance
Stacked on the First-Run Owner Setup branch. Mock/sandbox only. No deployment, real providers, external execution path, or workflow changes.