### PR TITLE
SP-OMNIBRAIN-001: Principal Command + OmniBrain Phase 2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ When the user requests a durable behavior change, record it here or in the relev
 | `portal/routers/AGENTS.md` | API route handlers | Router modules and their tests; delegates business logic to `services/` |
 | `agents/AGENTS.md` | Autonomous agent system | Nova, Sigma, Zero, Chat, Howard agents (Howard is approval-gated — evidence-intake only) |
 | `parl/AGENTS.md` | Parallel agent orchestration and Principal Command | PARL swarm execution, agent adapters, replay/policy learning, governed orchestrator, God Mode admission policy, tests |
+| `memory/AGENTS.md` | OmniBrain memory boundary | Scoped context packages, provenance graph, existing memory engine integration, one-way Obsidian projection, memory tests |
 | `intake_templates/AGENTS.md` | Evidence intake template library | JSON template definitions and usage guide |
 | `tests/AGENTS.md` | Root-level tests | Scheduler tests, agent unit tests, security tests (not portal-level tests)
 | `legal_authority/AGENTS.md` | Legal authority and jurisdiction rules | Normalized legal authority records, jurisdiction rules, conflicts, effective-date evaluation, provenance |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ When the user requests a durable behavior change, record it here or in the relev
 | `portal/AGENTS.md` | Client portal (FastAPI) | Auth, models, routes, services, middleware, SSO, WebSocket, DB schema, portal-level tests |
 | `portal/routers/AGENTS.md` | API route handlers | Router modules and their tests; delegates business logic to `services/` |
 | `agents/AGENTS.md` | Autonomous agent system | Nova, Sigma, Zero, Chat, Howard agents (Howard is approval-gated — evidence-intake only) |
+| `parl/AGENTS.md` | Parallel agent orchestration and Principal Command | PARL swarm execution, agent adapters, replay/policy learning, governed orchestrator, God Mode admission policy, tests |
 | `intake_templates/AGENTS.md` | Evidence intake template library | JSON template definitions and usage guide |
 | `tests/AGENTS.md` | Root-level tests | Scheduler tests, agent unit tests, security tests (not portal-level tests)
 | `legal_authority/AGENTS.md` | Legal authority and jurisdiction rules | Normalized legal authority records, jurisdiction rules, conflicts, effective-date evaluation, provenance |

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -19,7 +19,9 @@ Owns the autonomous agent system comprising four agent families:
 ## Local Contracts
 
 - Each agent runs as an autonomous module — no agent imports another agent's internals
-- Agents communicate via the portal API, file-system drop zones (`intake/`, `processed/`, `errors/`, `exports/`), or the shared database
+- Agents communicate via the portal API, file-system drop zones (`intake/`, `processed/`, `errors/`, `exports/`), the shared database, or the governed PARL orchestration facade
+- New multi-agent orchestration MUST prefer `parl.GovernedPARLOrchestrator`; elevated capabilities are admitted centrally before any worker is spawned
+- God Mode / Principal Command is a Principal capability, never an agent capability; agents must not self-elevate, bypass approvals, or infer elevated authority from task text
 - Nova: every action must route through `approval_gateway.py` and log to `execution_ledger.py`
 - Sigma: enforces coverage thresholds defined in `pyproject.toml` or `.safety-policy.yml`
 - Zero: all auto-patches must be revertible (`git revert` compliant)
@@ -29,11 +31,11 @@ Howard recovery/intake/template agents must remain evidence-intake-only unless e
 
 ## Work Guidance
 
-*(No project-specific standards yet — fill when engineering conventions emerge.)*
+- When adding a new agent to shared orchestration, register it through the governed PARL facade and declare its task risk/capability metadata rather than granting broad ambient authority.
 
 ## Verification
 
-*(No verification framework documented yet — fill when test/coverage thresholds exist.)*
+- Principal Command behavior: `pytest parl/tests/test_god_mode.py parl/tests/test_governed_orchestrator.py`
 
 ## Child DOX Index
 

--- a/memory/AGENTS.md
+++ b/memory/AGENTS.md
@@ -1,0 +1,36 @@
+# memory — OmniBrain Memory Boundary
+
+## Purpose
+
+Owns SintraPrime persistent memory, scoped context packaging, provenance relationships, and read-only human projections.
+
+## Ownership
+
+- Existing semantic, episodic, working-memory, profile, and memory API modules
+- Scoped context packages used by governed agent orchestration
+- Provenance/knowledge graph storage for memory relationships
+- One-way Obsidian-compatible Markdown projection
+
+## Local Contracts
+
+- Memory retrieval must be scope-filtered before content is exposed to an agent.
+- Legacy unscoped memories may only be included when bound to the requesting `user_id`; anonymous unscoped memories are not globally visible.
+- Provenance is additive: derived context must retain the source memory ID and available source metadata.
+- Obsidian is a projection only. Markdown files generated from memory must never become trusted canonical memory through an automatic reverse sync.
+- Credentials, OAuth tokens, secret values, and raw authentication material must not be projected into Markdown.
+- `memory/` supplies context; it does not grant action authority.
+
+## Work Guidance
+
+- Extend existing memory primitives rather than creating a parallel store.
+- Keep APIs backward compatible where practical.
+- Prefer deterministic, inspectable Python/SQLite/Markdown representations.
+
+## Verification
+
+- `pytest memory/tests`
+- Governed integration coverage also lives under `parl/tests/`.
+
+## Child DOX Index
+
+*(No child DOX boundaries yet.)*

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,6 +1,6 @@
 """
 SintraPrime-Unified Memory Engine
-Multi-layer persistent memory system inspired by Hermes Agent, Claude Memory, GPT-5.5, and Pi AI.
+Multi-layer persistent memory plus governed OmniBrain context services.
 """
 
 from .memory_engine import MemoryEngine
@@ -8,13 +8,10 @@ from .semantic_memory import SemanticMemory
 from .working_memory import WorkingMemory
 from .episodic_memory import EpisodicMemory
 from .user_profile import UserProfileManager
-from .memory_types import (
-    MemoryEntry,
-    MemoryType,
-    UserProfile,
-    MemorySearchResult,
-    SkillRecord,
-)
+from .memory_types import MemoryEntry, MemoryType, UserProfile, MemorySearchResult, SkillRecord
+from .context_packages import ContextItem, ContextPackage, ContextPackageBuilder, ContextScope
+from .knowledge_graph import GraphEdge, KnowledgeGraphStore
+from .obsidian_projection import ObsidianProjector
 
 __all__ = [
     "MemoryEngine",
@@ -27,7 +24,14 @@ __all__ = [
     "MemoryType",
     "MemorySearchResult",
     "SkillRecord",
+    "ContextScope",
+    "ContextItem",
+    "ContextPackage",
+    "ContextPackageBuilder",
+    "GraphEdge",
+    "KnowledgeGraphStore",
+    "ObsidianProjector",
 ]
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __author__ = "SintraPrime-Unified"

--- a/memory/context_packages.py
+++ b/memory/context_packages.py
@@ -1,0 +1,141 @@
+"""Scoped context packages for governed SintraPrime agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .memory_engine import MemoryEngine
+
+
+@dataclass(frozen=True)
+class ContextScope:
+    agent_id: str
+    user_id: Optional[str] = None
+    project_id: Optional[str] = None
+    matter_id: Optional[str] = None
+    tenant_id: Optional[str] = None
+    max_items: int = 8
+    allow_legacy_user_scoped: bool = True
+
+
+@dataclass
+class ContextItem:
+    memory_id: str
+    content: str
+    relevance_score: float
+    importance: float
+    tags: List[str]
+    provenance: Dict[str, Any]
+    scope: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "memory_id": self.memory_id,
+            "content": self.content,
+            "relevance_score": self.relevance_score,
+            "importance": self.importance,
+            "tags": list(self.tags),
+            "provenance": dict(self.provenance),
+            "scope": dict(self.scope),
+        }
+
+
+@dataclass
+class ContextPackage:
+    query: str
+    scope: ContextScope
+    items: List[ContextItem] = field(default_factory=list)
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "query": self.query,
+            "scope": {
+                "agent_id": self.scope.agent_id,
+                "user_id": self.scope.user_id,
+                "project_id": self.scope.project_id,
+                "matter_id": self.scope.matter_id,
+                "tenant_id": self.scope.tenant_id,
+            },
+            "created_at": self.created_at,
+            "items": [item.to_dict() for item in self.items],
+        }
+
+
+class ContextPackageBuilder:
+    """Build scope-filtered memory payloads before agent exposure."""
+
+    def __init__(self, engine: Optional[MemoryEngine] = None):
+        self.engine = engine or MemoryEngine()
+
+    def build(self, query: str, scope: ContextScope) -> ContextPackage:
+        # Query only semantic memory to avoid anonymous synthetic working-memory
+        # entries from being treated as durable cross-agent context.
+        results = self.engine.semantic.recall(
+            query=query,
+            top_k=max(scope.max_items * 4, scope.max_items),
+            user_id=scope.user_id,
+        )
+        items: List[ContextItem] = []
+        for result in results:
+            entry = result.entry
+            if not self._allowed(entry.user_id, entry.metadata, scope):
+                continue
+            metadata = dict(entry.metadata or {})
+            items.append(
+                ContextItem(
+                    memory_id=entry.id,
+                    content=entry.content,
+                    relevance_score=result.relevance_score,
+                    importance=entry.importance,
+                    tags=list(entry.tags),
+                    provenance={
+                        "memory_id": entry.id,
+                        "source": metadata.get("source", "unknown"),
+                        "source_id": metadata.get("source_id"),
+                        "source_uri": metadata.get("source_uri"),
+                        "created_at": entry.created_at.isoformat(),
+                    },
+                    scope={
+                        "user_id": entry.user_id,
+                        "project_id": metadata.get("project_id"),
+                        "matter_id": metadata.get("matter_id"),
+                        "tenant_id": metadata.get("tenant_id"),
+                        "agent_ids": metadata.get("agent_ids", []),
+                        "legacy_unscoped": not any(
+                            metadata.get(key)
+                            for key in ("project_id", "matter_id", "tenant_id", "agent_ids")
+                        ),
+                    },
+                )
+            )
+            if len(items) >= scope.max_items:
+                break
+        return ContextPackage(query=query, scope=scope, items=items)
+
+    @staticmethod
+    def _allowed(entry_user_id: Optional[str], metadata: Dict[str, Any], scope: ContextScope) -> bool:
+        agent_ids = metadata.get("agent_ids") or []
+        if agent_ids and scope.agent_id not in agent_ids:
+            return False
+        for key, requested in (
+            ("project_id", scope.project_id),
+            ("matter_id", scope.matter_id),
+            ("tenant_id", scope.tenant_id),
+        ):
+            stored = metadata.get(key)
+            if stored is not None and requested != stored:
+                return False
+        explicitly_global = metadata.get("visibility") == "global"
+        explicitly_scoped = bool(agent_ids) or any(
+            metadata.get(key) is not None for key in ("project_id", "matter_id", "tenant_id")
+        )
+        if entry_user_id is None and not explicitly_global and not explicitly_scoped:
+            return False
+        if entry_user_id is not None and scope.user_id != entry_user_id:
+            return False
+        if not explicitly_scoped and not explicitly_global:
+            return bool(scope.allow_legacy_user_scoped and scope.user_id and entry_user_id == scope.user_id)
+        return True

--- a/memory/knowledge_graph.py
+++ b/memory/knowledge_graph.py
@@ -1,0 +1,116 @@
+"""Minimal durable knowledge/provenance graph for OmniBrain."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from .context_packages import ContextPackage
+
+
+@dataclass(frozen=True)
+class GraphEdge:
+    source_id: str
+    relation: str
+    target_id: str
+    metadata: Dict[str, Any]
+
+
+class KnowledgeGraphStore:
+    def __init__(self, db_path: Optional[str] = None):
+        if db_path is None:
+            root = Path.home() / ".sintra" / "memory"
+            root.mkdir(parents=True, exist_ok=True)
+            db_path = str(root / "knowledge_graph.db")
+        self.db_path = db_path
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS graph_nodes (
+                    node_id TEXT PRIMARY KEY,
+                    node_type TEXT NOT NULL,
+                    label TEXT NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL
+                )"""
+            )
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS graph_edges (
+                    source_id TEXT NOT NULL,
+                    relation TEXT NOT NULL,
+                    target_id TEXT NOT NULL,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    PRIMARY KEY (source_id, relation, target_id)
+                )"""
+            )
+            conn.commit()
+
+    def upsert_node(self, node_id: str, node_type: str, label: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        with self._connect() as conn:
+            conn.execute(
+                """INSERT INTO graph_nodes(node_id, node_type, label, metadata, created_at)
+                   VALUES (?, ?, ?, ?, ?)
+                   ON CONFLICT(node_id) DO UPDATE SET
+                     node_type=excluded.node_type,
+                     label=excluded.label,
+                     metadata=excluded.metadata""",
+                (node_id, node_type, label, json.dumps(metadata or {}), now),
+            )
+            conn.commit()
+
+    def add_edge(self, source_id: str, relation: str, target_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        with self._connect() as conn:
+            conn.execute(
+                """INSERT OR REPLACE INTO graph_edges(source_id, relation, target_id, metadata, created_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (source_id, relation, target_id, json.dumps(metadata or {}), now),
+            )
+            conn.commit()
+
+    def record_context_package(self, package: ContextPackage) -> None:
+        agent_node = f"agent:{package.scope.agent_id}"
+        self.upsert_node(agent_node, "agent", package.scope.agent_id)
+        for item in package.items:
+            memory_node = f"memory:{item.memory_id}"
+            self.upsert_node(
+                memory_node,
+                "memory",
+                item.content[:120],
+                {"tags": item.tags, "scope": item.scope, "provenance": item.provenance},
+            )
+            self.add_edge(agent_node, "RECALLED", memory_node, {"query": package.query})
+            source_id = item.provenance.get("source_id")
+            if source_id:
+                source_node = f"source:{source_id}"
+                self.upsert_node(source_node, "source", str(source_id), item.provenance)
+                self.add_edge(memory_node, "DERIVED_FROM", source_node)
+            for key, relation in (
+                ("project_id", "SCOPED_TO_PROJECT"),
+                ("matter_id", "SCOPED_TO_MATTER"),
+                ("tenant_id", "SCOPED_TO_TENANT"),
+            ):
+                value = item.scope.get(key)
+                if value:
+                    scope_node = f"{key}:{value}"
+                    self.upsert_node(scope_node, key.removesuffix("_id"), str(value))
+                    self.add_edge(memory_node, relation, scope_node)
+
+    def stats(self) -> Dict[str, int]:
+        with self._connect() as conn:
+            nodes = conn.execute("SELECT COUNT(*) FROM graph_nodes").fetchone()[0]
+            edges = conn.execute("SELECT COUNT(*) FROM graph_edges").fetchone()[0]
+        return {"nodes": int(nodes), "edges": int(edges)}

--- a/memory/obsidian_projection.py
+++ b/memory/obsidian_projection.py
@@ -1,0 +1,91 @@
+"""One-way Obsidian-compatible Markdown projection for approved OmniBrain context."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Iterable, List
+
+from .context_packages import ContextPackage
+
+
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)(api[_-]?key|client[_-]?secret|refresh[_-]?token|access[_-]?token|password)\s*[:=]\s*\S+"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+)
+
+
+def _safe_name(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-.")
+    return cleaned[:100] or "item"
+
+
+def _redact(text: str) -> str:
+    redacted = text
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    return redacted
+
+
+class ObsidianProjector:
+    """Writes read-only projection files; never ingests them back into memory."""
+
+    def __init__(self, vault_root: str):
+        self.vault_root = Path(vault_root)
+
+    def project_package(self, package: ContextPackage) -> List[Path]:
+        written: List[Path] = []
+        agent_dir = self.vault_root / "Agents" / _safe_name(package.scope.agent_id)
+        memory_dir = self.vault_root / "Memory"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        memory_dir.mkdir(parents=True, exist_ok=True)
+
+        links: List[str] = []
+        for item in package.items:
+            filename = f"{_safe_name(item.memory_id)}.md"
+            path = memory_dir / filename
+            body = _redact(item.content)
+            source = item.provenance.get("source") or "unknown"
+            source_id = item.provenance.get("source_id") or ""
+            scope = item.scope
+            content_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()
+            frontmatter = [
+                "---",
+                f"id: {item.memory_id}",
+                "type: memory",
+                f"source: {source}",
+                f"source_id: {source_id}",
+                f"project_id: {scope.get('project_id') or ''}",
+                f"matter_id: {scope.get('matter_id') or ''}",
+                f"tenant_id: {scope.get('tenant_id') or ''}",
+                f"content_sha256: {content_hash}",
+                "projection: one-way",
+                "---",
+                "",
+            ]
+            path.write_text("\n".join(frontmatter) + body + "\n", encoding="utf-8")
+            written.append(path)
+            links.append(f"[[Memory/{filename[:-3]}]]")
+
+        package_name = _safe_name(package.created_at.replace(":", "-"))
+        index_path = agent_dir / f"context-{package_name}.md"
+        index_lines = [
+            "---",
+            f"agent_id: {package.scope.agent_id}",
+            f"user_id: {package.scope.user_id or ''}",
+            f"project_id: {package.scope.project_id or ''}",
+            f"matter_id: {package.scope.matter_id or ''}",
+            "projection: one-way",
+            "---",
+            "",
+            f"# Context package — {package.scope.agent_id}",
+            "",
+            f"Query: {_redact(package.query)}",
+            "",
+            *[f"- {link}" for link in links],
+            "",
+        ]
+        index_path.write_text("\n".join(index_lines), encoding="utf-8")
+        written.append(index_path)
+        return written

--- a/memory/tests/test_context_packages.py
+++ b/memory/tests/test_context_packages.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+from memory.context_packages import ContextPackageBuilder, ContextScope
+from memory.memory_types import MemoryEntry, MemorySearchResult, MemoryType
+
+
+class FakeSemantic:
+    def __init__(self, results):
+        self.results = results
+
+    def recall(self, **kwargs):
+        return list(self.results)
+
+
+class FakeEngine:
+    def __init__(self, results):
+        self.semantic = FakeSemantic(results)
+
+
+def result(*, user_id=None, metadata=None, content="memory", score=0.9):
+    entry = MemoryEntry(
+        content=content,
+        memory_type=MemoryType.SEMANTIC,
+        user_id=user_id,
+        metadata=metadata or {},
+        created_at=datetime.utcnow(),
+    )
+    return MemorySearchResult(entry=entry, relevance_score=score)
+
+
+def test_legacy_memory_requires_matching_user():
+    builder = ContextPackageBuilder(FakeEngine([result(user_id="u1")]))
+    allowed = builder.build("q", ContextScope(agent_id="hermes", user_id="u1"))
+    denied = builder.build("q", ContextScope(agent_id="hermes", user_id="u2"))
+    assert len(allowed.items) == 1
+    assert allowed.items[0].scope["legacy_unscoped"] is True
+    assert denied.items == []
+
+
+def test_anonymous_unscoped_memory_is_not_global():
+    builder = ContextPackageBuilder(FakeEngine([result(user_id=None)]))
+    package = builder.build("q", ContextScope(agent_id="hermes"))
+    assert package.items == []
+
+
+def test_explicit_agent_and_project_scope_is_enforced():
+    memory = result(
+        user_id=None,
+        metadata={"agent_ids": ["hermes"], "project_id": "p1", "source_id": "src-1"},
+    )
+    builder = ContextPackageBuilder(FakeEngine([memory]))
+    ok = builder.build("q", ContextScope(agent_id="hermes", project_id="p1"))
+    wrong_agent = builder.build("q", ContextScope(agent_id="sigma", project_id="p1"))
+    wrong_project = builder.build("q", ContextScope(agent_id="hermes", project_id="p2"))
+    assert len(ok.items) == 1
+    assert ok.items[0].provenance["source_id"] == "src-1"
+    assert wrong_agent.items == []
+    assert wrong_project.items == []

--- a/memory/tests/test_omnibrain_projection.py
+++ b/memory/tests/test_omnibrain_projection.py
@@ -1,0 +1,46 @@
+from memory.context_packages import ContextItem, ContextPackage, ContextScope
+from memory.knowledge_graph import KnowledgeGraphStore
+from memory.obsidian_projection import ObsidianProjector
+
+
+def package():
+    return ContextPackage(
+        query="review project",
+        scope=ContextScope(agent_id="hermes", user_id="u1", project_id="p1"),
+        items=[
+            ContextItem(
+                memory_id="m1",
+                content="API_KEY=supersecret important project fact",
+                relevance_score=0.9,
+                importance=0.8,
+                tags=["project"],
+                provenance={"source": "github", "source_id": "sha-1", "source_uri": "repo://x"},
+                scope={
+                    "user_id": "u1",
+                    "project_id": "p1",
+                    "matter_id": None,
+                    "tenant_id": None,
+                    "agent_ids": ["hermes"],
+                    "legacy_unscoped": False,
+                },
+            )
+        ],
+    )
+
+
+def test_graph_records_provenance_edges(tmp_path):
+    store = KnowledgeGraphStore(str(tmp_path / "graph.db"))
+    store.record_context_package(package())
+    stats = store.stats()
+    assert stats["nodes"] >= 4
+    assert stats["edges"] >= 3
+
+
+def test_obsidian_projection_is_one_way_and_redacts_secrets(tmp_path):
+    projector = ObsidianProjector(str(tmp_path / "vault"))
+    paths = projector.project_package(package())
+    text = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+    assert "projection: one-way" in text
+    assert "supersecret" not in text
+    assert "[REDACTED]" in text
+    assert "[[Memory/m1]]" in text

--- a/parl/AGENTS.md
+++ b/parl/AGENTS.md
@@ -1,0 +1,41 @@
+# parl — Parallel Agent Orchestration
+
+## Purpose
+
+Owns SintraPrime's central multi-agent orchestration, experience replay, policy synchronization, reward logic, and Principal Command admission control.
+
+## Ownership
+
+- `orchestrator.py` — base PARL task decomposition and parallel execution
+- `governed_orchestrator.py` — governed facade for SintraPrime-wide agent execution
+- `god_mode.py` — Principal Command / God Mode session tiers and admission policy
+- `agent_adapters.py` — runtime-specific agent adapters
+- `experience_replay.py`, `reward_engine.py`, `policy_sync.py` — PARL learning infrastructure
+- `tests/` — PARL and Principal Command behavioral tests
+
+## Local Contracts
+
+- God Mode belongs to the authenticated Principal, never to a model or subagent.
+- `GovernedPARLOrchestrator` is the preferred entrypoint for new orchestration work.
+- Missing `risk_level` remains ordinary orchestration for backward compatibility.
+- `write`, `external`, and `critical` risk levels require an authenticated, non-expired Principal session at the required tier.
+- External and critical admission never substitutes for downstream approval gateways.
+- `disable_governance`, `self_elevate`, `reveal_secrets`, `export_raw_credentials`, and `bypass_approval` are non-delegable capabilities.
+- Critical administration requires step-up verification.
+- Agent compromise must remain compartmentalized; no worker receives global credentials merely because a Principal session exists.
+
+## Work Guidance
+
+- Prefer extending the governed facade over modifying the base PARL execution semantics when the change concerns authority or approval.
+- Keep Principal Command provider/model neutral.
+- Add a behavioral test for every new tier, risk class, non-delegable capability, or approval rule.
+
+## Verification
+
+Run:
+
+`pytest parl/tests/test_god_mode.py parl/tests/test_governed_orchestrator.py parl/tests/test_parl.py`
+
+## Child DOX Index
+
+*(No child AGENTS.md files yet.)*

--- a/parl/AGENTS.md
+++ b/parl/AGENTS.md
@@ -2,39 +2,45 @@
 
 ## Purpose
 
-Owns SintraPrime's central multi-agent orchestration, experience replay, policy synchronization, reward logic, and Principal Command admission control.
+Owns SintraPrime's central multi-agent orchestration, experience replay, policy synchronization, reward logic, Principal Command admission control, GOD-0 Principal Brief, and bounded GOD-1 swarm planning.
 
 ## Ownership
 
 - `orchestrator.py` — base PARL task decomposition and parallel execution
-- `governed_orchestrator.py` — governed facade for SintraPrime-wide agent execution
+- `governed_orchestrator.py` — governed facade and scoped OmniBrain context injection
 - `god_mode.py` — Principal Command / God Mode session tiers and admission policy
+- `principal_brief.py` — read-only GOD-0 Principal Brief and Mission Control snapshot contract
+- `swarms.py` — GOD-1 Council, Research, and Build swarm templates
 - `agent_adapters.py` — runtime-specific agent adapters
 - `experience_replay.py`, `reward_engine.py`, `policy_sync.py` — PARL learning infrastructure
-- `tests/` — PARL and Principal Command behavioral tests
+- `tests/` — PARL, Principal Command, context, brief, and swarm behavioral tests
 
 ## Local Contracts
 
 - God Mode belongs to the authenticated Principal, never to a model or subagent.
 - `GovernedPARLOrchestrator` is the preferred entrypoint for new orchestration work.
+- Every governed subtask receives a scope-filtered OmniBrain context package before worker execution.
+- Context retrieval does not grant action authority and must preserve memory provenance.
 - Missing `risk_level` remains ordinary orchestration for backward compatibility.
 - `write`, `external`, and `critical` risk levels require an authenticated, non-expired Principal session at the required tier.
 - External and critical admission never substitutes for downstream approval gateways.
 - `disable_governance`, `self_elevate`, `reveal_secrets`, `export_raw_credentials`, and `bypass_approval` are non-delegable capabilities.
 - Critical administration requires step-up verification.
+- GOD-0 Principal Brief and Mission Control are read-only aggregation surfaces.
+- GOD-1 Council, Research, and Build swarms are orchestration-only and do not receive external-write authority.
 - Agent compromise must remain compartmentalized; no worker receives global credentials merely because a Principal session exists.
 
 ## Work Guidance
 
-- Prefer extending the governed facade over modifying the base PARL execution semantics when the change concerns authority or approval.
+- Prefer extending the governed facade over modifying base PARL execution semantics when the change concerns authority, context, or approval.
 - Keep Principal Command provider/model neutral.
-- Add a behavioral test for every new tier, risk class, non-delegable capability, or approval rule.
+- Add a behavioral test for every new tier, risk class, non-delegable capability, approval rule, or swarm mode.
 
 ## Verification
 
 Run:
 
-`pytest parl/tests/test_god_mode.py parl/tests/test_governed_orchestrator.py parl/tests/test_parl.py`
+`pytest parl/tests/test_god_mode.py parl/tests/test_governed_orchestrator.py parl/tests/test_principal_brief_and_swarms.py parl/tests/test_parl.py memory/tests/test_context_packages.py memory/tests/test_omnibrain_projection.py`
 
 ## Child DOX Index
 

--- a/parl/__init__.py
+++ b/parl/__init__.py
@@ -1,34 +1,9 @@
 """
 PARL — Parallel-Agent Reinforcement Learning for SintraPrime.
 
-Implements the Kimi K2.5 PARL training paradigm:
-
-    r_PARL(x, y) = λ1·r_parallel + λ2·r_finish + r_perf(x, y)
-
-Key components:
-- PARLReward          : Three-term reward function with λ1/λ2 annealing
-- CriticalStepsMetric : Latency-oriented evaluation (critical path)
-- SharedReplayBuffer  : Multi-agent shared experience replay
-- PolicyStore         : Centralised parameter server (CTDE pattern)
-- PARLOrchestrator    : Task decomposition + parallel subagent execution
-- GovernedPARLOrchestrator: Principal Command admission control for all spawned subtasks
-
-Quick start::
-
-    from parl import GovernedPARLOrchestrator, AgentType
-
-    orch = GovernedPARLOrchestrator(max_workers=4)
-    orch.register_agent(AgentType.ZERO, my_zero_fn)
-    orch.register_agent(AgentType.SIGMA, my_sigma_fn)
-
-    task = orch.decompose_and_run(
-        description="Audit and test the codebase",
-        subtask_specs=[
-            {"agent_type": AgentType.ZERO, "description": "Fix import errors"},
-            {"agent_type": AgentType.SIGMA, "description": "Run test suite"},
-        ],
-    )
-    print(f"PARL reward: {task.reward_breakdown.total_reward:.4f}")
+Adds governed Principal Command, OmniBrain context injection, read-only GOD-0
+Mission Control snapshots, and bounded GOD-1 swarm planning on top of the
+existing PARL coordinator.
 """
 
 from parl.reward_engine import (
@@ -41,40 +16,19 @@ from parl.reward_engine import (
     compute_finish_reward,
     compute_task_quality,
 )
-from parl.experience_replay import (
-    SharedReplayBuffer,
-    AgentExperienceCollector,
-    Experience,
-    ReplayStats,
-)
-from parl.policy_sync import (
-    PolicyStore,
-    PolicyVersion,
-    GradientAccumulator,
-)
-from parl.orchestrator import (
-    PARLOrchestrator,
-    AgentType,
-    Task,
-    Subtask,
-    SubtaskStatus,
-    SubagentRunner,
-)
-from parl.god_mode import (
-    ActionRisk,
-    GodModeTier,
-    PolicyDecision,
-    PrincipalCommandPolicy,
-    PrincipalSession,
-)
+from parl.experience_replay import SharedReplayBuffer, AgentExperienceCollector, Experience, ReplayStats
+from parl.policy_sync import PolicyStore, PolicyVersion, GradientAccumulator
+from parl.orchestrator import PARLOrchestrator, AgentType, Task, Subtask, SubtaskStatus, SubagentRunner
+from parl.god_mode import ActionRisk, GodModeTier, PolicyDecision, PrincipalCommandPolicy, PrincipalSession
 from parl.governed_orchestrator import GovernedPARLOrchestrator
+from parl.principal_brief import PrincipalBrief, PrincipalBriefService
+from parl.swarms import GodOneSwarmPlanner, SwarmMode, SwarmPlan
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __author__ = "SintraPrime"
 __license__ = "Apache-2.0"
 
 __all__ = [
-    # Reward engine
     "PARLReward",
     "CriticalStepsMetric",
     "LambdaScheduler",
@@ -83,16 +37,13 @@ __all__ = [
     "compute_instantiation_reward",
     "compute_finish_reward",
     "compute_task_quality",
-    # Experience replay
     "SharedReplayBuffer",
     "AgentExperienceCollector",
     "Experience",
     "ReplayStats",
-    # Policy sync
     "PolicyStore",
     "PolicyVersion",
     "GradientAccumulator",
-    # Orchestrator
     "PARLOrchestrator",
     "GovernedPARLOrchestrator",
     "AgentType",
@@ -100,10 +51,14 @@ __all__ = [
     "Subtask",
     "SubtaskStatus",
     "SubagentRunner",
-    # Principal Command / God Mode
     "ActionRisk",
     "GodModeTier",
     "PolicyDecision",
     "PrincipalCommandPolicy",
     "PrincipalSession",
+    "PrincipalBrief",
+    "PrincipalBriefService",
+    "SwarmMode",
+    "SwarmPlan",
+    "GodOneSwarmPlanner",
 ]

--- a/parl/__init__.py
+++ b/parl/__init__.py
@@ -11,12 +11,13 @@ Key components:
 - SharedReplayBuffer  : Multi-agent shared experience replay
 - PolicyStore         : Centralised parameter server (CTDE pattern)
 - PARLOrchestrator    : Task decomposition + parallel subagent execution
+- GovernedPARLOrchestrator: Principal Command admission control for all spawned subtasks
 
 Quick start::
 
-    from parl import PARLOrchestrator, AgentType
+    from parl import GovernedPARLOrchestrator, AgentType
 
-    orch = PARLOrchestrator(max_workers=4)
+    orch = GovernedPARLOrchestrator(max_workers=4)
     orch.register_agent(AgentType.ZERO, my_zero_fn)
     orch.register_agent(AgentType.SIGMA, my_sigma_fn)
 
@@ -59,8 +60,16 @@ from parl.orchestrator import (
     SubtaskStatus,
     SubagentRunner,
 )
+from parl.god_mode import (
+    ActionRisk,
+    GodModeTier,
+    PolicyDecision,
+    PrincipalCommandPolicy,
+    PrincipalSession,
+)
+from parl.governed_orchestrator import GovernedPARLOrchestrator
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __author__ = "SintraPrime"
 __license__ = "Apache-2.0"
 
@@ -85,9 +94,16 @@ __all__ = [
     "GradientAccumulator",
     # Orchestrator
     "PARLOrchestrator",
+    "GovernedPARLOrchestrator",
     "AgentType",
     "Task",
     "Subtask",
     "SubtaskStatus",
     "SubagentRunner",
+    # Principal Command / God Mode
+    "ActionRisk",
+    "GodModeTier",
+    "PolicyDecision",
+    "PrincipalCommandPolicy",
+    "PrincipalSession",
 ]

--- a/parl/god_mode.py
+++ b/parl/god_mode.py
@@ -1,0 +1,154 @@
+"""Principal Command (God Mode) governance for the PARL orchestration layer.
+
+God Mode is a Principal capability, never an agent capability.  This module
+keeps elevated orchestration explicit, short-lived, least-privileged, and
+independent from any model/provider implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import IntEnum, StrEnum
+from typing import Any, Iterable, Mapping, Optional
+
+
+class GodModeTier(IntEnum):
+    """Principal Command capability tiers."""
+
+    GLOBAL_READ = 0
+    GLOBAL_ORCHESTRATION = 1
+    CONTROLLED_WRITE = 2
+    EXTERNAL_ACTION = 3
+    CRITICAL_ADMIN = 4
+
+
+class ActionRisk(StrEnum):
+    """Normalized action risk classes understood by the central router."""
+
+    READ = "read"
+    ORCHESTRATE = "orchestrate"
+    WRITE = "write"
+    EXTERNAL = "external"
+    CRITICAL = "critical"
+
+
+_MINIMUM_TIER = {
+    ActionRisk.READ: GodModeTier.GLOBAL_READ,
+    ActionRisk.ORCHESTRATE: GodModeTier.GLOBAL_ORCHESTRATION,
+    ActionRisk.WRITE: GodModeTier.CONTROLLED_WRITE,
+    ActionRisk.EXTERNAL: GodModeTier.EXTERNAL_ACTION,
+    ActionRisk.CRITICAL: GodModeTier.CRITICAL_ADMIN,
+}
+
+_NEVER_DELEGATE = frozenset(
+    {
+        "disable_governance",
+        "self_elevate",
+        "reveal_secrets",
+        "export_raw_credentials",
+        "bypass_approval",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PrincipalSession:
+    """Short-lived authenticated Principal Command session."""
+
+    principal_id: str
+    tier: GodModeTier
+    expires_at: datetime
+    authenticated: bool = True
+    step_up_verified: bool = False
+    capabilities: frozenset[str] = field(default_factory=frozenset)
+
+    @property
+    def expired(self) -> bool:
+        now = datetime.now(timezone.utc)
+        expiry = self.expires_at
+        if expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=timezone.utc)
+        return now >= expiry
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    allowed: bool
+    reason: str
+    approval_required: bool = False
+    minimum_tier: GodModeTier = GodModeTier.GLOBAL_READ
+
+
+class PrincipalCommandPolicy:
+    """Fail-closed evaluator for elevated PARL work.
+
+    Ordinary read/orchestration remains backward compatible.  Write,
+    external, and critical work can only be admitted when a valid Principal
+    session is supplied.  Admission never substitutes for the downstream
+    approval gateway: external and critical actions remain approval-gated.
+    """
+
+    def evaluate(
+        self,
+        *,
+        risk: ActionRisk | str,
+        session: Optional[PrincipalSession],
+        requested_capability: Optional[str] = None,
+    ) -> PolicyDecision:
+        risk = ActionRisk(risk)
+        minimum = _MINIMUM_TIER[risk]
+
+        if requested_capability in _NEVER_DELEGATE:
+            return PolicyDecision(False, "capability is non-delegable", minimum_tier=minimum)
+
+        if risk in (ActionRisk.READ, ActionRisk.ORCHESTRATE) and session is None:
+            return PolicyDecision(True, "ordinary non-privileged execution", minimum_tier=minimum)
+
+        if session is None:
+            return PolicyDecision(False, "principal session required", minimum_tier=minimum)
+        if not session.authenticated:
+            return PolicyDecision(False, "principal session is not authenticated", minimum_tier=minimum)
+        if session.expired:
+            return PolicyDecision(False, "principal session expired", minimum_tier=minimum)
+        if session.tier < minimum:
+            return PolicyDecision(False, "principal session tier is insufficient", minimum_tier=minimum)
+        if requested_capability and session.capabilities and requested_capability not in session.capabilities:
+            return PolicyDecision(False, "capability is outside the session scope", minimum_tier=minimum)
+        if risk is ActionRisk.CRITICAL and not session.step_up_verified:
+            return PolicyDecision(False, "critical action requires step-up verification", minimum_tier=minimum)
+
+        approval_required = risk in (ActionRisk.EXTERNAL, ActionRisk.CRITICAL)
+        return PolicyDecision(
+            True,
+            "principal command policy admitted task",
+            approval_required=approval_required,
+            minimum_tier=minimum,
+        )
+
+    def authorize_specs(
+        self,
+        specs: Iterable[Mapping[str, Any]],
+        *,
+        session: Optional[PrincipalSession],
+    ) -> None:
+        """Validate every subtask specification before any worker is spawned.
+
+        A spec may declare ``risk_level`` and ``capability`` at the top level
+        or inside its payload.  Missing risk defaults to ``orchestrate`` so
+        existing PARL callers continue to work unchanged.
+        """
+
+        for spec in specs:
+            payload = spec.get("payload", {}) or {}
+            risk = spec.get("risk_level", payload.get("risk_level", ActionRisk.ORCHESTRATE))
+            capability = spec.get("capability", payload.get("capability"))
+            decision = self.evaluate(risk=risk, session=session, requested_capability=capability)
+            if not decision.allowed:
+                raise PermissionError(f"Principal Command denied subtask: {decision.reason}")
+            if decision.approval_required:
+                payload_approval = payload.get("approval_granted", False)
+                if not payload_approval:
+                    raise PermissionError(
+                        "Principal Command admitted the capability, but downstream approval is required"
+                    )

--- a/parl/governed_orchestrator.py
+++ b/parl/governed_orchestrator.py
@@ -1,0 +1,39 @@
+"""Governed PARL facade for SintraPrime-wide agent orchestration."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from parl.god_mode import PrincipalCommandPolicy, PrincipalSession
+from parl.orchestrator import PARLOrchestrator, Task
+
+
+class GovernedPARLOrchestrator(PARLOrchestrator):
+    """PARL orchestrator with Principal Command admission control.
+
+    This preserves the existing PARL implementation and registration model,
+    while placing one policy boundary in front of every subtask spawned by
+    this facade.  Existing read/orchestration work stays compatible; elevated
+    work must carry a valid Principal session and, where applicable, a
+    downstream approval receipt.
+    """
+
+    def __init__(self, *args: Any, command_policy: Optional[PrincipalCommandPolicy] = None, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.command_policy = command_policy or PrincipalCommandPolicy()
+
+    def decompose_and_run(
+        self,
+        description: str,
+        subtask_specs: List[Dict[str, Any]],
+        training_step: Optional[int] = None,
+        timeout: Optional[float] = None,
+        principal_session: Optional[PrincipalSession] = None,
+    ) -> Task:
+        self.command_policy.authorize_specs(subtask_specs, session=principal_session)
+        return super().decompose_and_run(
+            description=description,
+            subtask_specs=subtask_specs,
+            training_step=training_step,
+            timeout=timeout,
+        )

--- a/parl/governed_orchestrator.py
+++ b/parl/governed_orchestrator.py
@@ -4,23 +4,61 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from memory.context_packages import ContextPackageBuilder, ContextScope
+from memory.knowledge_graph import KnowledgeGraphStore
+from memory.memory_engine import MemoryEngine
 from parl.god_mode import PrincipalCommandPolicy, PrincipalSession
 from parl.orchestrator import PARLOrchestrator, Task
 
 
 class GovernedPARLOrchestrator(PARLOrchestrator):
-    """PARL orchestrator with Principal Command admission control.
+    """PARL orchestrator with Principal Command and scoped OmniBrain context.
 
-    This preserves the existing PARL implementation and registration model,
-    while placing one policy boundary in front of every subtask spawned by
-    this facade.  Existing read/orchestration work stays compatible; elevated
-    work must carry a valid Principal session and, where applicable, a
-    downstream approval receipt.
+    Existing PARL registration/execution stays intact.  Before workers spawn,
+    each subtask receives a scope-filtered context package from the existing
+    memory subsystem.  The package is recorded into the provenance graph and
+    then evaluated by Principal Command admission control.
     """
 
-    def __init__(self, *args: Any, command_policy: Optional[PrincipalCommandPolicy] = None, **kwargs: Any):
+    def __init__(
+        self,
+        *args: Any,
+        command_policy: Optional[PrincipalCommandPolicy] = None,
+        memory_engine: Optional[MemoryEngine] = None,
+        context_builder: Optional[ContextPackageBuilder] = None,
+        graph_store: Optional[KnowledgeGraphStore] = None,
+        **kwargs: Any,
+    ):
         super().__init__(*args, **kwargs)
         self.command_policy = command_policy or PrincipalCommandPolicy()
+        self.memory_engine = memory_engine or MemoryEngine()
+        self.context_builder = context_builder or ContextPackageBuilder(self.memory_engine)
+        self.graph_store = graph_store or KnowledgeGraphStore()
+
+    def _attach_context(self, specs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        decorated: List[Dict[str, Any]] = []
+        for original in specs:
+            spec = dict(original)
+            payload = dict(spec.get("payload", {}) or {})
+            agent_type = spec.get("agent_type")
+            agent_id = getattr(agent_type, "value", None) or str(agent_type or "generic")
+            scope_data = dict(payload.get("context_scope", {}) or {})
+            scope = ContextScope(
+                agent_id=str(scope_data.get("agent_id") or agent_id),
+                user_id=scope_data.get("user_id", payload.get("user_id")),
+                project_id=scope_data.get("project_id", payload.get("project_id")),
+                matter_id=scope_data.get("matter_id", payload.get("matter_id")),
+                tenant_id=scope_data.get("tenant_id", payload.get("tenant_id")),
+                max_items=int(scope_data.get("max_items", 8)),
+                allow_legacy_user_scoped=bool(scope_data.get("allow_legacy_user_scoped", True)),
+            )
+            query = str(payload.get("context_query") or spec.get("description") or "current task")
+            package = self.context_builder.build(query=query, scope=scope)
+            self.graph_store.record_context_package(package)
+            payload["omnibrain_context"] = package.to_dict()
+            spec["payload"] = payload
+            decorated.append(spec)
+        return decorated
 
     def decompose_and_run(
         self,
@@ -30,10 +68,11 @@ class GovernedPARLOrchestrator(PARLOrchestrator):
         timeout: Optional[float] = None,
         principal_session: Optional[PrincipalSession] = None,
     ) -> Task:
-        self.command_policy.authorize_specs(subtask_specs, session=principal_session)
+        governed_specs = self._attach_context(subtask_specs)
+        self.command_policy.authorize_specs(governed_specs, session=principal_session)
         return super().decompose_and_run(
             description=description,
-            subtask_specs=subtask_specs,
+            subtask_specs=governed_specs,
             training_step=training_step,
             timeout=timeout,
         )

--- a/parl/principal_brief.py
+++ b/parl/principal_brief.py
@@ -1,0 +1,107 @@
+"""GOD-0 read-only Principal Brief and Mission Control snapshot."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from memory.knowledge_graph import KnowledgeGraphStore
+from memory.memory_engine import MemoryEngine
+from parl.god_mode import GodModeTier, PrincipalSession
+from parl.orchestrator import PARLOrchestrator
+
+
+@dataclass
+class PrincipalBrief:
+    generated_at: str
+    principal_id: str
+    system_health: Dict[str, Any]
+    agent_parliament: Dict[str, Any]
+    memory_health: Dict[str, Any]
+    graph_health: Dict[str, Any]
+    pending_approvals: list[Dict[str, Any]]
+    critical: list[Dict[str, Any]]
+    recommended_actions: list[Dict[str, Any]]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class PrincipalBriefService:
+    """Read-only aggregation service for Principal Command GOD-0."""
+
+    def __init__(
+        self,
+        orchestrator: PARLOrchestrator,
+        memory_engine: Optional[MemoryEngine] = None,
+        graph_store: Optional[KnowledgeGraphStore] = None,
+    ):
+        self.orchestrator = orchestrator
+        self.memory_engine = memory_engine or MemoryEngine()
+        self.graph_store = graph_store or KnowledgeGraphStore()
+
+    @staticmethod
+    def _require_god0(session: PrincipalSession) -> None:
+        if not session.authenticated:
+            raise PermissionError("Principal Brief requires authenticated Principal Command")
+        if session.expired:
+            raise PermissionError("Principal Command session expired")
+        if session.tier < GodModeTier.GLOBAL_READ:
+            raise PermissionError("GOD-0 or higher is required")
+
+    def build(self, session: PrincipalSession) -> PrincipalBrief:
+        self._require_god0(session)
+        history = self.orchestrator.task_history
+        failed = [task for task in history if task.failed_count > 0]
+        recent = history[-20:]
+        agent_types = sorted(getattr(a, "value", str(a)) for a in self.orchestrator._agent_registry)
+        critical = [
+            {
+                "type": "failed_task",
+                "task_id": task.task_id,
+                "description": task.description,
+                "failed_subtasks": task.failed_count,
+            }
+            for task in failed[-10:]
+        ]
+        recommendations = []
+        if failed:
+            recommendations.append(
+                {
+                    "action": "review_failed_agent_tasks",
+                    "reason": f"{len(failed)} task(s) in retained PARL history contain failures",
+                    "risk_level": "read",
+                }
+            )
+        return PrincipalBrief(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            principal_id=session.principal_id,
+            system_health={
+                "status": "attention" if critical else "nominal",
+                "read_only": True,
+                "god_mode_tier": int(session.tier),
+            },
+            agent_parliament={
+                "registered_agent_types": agent_types,
+                "task_history_count": len(history),
+                "recent_task_count": len(recent),
+                "failed_task_count": len(failed),
+                "training_step": self.orchestrator.training_step,
+                "buffer": self.orchestrator.buffer_stats(),
+            },
+            memory_health=self.memory_engine.memory_stats(),
+            graph_health=self.graph_store.stats(),
+            pending_approvals=[],
+            critical=critical,
+            recommended_actions=recommendations,
+        )
+
+    def mission_control_snapshot(self, session: PrincipalSession) -> Dict[str, Any]:
+        """Backend contract for a future Mission Control UI; performs no writes."""
+        brief = self.build(session)
+        return {
+            "mode": "GOD-0",
+            "read_only": True,
+            "brief": brief.to_dict(),
+        }

--- a/parl/swarms.py
+++ b/parl/swarms.py
@@ -1,0 +1,93 @@
+"""GOD-1 Council, Research, and Build swarm templates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Dict, List, Optional
+
+from parl.god_mode import GodModeTier, PrincipalSession
+from parl.orchestrator import AgentType, Task
+
+
+class SwarmMode(StrEnum):
+    COUNCIL = "council"
+    RESEARCH = "research"
+    BUILD = "build"
+
+
+@dataclass(frozen=True)
+class SwarmPlan:
+    mode: SwarmMode
+    objective: str
+    subtask_specs: List[Dict[str, Any]]
+
+
+class GodOneSwarmPlanner:
+    """Construct bounded multi-agent missions; never grants write authority."""
+
+    @staticmethod
+    def _require_god1(session: PrincipalSession) -> None:
+        if not session.authenticated or session.expired:
+            raise PermissionError("GOD-1 swarm requires an active authenticated Principal session")
+        if session.tier < GodModeTier.GLOBAL_ORCHESTRATION:
+            raise PermissionError("GOD-1 or higher is required for swarm orchestration")
+
+    def plan(
+        self,
+        mode: SwarmMode | str,
+        objective: str,
+        session: PrincipalSession,
+        *,
+        context_scope: Optional[Dict[str, Any]] = None,
+    ) -> SwarmPlan:
+        self._require_god1(session)
+        mode = SwarmMode(mode)
+        scope = dict(context_scope or {})
+        common = {"context_scope": scope, "context_query": objective, "swarm_mode": mode.value}
+
+        if mode is SwarmMode.COUNCIL:
+            roles = [
+                (AgentType.CHAT, "Planner", "Develop the strongest plan and explicit assumptions."),
+                (AgentType.SIGMA, "Verifier", "Challenge claims and identify what evidence would prove them."),
+                (AgentType.ZERO, "Skeptic", "Find failure modes, regressions, and operational weaknesses."),
+                (AgentType.NOVA, "Operator", "Assess execution feasibility and authority boundaries."),
+            ]
+        elif mode is SwarmMode.RESEARCH:
+            roles = [
+                (AgentType.CHAT, "Synthesizer", "Frame the research questions and synthesize findings."),
+                (AgentType.SIGMA, "Source Auditor", "Evaluate evidence quality, contradictions, and missing proof."),
+                (AgentType.ZERO, "Contrarian", "Search for counterexamples and alternative explanations."),
+            ]
+        else:
+            roles = [
+                (AgentType.CHAT, "Architect", "Define implementation structure and acceptance criteria."),
+                (AgentType.ZERO, "Implementer", "Produce the smallest reversible implementation increment."),
+                (AgentType.SIGMA, "Tester", "Verify behavior, regressions, and quality gates."),
+            ]
+
+        specs: List[Dict[str, Any]] = []
+        for agent_type, role, instruction in roles:
+            specs.append(
+                {
+                    "agent_type": agent_type,
+                    "description": f"{role}: {objective}",
+                    "risk_level": "orchestrate",
+                    "capability": f"swarm:{mode.value}",
+                    "payload": {
+                        **common,
+                        "role": role,
+                        "instruction": instruction,
+                        "external_writes_allowed": False,
+                    },
+                }
+            )
+        return SwarmPlan(mode=mode, objective=objective, subtask_specs=specs)
+
+    def run(self, orchestrator: Any, plan: SwarmPlan, session: PrincipalSession) -> Task:
+        self._require_god1(session)
+        return orchestrator.decompose_and_run(
+            description=f"{plan.mode.value.title()} swarm: {plan.objective}",
+            subtask_specs=plan.subtask_specs,
+            principal_session=session,
+        )

--- a/parl/tests/test_god_mode.py
+++ b/parl/tests/test_god_mode.py
@@ -1,0 +1,90 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from parl.god_mode import ActionRisk, GodModeTier, PrincipalCommandPolicy, PrincipalSession
+
+
+def session(tier: GodModeTier, *, step_up: bool = False, capabilities=frozenset()):
+    return PrincipalSession(
+        principal_id="principal-test",
+        tier=tier,
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=30),
+        step_up_verified=step_up,
+        capabilities=frozenset(capabilities),
+    )
+
+
+def test_ordinary_orchestration_remains_backward_compatible():
+    decision = PrincipalCommandPolicy().evaluate(risk=ActionRisk.ORCHESTRATE, session=None)
+    assert decision.allowed is True
+
+
+def test_write_requires_principal_session():
+    decision = PrincipalCommandPolicy().evaluate(risk=ActionRisk.WRITE, session=None)
+    assert decision.allowed is False
+    assert decision.minimum_tier is GodModeTier.CONTROLLED_WRITE
+
+
+def test_external_action_requires_downstream_approval():
+    policy = PrincipalCommandPolicy()
+    principal = session(GodModeTier.EXTERNAL_ACTION)
+    decision = policy.evaluate(risk=ActionRisk.EXTERNAL, session=principal)
+    assert decision.allowed is True
+    assert decision.approval_required is True
+
+
+def test_critical_admin_requires_step_up():
+    policy = PrincipalCommandPolicy()
+    principal = session(GodModeTier.CRITICAL_ADMIN, step_up=False)
+    assert policy.evaluate(risk=ActionRisk.CRITICAL, session=principal).allowed is False
+
+    elevated = session(GodModeTier.CRITICAL_ADMIN, step_up=True)
+    decision = policy.evaluate(risk=ActionRisk.CRITICAL, session=elevated)
+    assert decision.allowed is True
+    assert decision.approval_required is True
+
+
+def test_non_delegable_capabilities_stay_blocked_even_in_critical_admin():
+    principal = session(GodModeTier.CRITICAL_ADMIN, step_up=True)
+    decision = PrincipalCommandPolicy().evaluate(
+        risk=ActionRisk.CRITICAL,
+        session=principal,
+        requested_capability="bypass_approval",
+    )
+    assert decision.allowed is False
+
+
+def test_expired_session_is_rejected():
+    expired = PrincipalSession(
+        principal_id="principal-test",
+        tier=GodModeTier.CRITICAL_ADMIN,
+        expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+        step_up_verified=True,
+    )
+    decision = PrincipalCommandPolicy().evaluate(risk=ActionRisk.WRITE, session=expired)
+    assert decision.allowed is False
+
+
+def test_authorize_specs_denies_external_action_without_approval():
+    policy = PrincipalCommandPolicy()
+    principal = session(GodModeTier.EXTERNAL_ACTION)
+    with pytest.raises(PermissionError, match="downstream approval"):
+        policy.authorize_specs(
+            [{"risk_level": "external", "payload": {"capability": "send_message"}}],
+            session=principal,
+        )
+
+
+def test_authorize_specs_accepts_scoped_external_action_with_approval():
+    policy = PrincipalCommandPolicy()
+    principal = session(GodModeTier.EXTERNAL_ACTION, capabilities={"send_message"})
+    policy.authorize_specs(
+        [
+            {
+                "risk_level": "external",
+                "payload": {"capability": "send_message", "approval_granted": True},
+            }
+        ],
+        session=principal,
+    )

--- a/parl/tests/test_governed_orchestrator.py
+++ b/parl/tests/test_governed_orchestrator.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from parl import AgentType, GodModeTier, GovernedPARLOrchestrator, PrincipalSession
+
+
+def _agent(subtask):
+    return {"ok": True, "description": subtask.description}, 1.0
+
+
+def _principal(tier: GodModeTier, *, step_up: bool = False):
+    return PrincipalSession(
+        principal_id="principal-test",
+        tier=tier,
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=30),
+        step_up_verified=step_up,
+    )
+
+
+def test_read_only_swarm_runs_without_god_mode():
+    orch = GovernedPARLOrchestrator(max_workers=1)
+    orch.register_agent(AgentType.ZERO, _agent)
+    task = orch.decompose_and_run(
+        "inspect",
+        [{"agent_type": AgentType.ZERO, "description": "inspect repository", "risk_level": "read"}],
+    )
+    assert task.failed_count == 0
+    assert task.completed_count == 1
+
+
+def test_controlled_write_is_denied_without_principal_session():
+    orch = GovernedPARLOrchestrator(max_workers=1)
+    orch.register_agent(AgentType.ZERO, _agent)
+    with pytest.raises(PermissionError, match="principal session required"):
+        orch.decompose_and_run(
+            "edit",
+            [{"agent_type": AgentType.ZERO, "description": "edit branch", "risk_level": "write"}],
+        )
+
+
+def test_controlled_write_runs_with_god_2_session():
+    orch = GovernedPARLOrchestrator(max_workers=1)
+    orch.register_agent(AgentType.ZERO, _agent)
+    task = orch.decompose_and_run(
+        "edit",
+        [{"agent_type": AgentType.ZERO, "description": "edit branch", "risk_level": "write"}],
+        principal_session=_principal(GodModeTier.CONTROLLED_WRITE),
+    )
+    assert task.completed_count == 1
+
+
+def test_external_action_still_requires_explicit_downstream_approval():
+    orch = GovernedPARLOrchestrator(max_workers=1)
+    orch.register_agent(AgentType.NOVA, _agent)
+    with pytest.raises(PermissionError, match="downstream approval"):
+        orch.decompose_and_run(
+            "send",
+            [
+                {
+                    "agent_type": AgentType.NOVA,
+                    "description": "send external message",
+                    "risk_level": "external",
+                    "payload": {"capability": "send_message"},
+                }
+            ],
+            principal_session=_principal(GodModeTier.EXTERNAL_ACTION),
+        )

--- a/parl/tests/test_principal_brief_and_swarms.py
+++ b/parl/tests/test_principal_brief_and_swarms.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from parl.god_mode import GodModeTier, PrincipalSession
+from parl.orchestrator import PARLOrchestrator
+from parl.principal_brief import PrincipalBriefService
+from parl.swarms import GodOneSwarmPlanner, SwarmMode
+
+
+class FakeMemory:
+    def memory_stats(self):
+        return {"semantic": {"total_entries": 3}, "timestamp": "now"}
+
+
+class FakeGraph:
+    def stats(self):
+        return {"nodes": 4, "edges": 5}
+
+
+def session(tier):
+    return PrincipalSession(
+        principal_id="principal",
+        tier=tier,
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=30),
+    )
+
+
+def test_principal_brief_requires_authenticated_session_and_is_read_only():
+    service = PrincipalBriefService(PARLOrchestrator(), FakeMemory(), FakeGraph())
+    snapshot = service.mission_control_snapshot(session(GodModeTier.GLOBAL_READ))
+    assert snapshot["mode"] == "GOD-0"
+    assert snapshot["read_only"] is True
+    assert snapshot["brief"]["graph_health"]["edges"] == 5
+
+
+def test_god_one_swarm_rejects_god_zero():
+    planner = GodOneSwarmPlanner()
+    with pytest.raises(PermissionError):
+        planner.plan(SwarmMode.COUNCIL, "review architecture", session(GodModeTier.GLOBAL_READ))
+
+
+def test_god_one_swarm_templates_are_non_external():
+    planner = GodOneSwarmPlanner()
+    for mode in SwarmMode:
+        plan = planner.plan(
+            mode,
+            "review architecture",
+            session(GodModeTier.GLOBAL_ORCHESTRATION),
+            context_scope={"project_id": "sintraprime"},
+        )
+        assert plan.subtask_specs
+        assert all(spec["risk_level"] == "orchestrate" for spec in plan.subtask_specs)
+        assert all(spec["payload"]["external_writes_allowed"] is False for spec in plan.subtask_specs)
+        assert all(spec["payload"]["context_scope"]["project_id"] == "sintraprime" for spec in plan.subtask_specs)


### PR DESCRIPTION
## What changed

### Principal Command / God Mode foundation
- adds `PrincipalCommandPolicy` and explicit GOD-0 through GOD-4 tiers
- adds short-lived authenticated `PrincipalSession` support with expiry, scoped capabilities, and step-up verification for critical administration
- permanently blocks non-delegable capabilities including approval bypass, self-elevation, governance disablement, raw-secret export, and secret revelation
- adds `GovernedPARLOrchestrator` as the preferred facade for central multi-agent execution

### OmniBrain Phase 2
- attaches the existing `memory/` subsystem to every governed PARL subtask through `ContextPackageBuilder`
- adds explicit agent/user/project/matter/tenant context scopes before memory content is exposed to workers
- blocks anonymous legacy-unscoped memory from becoming global context; legacy unscoped memory is only admitted when bound to the matching user
- preserves memory provenance (`memory_id`, source, source ID/URI, created-at metadata) in every context package
- records recall/provenance relationships in a durable SQLite `KnowledgeGraphStore`
- adds one-way `ObsidianProjector` output with linked Markdown notes, hashes, projection markers, and basic secret redaction
- explicitly forbids automatic Obsidian-to-canonical-memory reverse synchronization

### GOD-0 Principal Brief + Mission Control contract
- adds `PrincipalBriefService`
- aggregates PARL task state, memory health, knowledge-graph health, failures, and recommended read-only follow-up
- exposes a read-only Mission Control snapshot contract; no UI write authority is introduced

### GOD-1 swarm foundation
- adds bounded Council, Research, and Build swarm templates
- GOD-1 requires an active authenticated Principal session at `GLOBAL_ORCHESTRATION` or higher
- swarm subtasks remain `orchestrate` risk only and explicitly carry `external_writes_allowed = false`
- each swarm worker receives the same governed scoped-context path

### DOX / tests
- adds `memory/AGENTS.md` and expands `parl/AGENTS.md`
- adds scope-isolation, provenance-graph, Obsidian-redaction, Principal Brief, and GOD-1 swarm tests

## Why

SintraPrime already contains mature `memory/`, `orchestration/`, agent, and PARL primitives. This PR extends those existing systems rather than introducing a competing OmniBrain runtime. PARL remains the central coordinator; `memory/` remains the canonical memory subsystem; Principal Command remains the authority boundary.

## Security posture

God Mode belongs to the authenticated Principal, not to models or subagents. Memory provides context, not authority. This PR grants no new production credentials, connector permissions, deployment authority, external-send authority, or autonomous GOD-2+ actions.

The Obsidian vault is deliberately a projection, not a source of truth. No OAuth credentials, raw secret stores, personal-drive access, or automatic reverse ingestion are introduced.

## Validation

Targeted coverage now includes:

- `parl/tests/test_god_mode.py`
- `parl/tests/test_governed_orchestrator.py`
- `parl/tests/test_principal_brief_and_swarms.py`
- `memory/tests/test_context_packages.py`
- `memory/tests/test_omnibrain_projection.py`
- existing `parl/tests/test_parl.py`

Recommended local command:

```bash
pytest parl/tests/test_god_mode.py parl/tests/test_governed_orchestrator.py parl/tests/test_principal_brief_and_swarms.py parl/tests/test_parl.py memory/tests/test_context_packages.py memory/tests/test_omnibrain_projection.py
```

CI for the current head is running. The branch is also behind current `main`, so this PR remains draft until CI is terminal and the mainline delta is reconciled/revalidated.

No merge or deployment is authorized.