### PR TITLE
R1: Fix ORM/Schema UUID Drift — MC Command Proven on PostgreSQL

### DIFF
--- a/portal/migrations/portal_schema.sql
+++ b/portal/migrations/portal_schema.sql
@@ -834,8 +834,9 @@ CREATE TABLE IF NOT EXISTS audit_logs (
     user_id             UUID REFERENCES users(id),
     actor_email         VARCHAR(320),
     actor_role          VARCHAR(50),
-    actor_ip            INET,
+    actor_ip            VARCHAR(45),
     actor_user_agent    TEXT,
+    session_id          VARCHAR(255),
     
     action              VARCHAR(100) NOT NULL,
     resource_type       VARCHAR(50),
@@ -843,6 +844,8 @@ CREATE TABLE IF NOT EXISTS audit_logs (
     resource_name       VARCHAR(500),
     status              VARCHAR(20) NOT NULL DEFAULT 'success',
     details             JSONB,
+    changes             JSONB,
+    request_id          VARCHAR(36),
     error_message       TEXT,
     
     http_method         VARCHAR(10),
@@ -852,6 +855,7 @@ CREATE TABLE IF NOT EXISTS audit_logs (
     -- Chain integrity
     previous_hash       VARCHAR(64),
     entry_hash          VARCHAR(64) NOT NULL,
+    hash_chain          VARCHAR(64),
     
     -- Retention: 7 years minimum
     created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/portal/models/audit.py
+++ b/portal/models/audit.py
@@ -13,6 +13,7 @@ from sqlalchemy import JSON, DateTime, ForeignKey, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class AuditLog(Base):
@@ -24,11 +25,11 @@ class AuditLog(Base):
 
     __tablename__ = "audit_logs"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("tenants.id"), nullable=True
+        PortableUUIDString, ForeignKey("tenants.id"), nullable=True
     )
-    user_id: Mapped[str | None] = mapped_column(String(36), ForeignKey("users.id"), nullable=True)
+    user_id: Mapped[str | None] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=True)
 
     # Who
     actor_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -62,7 +63,7 @@ class AuditLog(Base):
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Request context
-    request_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    request_id: Mapped[str | None] = mapped_column(PortableUUIDString, nullable=True)
     http_method: Mapped[str | None] = mapped_column(String(10), nullable=True)
     http_path: Mapped[str | None] = mapped_column(Text, nullable=True)
     http_status_code: Mapped[int | None] = mapped_column(nullable=True)

--- a/portal/models/audit_record.py
+++ b/portal/models/audit_record.py
@@ -19,7 +19,7 @@ from sqlalchemy import DateTime, ForeignKey, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ..database import Base
-from .types import PortableUUID
+from .types import PortableUUIDString, PortableUUID
 
 
 class AuditRecord(Base):
@@ -95,7 +95,7 @@ class AuditRecord(Base):
         doc="Server-set creation timestamp. Never modified.",
     )
     created_by: Mapped[str] = mapped_column(
-        String(36),
+        PortableUUIDString,
         ForeignKey("users.id"),
         nullable=False,
         doc="User/system that created this audit record.",

--- a/portal/models/billing.py
+++ b/portal/models/billing.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class TimeEntry(Base):
@@ -30,24 +31,23 @@ class TimeEntry(Base):
 
     __tablename__ = "time_entries"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
-    user_id: Mapped[uuid.UUID] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     client_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("clients.id"), nullable=True
+        PortableUUIDString, ForeignKey("clients.id"), nullable=True
     )
     case_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("cases.id"), nullable=True
+        PortableUUIDString, ForeignKey("cases.id"), nullable=True
     )
     matter_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("matters.id"), nullable=True
+        PortableUUIDString, ForeignKey("matters.id"), nullable=True
     )
     invoice_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("invoices.id"), nullable=True
+        PortableUUIDString, ForeignKey("invoices.id"), nullable=True
     )
 
     description: Mapped[str] = mapped_column(Text, nullable=False)
@@ -75,7 +75,7 @@ class TimeEntry(Base):
     is_billed: Mapped[bool] = mapped_column(Boolean, default=False)
     is_approved: Mapped[bool] = mapped_column(Boolean, default=False)
     approved_by: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
 
     # Timestamps
@@ -95,21 +95,20 @@ class Expense(Base):
 
     __tablename__ = "expenses"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
-    user_id: Mapped[uuid.UUID] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     client_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("clients.id"), nullable=True
+        PortableUUIDString, ForeignKey("clients.id"), nullable=True
     )
     case_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("cases.id"), nullable=True
+        PortableUUIDString, ForeignKey("cases.id"), nullable=True
     )
     invoice_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("invoices.id"), nullable=True
+        PortableUUIDString, ForeignKey("invoices.id"), nullable=True
     )
 
     description: Mapped[str] = mapped_column(Text, nullable=False)
@@ -121,7 +120,7 @@ class Expense(Base):
     is_billable: Mapped[bool] = mapped_column(Boolean, default=True)
     is_billed: Mapped[bool] = mapped_column(Boolean, default=False)
     receipt_document_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("documents.id"), nullable=True
+        PortableUUIDString, ForeignKey("documents.id"), nullable=True
     )
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
@@ -136,23 +135,22 @@ class Expense(Base):
 class Invoice(Base):
     __tablename__ = "invoices"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
     client_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("clients.id"), nullable=False
+        PortableUUIDString, ForeignKey("clients.id"), nullable=False
     )
     matter_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("matters.id"), nullable=True
+        PortableUUIDString, ForeignKey("matters.id"), nullable=True
     )
     case_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("cases.id"), nullable=True
+        PortableUUIDString, ForeignKey("cases.id"), nullable=True
     )
     created_by: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        PortableUUIDString, ForeignKey("users.id"), nullable=False
     )
 
     invoice_number: Mapped[str] = mapped_column(String(50), nullable=False)
@@ -180,7 +178,7 @@ class Invoice(Base):
 
     # PDF
     pdf_document_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("documents.id"), nullable=True
+        PortableUUIDString, ForeignKey("documents.id"), nullable=True
     )
 
     # Payment link
@@ -214,17 +212,16 @@ class Invoice(Base):
 class InvoiceLineItem(Base):
     __tablename__ = "invoice_line_items"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     invoice_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("invoices.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("invoices.id", ondelete="CASCADE"), nullable=False
     )
     time_entry_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("time_entries.id"), nullable=True
+        PortableUUIDString, ForeignKey("time_entries.id"), nullable=True
     )
     expense_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("expenses.id"), nullable=True
+        PortableUUIDString, ForeignKey("expenses.id"), nullable=True
     )
 
     description: Mapped[str] = mapped_column(Text, nullable=False)
@@ -242,17 +239,16 @@ class InvoiceLineItem(Base):
 class Payment(Base):
     __tablename__ = "payments"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
     invoice_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("invoices.id"), nullable=True
+        PortableUUIDString, ForeignKey("invoices.id"), nullable=True
     )
     client_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("clients.id"), nullable=False
+        PortableUUIDString, ForeignKey("clients.id"), nullable=False
     )
 
     amount: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
@@ -276,7 +272,7 @@ class Payment(Base):
     refund_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     received_by: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
@@ -290,17 +286,16 @@ class TrustAccount(Base):
 
     __tablename__ = "trust_accounts"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
     client_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("clients.id"), nullable=False
+        PortableUUIDString, ForeignKey("clients.id"), nullable=False
     )
     matter_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("matters.id"), nullable=True
+        PortableUUIDString, ForeignKey("matters.id"), nullable=True
     )
 
     transaction_type: Mapped[str] = mapped_column(String(20), nullable=False)
@@ -313,10 +308,10 @@ class TrustAccount(Base):
 
     transaction_date: Mapped[date] = mapped_column(Date, nullable=False)
     approved_by: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     created_by: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        PortableUUIDString, ForeignKey("users.id"), nullable=False
     )
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/portal/models/blackstone.py
+++ b/portal/models/blackstone.py
@@ -16,7 +16,7 @@ from sqlalchemy import JSON, DateTime, Index, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from portal.database import Base
-from portal.models.types import PortableUUID
+from portal.models.types import PortableUUIDString, PortableUUID
 
 
 class EvidenceLedger(Base):

--- a/portal/models/case.py
+++ b/portal/models/case.py
@@ -12,6 +12,7 @@ from sqlalchemy import JSON, Boolean, Date, DateTime, ForeignKey, String, Text, 
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class CaseStage(_enum.StrEnum):
@@ -30,17 +31,16 @@ class CaseStage(_enum.StrEnum):
 class Case(Base):
     __tablename__ = "cases"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     client_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("clients.id"), nullable=False
+        PortableUUIDString, ForeignKey("clients.id"), nullable=False
     )
     matter_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("matters.id"), nullable=True
+        PortableUUIDString, ForeignKey("matters.id"), nullable=True
     )
 
     case_number: Mapped[str] = mapped_column(String(50), nullable=False)
@@ -62,7 +62,7 @@ class Case(Base):
 
     # Staff assignments
     lead_attorney_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     assigned_staff: Mapped[list | None] = mapped_column(
         JSON, nullable=True, default=list
@@ -125,17 +125,16 @@ class CaseEvent(Base):
 
     __tablename__ = "case_events"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     case_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("cases.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("cases.id", ondelete="CASCADE"), nullable=False
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
     created_by: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        PortableUUIDString, ForeignKey("users.id"), nullable=False
     )
 
     event_type: Mapped[str] = mapped_column(String(50), nullable=False)
@@ -163,20 +162,19 @@ class CaseDeadline(Base):
 
     __tablename__ = "case_deadlines"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     case_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("cases.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("cases.id", ondelete="CASCADE"), nullable=False
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
     assigned_to: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     created_by: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        PortableUUIDString, ForeignKey("users.id"), nullable=False
     )
 
     title: Mapped[str] = mapped_column(String(500), nullable=False)
@@ -208,17 +206,16 @@ class CaseNote(Base):
 
     __tablename__ = "case_notes"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     case_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("cases.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("cases.id", ondelete="CASCADE"), nullable=False
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
     created_by: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        PortableUUIDString, ForeignKey("users.id"), nullable=False
     )
 
     title: Mapped[str | None] = mapped_column(String(500), nullable=True)
@@ -243,20 +240,19 @@ class CaseTask(Base):
 
     __tablename__ = "case_tasks"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     case_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("cases.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("cases.id", ondelete="CASCADE"), nullable=False
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
     assigned_to: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     created_by: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        PortableUUIDString, ForeignKey("users.id"), nullable=False
     )
 
     title: Mapped[str] = mapped_column(String(500), nullable=False)

--- a/portal/models/client.py
+++ b/portal/models/client.py
@@ -12,16 +12,16 @@ from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Numeric, String, Tex
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class Client(Base):
     __tablename__ = "clients"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
 
     # Type: individual or organization
@@ -58,13 +58,13 @@ class Client(Base):
 
     # Portal access
     portal_user_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     portal_access: Mapped[bool] = mapped_column(Boolean, default=False)
 
     # Assigned attorney
     primary_attorney_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
 
     # Client status
@@ -108,14 +108,13 @@ class Matter(Base):
 
     __tablename__ = "matters"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     client_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("clients.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("clients.id", ondelete="CASCADE"), nullable=False
     )
 
     matter_number: Mapped[str] = mapped_column(String(50), nullable=False)  # e.g., "2024-001"
@@ -135,10 +134,10 @@ class Matter(Base):
 
     # Staff
     responsible_attorney_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     billing_attorney_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
 
     opened_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/portal/models/deadline_evidence.py
+++ b/portal/models/deadline_evidence.py
@@ -9,17 +9,18 @@ from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text, Unique
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class MatterDeadline(Base):
     __tablename__ = "matter_deadlines"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     deadline_type: Mapped[str] = mapped_column(String(40), nullable=False)
@@ -38,7 +39,7 @@ class MatterDeadline(Base):
     limitations: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
     review_status: Mapped[str] = mapped_column(String(40), nullable=False, default="NOT_SUBMITTED")
     current_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -54,15 +55,15 @@ class MatterDeadlineVersion(Base):
         UniqueConstraint("deadline_id", "version_number", name="uq_matter_deadline_version"),
     )
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     deadline_id: Mapped[str] = mapped_column(
-        String(36),
+        PortableUUIDString,
         ForeignKey("matter_deadlines.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -74,7 +75,7 @@ class MatterDeadlineVersion(Base):
     calculation_inputs_redacted: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
     assumptions: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
     limitations: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -83,19 +84,19 @@ class MatterDeadlineVersion(Base):
 class MatterEvidenceNode(Base):
     __tablename__ = "matter_evidence_nodes"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     node_type: Mapped[str] = mapped_column(String(32), nullable=False)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     statement_redacted: Mapped[str | None] = mapped_column(Text, nullable=True)
     evidence_status: Mapped[str] = mapped_column(String(32), nullable=False)
     source_document_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("documents.id"), nullable=True
+        PortableUUIDString, ForeignKey("documents.id"), nullable=True
     )
     source_authority_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     source_rule_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
@@ -103,7 +104,7 @@ class MatterEvidenceNode(Base):
         "provenance", JSON, nullable=True, default=dict
     )
     review_status: Mapped[str] = mapped_column(String(40), nullable=False, default="NOT_SUBMITTED")
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -116,23 +117,23 @@ class MatterEvidenceNode(Base):
 class MatterEvidenceLink(Base):
     __tablename__ = "matter_evidence_links"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     source_node_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matter_evidence_nodes.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("matter_evidence_nodes.id", ondelete="CASCADE"), nullable=False
     )
     target_node_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matter_evidence_nodes.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("matter_evidence_nodes.id", ondelete="CASCADE"), nullable=False
     )
     relationship_type: Mapped[str] = mapped_column(String(32), nullable=False)
     confidence: Mapped[float] = mapped_column(nullable=False, default=0.0)
     notes_redacted: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -141,23 +142,23 @@ class MatterEvidenceLink(Base):
 class MatterEvidenceFinding(Base):
     __tablename__ = "matter_evidence_findings"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     finding_type: Mapped[str] = mapped_column(String(32), nullable=False)
     node_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("matter_evidence_nodes.id", ondelete="CASCADE"), nullable=True
+        PortableUUIDString, ForeignKey("matter_evidence_nodes.id", ondelete="CASCADE"), nullable=True
     )
     related_node_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("matter_evidence_nodes.id", ondelete="CASCADE"), nullable=True
+        PortableUUIDString, ForeignKey("matter_evidence_nodes.id", ondelete="CASCADE"), nullable=True
     )
     summary_redacted: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(24), nullable=False, default="OPEN")
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/portal/models/document.py
+++ b/portal/models/document.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class DocumentFolder(Base):
@@ -29,14 +30,13 @@ class DocumentFolder(Base):
 
     __tablename__ = "document_folders"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
     parent_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("document_folders.id", ondelete="SET NULL"), nullable=True
+        PortableUUIDString, ForeignKey("document_folders.id", ondelete="SET NULL"), nullable=True
     )
 
     name: Mapped[str] = mapped_column(String(255), nullable=False)
@@ -46,14 +46,14 @@ class DocumentFolder(Base):
 
     # Context: can belong to a client, case, or be global
     client_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("clients.id"), nullable=True
+        PortableUUIDString, ForeignKey("clients.id"), nullable=True
     )
     case_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("cases.id"), nullable=True
+        PortableUUIDString, ForeignKey("cases.id"), nullable=True
     )
 
     created_by: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        PortableUUIDString, ForeignKey("users.id"), nullable=False
     )
     color: Mapped[str | None] = mapped_column(String(7), nullable=True)  # hex color
     icon: Mapped[str | None] = mapped_column(String(50), nullable=True)
@@ -75,28 +75,27 @@ class DocumentFolder(Base):
 class Document(Base):
     __tablename__ = "documents"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
 
     # Ownership context
     client_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("clients.id"), nullable=True
+        PortableUUIDString, ForeignKey("clients.id"), nullable=True
     )
     case_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("cases.id"), nullable=True
+        PortableUUIDString, ForeignKey("cases.id"), nullable=True
     )
     matter_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("matters.id"), nullable=True
+        PortableUUIDString, ForeignKey("matters.id"), nullable=True
     )
     folder_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("document_folders.id"), nullable=True
+        PortableUUIDString, ForeignKey("document_folders.id"), nullable=True
     )
     uploaded_by: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        PortableUUIDString, ForeignKey("users.id"), nullable=False
     )
 
     # File metadata
@@ -137,7 +136,7 @@ class Document(Base):
     # Digital signature
     signed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     signed_by: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     signature_data: Mapped[dict | None] = mapped_column(JSON, nullable=True)
 
@@ -184,11 +183,10 @@ class DocumentVersion(Base):
 
     __tablename__ = "document_versions"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     document_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("documents.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("documents.id", ondelete="CASCADE"), nullable=False
     )
     version_number: Mapped[int] = mapped_column(Integer, nullable=False)
 
@@ -200,7 +198,7 @@ class DocumentVersion(Base):
 
     change_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     uploaded_by: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        PortableUUIDString, ForeignKey("users.id"), nullable=False
     )
 
     is_encrypted: Mapped[bool] = mapped_column(Boolean, default=True)
@@ -219,24 +217,23 @@ class DocumentShare(Base):
 
     __tablename__ = "document_shares"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     document_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("documents.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("documents.id", ondelete="CASCADE"), nullable=False
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
 
     share_token: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
     created_by: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        PortableUUIDString, ForeignKey("users.id"), nullable=False
     )
 
     # Share target (optional — if None, it's a public link)
     shared_with_user_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     shared_with_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
 

--- a/portal/models/evidence_snapshot.py
+++ b/portal/models/evidence_snapshot.py
@@ -20,7 +20,7 @@ from sqlalchemy import DateTime, ForeignKey, Integer, String, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ..database import Base
-from .types import PortableUUID
+from .types import PortableUUIDString, PortableUUID
 
 
 class SnapshotStatus(_enum.StrEnum):
@@ -63,7 +63,7 @@ class EvidenceSnapshot(Base):
         default=uuid.uuid4,
     )
     case_id: Mapped[str] = mapped_column(
-        String(36),
+        PortableUUIDString,
         ForeignKey("cases.id"),
         nullable=False,
         index=True,
@@ -97,7 +97,7 @@ class EvidenceSnapshot(Base):
         doc="Server-set creation timestamp. Never modified.",
     )
     created_by: Mapped[str] = mapped_column(
-        String(36),
+        PortableUUIDString,
         ForeignKey("users.id"),
         nullable=False,
         doc="User who created this snapshot.",

--- a/portal/models/legal_authority.py
+++ b/portal/models/legal_authority.py
@@ -10,7 +10,7 @@ from sqlalchemy import JSON, DateTime, Float, Index, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from portal.database import Base
-from portal.models.types import PortableUUID
+from portal.models.types import PortableUUIDString, PortableUUID
 
 
 class LegalAuthorityRecord(Base):

--- a/portal/models/matter_intelligence.py
+++ b/portal/models/matter_intelligence.py
@@ -9,17 +9,18 @@ from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class MatterParty(Base):
     __tablename__ = "matter_parties"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     role: Mapped[str] = mapped_column(String(40), nullable=False)
     display_name: Mapped[str] = mapped_column(String(255), nullable=False)
@@ -28,7 +29,7 @@ class MatterParty(Base):
     metadata_json: Mapped[dict | None] = mapped_column(
         "metadata", JSON, nullable=True, default=dict
     )
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -41,35 +42,35 @@ class MatterParty(Base):
 class MatterAccount(Base):
     __tablename__ = "matter_accounts"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     account_type: Mapped[str] = mapped_column(String(50), nullable=False)
     account_reference_redacted: Mapped[str | None] = mapped_column(String(128), nullable=True)
     creditor_party_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("matter_parties.id"), nullable=True
+        PortableUUIDString, ForeignKey("matter_parties.id"), nullable=True
     )
     collector_party_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("matter_parties.id"), nullable=True
+        PortableUUIDString, ForeignKey("matter_parties.id"), nullable=True
     )
     furnisher_party_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("matter_parties.id"), nullable=True
+        PortableUUIDString, ForeignKey("matter_parties.id"), nullable=True
     )
     servicer_party_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("matter_parties.id"), nullable=True
+        PortableUUIDString, ForeignKey("matter_parties.id"), nullable=True
     )
     assignee_party_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("matter_parties.id"), nullable=True
+        PortableUUIDString, ForeignKey("matter_parties.id"), nullable=True
     )
     status: Mapped[str] = mapped_column(String(30), nullable=False, default="open")
     details_redacted: Mapped[dict | None] = mapped_column(
         "details", JSON, nullable=True, default=dict
     )
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -82,12 +83,12 @@ class MatterAccount(Base):
 class MatterFiling(Base):
     __tablename__ = "matter_filings"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     filing_kind: Mapped[str] = mapped_column(String(50), nullable=False)
     filing_number_redacted: Mapped[str | None] = mapped_column(String(128), nullable=True)
@@ -96,13 +97,13 @@ class MatterFiling(Base):
     filed_on: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     debtor_name_redacted: Mapped[str | None] = mapped_column(String(255), nullable=True)
     secured_party_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("matter_parties.id"), nullable=True
+        PortableUUIDString, ForeignKey("matter_parties.id"), nullable=True
     )
     status: Mapped[str] = mapped_column(String(30), nullable=False, default="reported")
     details_redacted: Mapped[dict | None] = mapped_column(
         "details", JSON, nullable=True, default=dict
     )
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -115,28 +116,28 @@ class MatterFiling(Base):
 class MatterCommunication(Base):
     __tablename__ = "matter_communications"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     communication_type: Mapped[str] = mapped_column(String(40), nullable=False)
     direction: Mapped[str] = mapped_column(String(20), nullable=False)
     occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     sender_party_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("matter_parties.id"), nullable=True
+        PortableUUIDString, ForeignKey("matter_parties.id"), nullable=True
     )
     recipient_party_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("matter_parties.id"), nullable=True
+        PortableUUIDString, ForeignKey("matter_parties.id"), nullable=True
     )
     subject_redacted: Mapped[str | None] = mapped_column(String(500), nullable=True)
     content_redacted: Mapped[str | None] = mapped_column(Text, nullable=True)
     source_document_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("documents.id"), nullable=True
+        PortableUUIDString, ForeignKey("documents.id"), nullable=True
     )
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -146,15 +147,15 @@ class MatterCommunication(Base):
 class MatterDispute(Base):
     __tablename__ = "matter_disputes"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     account_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("matter_accounts.id"), nullable=True
+        PortableUUIDString, ForeignKey("matter_accounts.id"), nullable=True
     )
     dispute_type: Mapped[str] = mapped_column(String(50), nullable=False)
     status: Mapped[str] = mapped_column(String(30), nullable=False, default="open")
@@ -164,7 +165,7 @@ class MatterDispute(Base):
     details_redacted: Mapped[dict | None] = mapped_column(
         "details", JSON, nullable=True, default=dict
     )
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -177,15 +178,15 @@ class MatterDispute(Base):
 class MatterAttachment(Base):
     __tablename__ = "matter_attachments"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     document_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("documents.id"), nullable=True
+        PortableUUIDString, ForeignKey("documents.id"), nullable=True
     )
     label_redacted: Mapped[str] = mapped_column(String(255), nullable=False)
     attachment_kind: Mapped[str] = mapped_column(String(40), nullable=False)
@@ -197,7 +198,7 @@ class MatterAttachment(Base):
     metadata_redacted: Mapped[dict | None] = mapped_column(
         "metadata", JSON, nullable=True, default=dict
     )
-    uploaded_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    uploaded_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -207,12 +208,12 @@ class MatterAttachment(Base):
 class MatterAssessment(Base):
     __tablename__ = "matter_assessments"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     assessment_type: Mapped[str] = mapped_column(String(50), nullable=False)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
@@ -222,7 +223,7 @@ class MatterAssessment(Base):
     reviewer_identity: Mapped[str | None] = mapped_column(String(255), nullable=True)
     review_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     reviewed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -235,15 +236,15 @@ class MatterAssessment(Base):
 class MatterAssessmentVersion(Base):
     __tablename__ = "matter_assessment_versions"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
     assessment_id: Mapped[str] = mapped_column(
-        String(36),
+        PortableUUIDString,
         ForeignKey("matter_assessments.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -252,7 +253,7 @@ class MatterAssessmentVersion(Base):
     facts_redacted: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
     conclusions_redacted: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
     limitations: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
-    created_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    created_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -261,17 +262,17 @@ class MatterAssessmentVersion(Base):
 class MatterAuditEvent(Base):
     __tablename__ = "matter_audit_events"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     tenant_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
     matter_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("matters.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    actor_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    actor_id: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     action: Mapped[str] = mapped_column(String(80), nullable=False)
     object_type: Mapped[str] = mapped_column(String(60), nullable=False)
-    object_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    object_id: Mapped[str] = mapped_column(PortableUUIDString, nullable=False)
     details_redacted: Mapped[dict | None] = mapped_column(
         "details", JSON, nullable=True, default=dict
     )

--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -12,16 +12,16 @@ from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Tex
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class MessageThread(Base):
     __tablename__ = "message_threads"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
 
     subject: Mapped[str] = mapped_column(String(500), nullable=False)
@@ -30,10 +30,10 @@ class MessageThread(Base):
 
     # Context
     client_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("clients.id"), nullable=True
+        PortableUUIDString, ForeignKey("clients.id"), nullable=True
     )
     case_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("cases.id"), nullable=True
+        PortableUUIDString, ForeignKey("cases.id"), nullable=True
     )
 
     # Participants: list of user_ids
@@ -51,7 +51,7 @@ class MessageThread(Base):
     message_count: Mapped[int] = mapped_column(Integer, default=0)
 
     created_by: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        PortableUUIDString, ForeignKey("users.id"), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
@@ -70,16 +70,15 @@ class MessageThread(Base):
 class Message(Base):
     __tablename__ = "messages"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     thread_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("message_threads.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("message_threads.id", ondelete="CASCADE"), nullable=False
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False
     )
-    sender_id: Mapped[uuid.UUID] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    sender_id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
     idempotency_key: Mapped[str | None] = mapped_column(String(64), nullable=True, unique=True)
 
     # Content (stored encrypted if thread.is_encrypted)
@@ -96,12 +95,12 @@ class Message(Base):
     is_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     deleted_by: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
 
     # Reply to
     reply_to_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("messages.id"), nullable=True
+        PortableUUIDString, ForeignKey("messages.id"), nullable=True
     )
 
     # Read receipts: {user_id: iso_timestamp}
@@ -129,14 +128,13 @@ class MessageAttachment(Base):
 
     __tablename__ = "message_attachments"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     message_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("messages.id", ondelete="CASCADE"), nullable=False
+        PortableUUIDString, ForeignKey("messages.id", ondelete="CASCADE"), nullable=False
     )
     document_id: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("documents.id"), nullable=True
+        PortableUUIDString, ForeignKey("documents.id"), nullable=True
     )
 
     # For external attachments not in vault

--- a/portal/models/mission_control_command.py
+++ b/portal/models/mission_control_command.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class MissionControlCommand(Base):
@@ -26,9 +27,9 @@ class MissionControlCommand(Base):
 
     __tablename__ = "mission_control_commands"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
-    tenant_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
-    requested_by: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("tenants.id"), nullable=False)
+    requested_by: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
 
     command_type: Mapped[str] = mapped_column(String(40), nullable=False)
     target_type: Mapped[str] = mapped_column(String(40), nullable=False)
@@ -43,7 +44,7 @@ class MissionControlCommand(Base):
     metadata_json: Mapped[dict] = mapped_column("metadata", JSON, nullable=False, default=dict)
 
     audit_log_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("audit_logs.id"), nullable=True
+        PortableUUIDString, ForeignKey("audit_logs.id"), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -79,9 +80,9 @@ class MissionControlCommandEvent(Base):
 
     __tablename__ = "mission_control_command_events"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     command_id: Mapped[str] = mapped_column(
-        String(36),
+        PortableUUIDString,
         ForeignKey("mission_control_commands.id", ondelete="CASCADE"),
         nullable=False,
     )
@@ -109,16 +110,16 @@ class MissionControlCommandReceipt(Base):
 
     __tablename__ = "mission_control_command_receipts"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     command_id: Mapped[str] = mapped_column(
-        String(36),
+        PortableUUIDString,
         ForeignKey("mission_control_commands.id", ondelete="CASCADE"),
         nullable=False,
     )
     receipt_type: Mapped[str] = mapped_column(String(40), nullable=False)
     receipt_hash: Mapped[str] = mapped_column(String(64), nullable=False)
     audit_log_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("audit_logs.id"), nullable=True
+        PortableUUIDString, ForeignKey("audit_logs.id"), nullable=True
     )
     evidence_refs: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/portal/models/mission_control_outbox.py
+++ b/portal/models/mission_control_outbox.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 from sqlalchemy import JSON, DateTime, Integer, String, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 class MissionControlOutbox(Base):
     """

--- a/portal/models/mission_control_run_control.py
+++ b/portal/models/mission_control_run_control.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class RunControlState(StrEnum):
@@ -47,11 +48,11 @@ class MissionControlRunControl(Base):
 
     __tablename__ = "mission_control_run_controls"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
-    tenant_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("tenants.id"), nullable=False)
     workflow_id: Mapped[str] = mapped_column(String(128), nullable=False)
     command_id: Mapped[str | None] = mapped_column(
-        String(36),
+        PortableUUIDString,
         ForeignKey("mission_control_commands.id", ondelete="SET NULL"),
         nullable=True,
     )
@@ -68,12 +69,12 @@ class MissionControlRunControl(Base):
 
     pause_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     requested_by: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     requested_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     confirmation_ref: Mapped[str | None] = mapped_column(String(128), nullable=True)
     acknowledged_by: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     acknowledged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     paused_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -112,9 +113,9 @@ class MissionControlRunControlEvent(Base):
 
     __tablename__ = "mission_control_run_control_events"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     run_control_id: Mapped[str] = mapped_column(
-        String(36),
+        PortableUUIDString,
         ForeignKey("mission_control_run_controls.id", ondelete="CASCADE"),
         nullable=False,
     )
@@ -125,10 +126,10 @@ class MissionControlRunControlEvent(Base):
     previous_version: Mapped[int] = mapped_column(Integer, nullable=False)
     new_version: Mapped[int] = mapped_column(Integer, nullable=False)
     principal_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     command_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("mission_control_commands.id", ondelete="SET NULL"), nullable=True
+        PortableUUIDString, ForeignKey("mission_control_commands.id", ondelete="SET NULL"), nullable=True
     )
     reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     payload: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)

--- a/portal/models/orchestration.py
+++ b/portal/models/orchestration.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class OrchestrationTaskType(StrEnum):

--- a/portal/models/types.py
+++ b/portal/models/types.py
@@ -41,3 +41,36 @@ class PortableUUID(TypeDecorator[uuid.UUID]):
         if isinstance(value, uuid.UUID):
             return value
         return uuid.UUID(str(value))
+
+
+class PortableUUIDString(TypeDecorator[str]):
+    """UUID stored as native PostgreSQL UUID and SQLite-compatible text.
+
+    Unlike :class:`PortableUUID`, Python code always sees canonical ``str``
+    values (``"xxxxxxxx-xxxx-..."``), so existing callers and Pydantic
+    schemas that declare ``tenant_id: str`` keep working unchanged. Bind
+    parameters accept ``str`` or ``uuid.UUID``.
+    """
+
+    impl = String(36)
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect: Dialect) -> TypeEngine[Any]:
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(PGUUID(as_uuid=False))
+        return dialect.type_descriptor(String(36))
+
+    def process_bind_param(self, value: Any, dialect: Dialect) -> str | None:
+        if value is None:
+            return None
+        parsed = value if isinstance(value, uuid.UUID) else uuid.UUID(str(value))
+        if dialect.name == "postgresql":
+            return str(parsed)
+        return str(parsed)
+
+    def process_result_value(self, value: Any, _dialect: Dialect) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, uuid.UUID):
+            return str(value)
+        return str(value)

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 # ── Tenant (Firm) ─────────────────────────────────────────────────────────────
 
@@ -29,8 +30,7 @@ from ..database import Base
 class Tenant(Base):
     __tablename__ = "tenants"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     slug: Mapped[str] = mapped_column(String(100), unique=True, nullable=False, index=True)
@@ -75,8 +75,7 @@ class Tenant(Base):
 class Role(Base):
     __tablename__ = "roles"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     name: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
     display_name: Mapped[str] = mapped_column(String(100), nullable=False)
@@ -98,8 +97,7 @@ class Role(Base):
 class Permission(Base):
     __tablename__ = "permissions"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
     resource: Mapped[str] = mapped_column(String(50), nullable=False)
@@ -116,10 +114,10 @@ class RolePermission(Base):
     __tablename__ = "role_permissions"
 
     role_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True
+        PortableUUIDString, ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True
     )
     permission_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("permissions.id", ondelete="CASCADE"), primary_key=True
+        PortableUUIDString, ForeignKey("permissions.id", ondelete="CASCADE"), primary_key=True
     )
 
 
@@ -129,13 +127,12 @@ class RolePermission(Base):
 class User(Base):
     __tablename__ = "users"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        String(36), primary_key=True, default=lambda: str(uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, primary_key=True, default=lambda: str(uuid.uuid4)
     )
     tenant_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
+        PortableUUIDString, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    role_id: Mapped[uuid.UUID] = mapped_column(String(36), ForeignKey("roles.id"), nullable=False)
+    role_id: Mapped[uuid.UUID] = mapped_column(PortableUUIDString, ForeignKey("roles.id"), nullable=False)
 
     email: Mapped[str] = mapped_column(String(255), nullable=False)
     email_verified: Mapped[bool] = mapped_column(Boolean, default=False)
@@ -212,13 +209,13 @@ class UserPermissionAssoc(Base):
     __tablename__ = "user_permissions"
 
     user_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+        PortableUUIDString, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
     )
     permission_id: Mapped[uuid.UUID] = mapped_column(
-        String(36), ForeignKey("permissions.id", ondelete="CASCADE"), primary_key=True
+        PortableUUIDString, ForeignKey("permissions.id", ondelete="CASCADE"), primary_key=True
     )
     granted: Mapped[bool] = mapped_column(Boolean, default=True)  # False = explicit deny
     granted_by: Mapped[uuid.UUID | None] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=True
+        PortableUUIDString, ForeignKey("users.id"), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/portal/models/voice_command.py
+++ b/portal/models/voice_command.py
@@ -18,6 +18,7 @@ from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String, Text,
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..database import Base
+from ..models.types import PortableUUIDString
 
 
 class VoiceCommand(Base):
@@ -31,9 +32,9 @@ class VoiceCommand(Base):
 
     __tablename__ = "voice_commands"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
-    tenant_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
-    principal_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
+    tenant_id: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("tenants.id"), nullable=False)
+    principal_id: Mapped[str] = mapped_column(PortableUUIDString, ForeignKey("users.id"), nullable=False)
 
     command_id: Mapped[str] = mapped_column(String(80), nullable=False)
     voice_session_id: Mapped[str] = mapped_column(String(80), nullable=False)
@@ -62,7 +63,7 @@ class VoiceCommand(Base):
     artifacts: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
 
     audit_log_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("audit_logs.id"), nullable=True
+        PortableUUIDString, ForeignKey("audit_logs.id"), nullable=True
     )
     # Timestamps are set client-side (never server_default/onupdate). Under the
     # async engine, reading a column back after flush() (not commit()+refresh())
@@ -110,9 +111,9 @@ class VoiceCommandEvent(Base):
 
     __tablename__ = "voice_command_events"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     command_id: Mapped[str] = mapped_column(
-        String(36),
+        PortableUUIDString,
         ForeignKey("voice_commands.id", ondelete="CASCADE"),
         nullable=False,
     )
@@ -139,9 +140,9 @@ class VoiceCommandReceipt(Base):
 
     __tablename__ = "voice_command_receipts"
 
-    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    id: Mapped[str] = mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)
     command_id: Mapped[str] = mapped_column(
-        String(36),
+        PortableUUIDString,
         ForeignKey("voice_commands.id", ondelete="CASCADE"),
         nullable=False,
     )
@@ -149,7 +150,7 @@ class VoiceCommandReceipt(Base):
     receipt_hash: Mapped[str] = mapped_column(String(64), nullable=False)
     result: Mapped[str] = mapped_column(String(40), nullable=False)
     audit_log_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("audit_logs.id"), nullable=True
+        PortableUUIDString, ForeignKey("audit_logs.id"), nullable=True
     )
     evidence_refs: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
     created_at: Mapped[datetime] = mapped_column(

--- a/scripts/scan_schema_drift.py
+++ b/scripts/scan_schema_drift.py
@@ -1,17 +1,15 @@
 """Scan ORM model columns vs SQL migration schema for the canonical bootstrap tables."""
+
+import os
 import re
 import sys
 from pathlib import Path
 
-import sqlalchemy as sa
-
 sys.path.insert(0, str(Path(".").resolve()))
 
-# Load all portal models
-import os
 os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./probe.db")
+import portal.models
 from portal.database import Base
-import portal.models  # noqa
 
 # Build SQL schema column map from migration files
 MIGRATIONS = [
@@ -34,7 +32,11 @@ for mig in MIGRATIONS:
             sql_cols[table] = {}
         for line in body.splitlines():
             line = line.strip()
-            if not line or line.startswith("--") or line.startswith(("CONSTRAINT", "PRIMARY", "UNIQUE", "FOREIGN", "CHECK", "INDEX")):
+            if (
+                not line
+                or line.startswith("--")
+                or line.startswith(("CONSTRAINT", "PRIMARY", "UNIQUE", "FOREIGN", "CHECK", "INDEX"))
+            ):
                 continue
             parts = line.split()
             if len(parts) < 2:

--- a/scripts/scan_schema_drift.py
+++ b/scripts/scan_schema_drift.py
@@ -1,0 +1,71 @@
+"""Scan ORM model columns vs SQL migration schema for the canonical bootstrap tables."""
+import re
+import sys
+from pathlib import Path
+
+import sqlalchemy as sa
+
+sys.path.insert(0, str(Path(".").resolve()))
+
+# Load all portal models
+import os
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./probe.db")
+from portal.database import Base
+import portal.models  # noqa
+
+# Build SQL schema column map from migration files
+MIGRATIONS = [
+    "portal/migrations/portal_schema.sql",
+    "portal/migrations/add_evidence_snapshots.sql",
+    "portal/migrations/add_audit_records.sql",
+    "portal/migrations/add_mission_control_command_ledger.sql",
+    "portal/migrations/add_mission_control_run_control_projection.sql",
+]
+
+sql_cols: dict[str, dict[str, str]] = {}  # table -> {col: type}
+
+for mig in MIGRATIONS:
+    text = Path(mig).read_text(encoding="utf-8")
+    # find CREATE TABLE blocks
+    for m in re.finditer(r"CREATE TABLE (?:IF NOT EXISTS )?([\w.]+)\s*\((.*?)\)\s*;", text, re.S):
+        table = m.group(1).strip('"').split(".")[-1]
+        body = m.group(2)
+        if table not in sql_cols:
+            sql_cols[table] = {}
+        for line in body.splitlines():
+            line = line.strip()
+            if not line or line.startswith("--") or line.startswith(("CONSTRAINT", "PRIMARY", "UNIQUE", "FOREIGN", "CHECK", "INDEX")):
+                continue
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            col = parts[0].strip('"')
+            typ = parts[1].upper()
+            sql_cols[table][col] = typ
+
+# Compare ORM
+missing: list[str] = []
+extra: list[str] = []
+type_mismatch: list[str] = []
+for table_name, table in Base.metadata.tables.items():
+    if table_name not in sql_cols:
+        missing.append(f"TABLE {table_name}: exists in ORM but NOT in SQL migrations")
+        continue
+    orm_cols = {c.name: str(c.type).upper() for c in table.columns}
+    sql_tbl = sql_cols[table_name]
+    for col in orm_cols:
+        if col not in sql_tbl:
+            missing.append(f"  {table_name}.{col} (ORM {orm_cols[col]}) MISSING in SQL")
+    for col in sql_tbl:
+        if col not in orm_cols:
+            extra.append(f"  {table_name}.{col} (SQL {sql_tbl[col]}) not in ORM")
+
+print("=== MISSING in SQL (ORM has, schema lacks) ===")
+for m in missing:
+    print(m)
+print("\n=== In SQL but not ORM ===")
+for e in extra:
+    print(e)
+
+if os.path.exists("probe.db"):
+    os.remove("probe.db")

--- a/scripts/scan_schema_drift2.py
+++ b/scripts/scan_schema_drift2.py
@@ -1,0 +1,49 @@
+"""Compare ORM column types vs SQL schema for canonical tables (type-level)."""
+import re, sys, os
+from pathlib import Path
+sys.path.insert(0, str(Path(".").resolve()))
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./probe.db")
+from portal.database import Base
+import portal.models  # noqa
+
+MIGRATIONS = [
+    "portal/migrations/portal_schema.sql",
+    "portal/migrations/add_evidence_snapshots.sql",
+    "portal/migrations/add_audit_records.sql",
+    "portal/migrations/add_mission_control_command_ledger.sql",
+    "portal/migrations/add_mission_control_run_control_projection.sql",
+]
+sql_cols = {}
+for mig in MIGRATIONS:
+    text = Path(mig).read_text(encoding="utf-8")
+    for m in re.finditer(r"CREATE TABLE (?:IF NOT EXISTS )?([\w.]+)\s*\((.*?)\)\s*;", text, re.S):
+        table = m.group(1).strip('"').split(".")[-1]
+        body = m.group(2)
+        sql_cols.setdefault(table, {})
+        for line in body.splitlines():
+            line = line.strip()
+            if not line or line.startswith("--") or line.startswith(("CONSTRAINT","PRIMARY","UNIQUE","FOREIGN","CHECK","INDEX")):
+                continue
+            parts = line.split()
+            if len(parts) < 2: continue
+            sql_cols[table][parts[0].strip('"')] = parts[1].upper()
+
+def norm(t):
+    t = t.upper()
+    for a, b in [("VARCHAR","VARCHAR"),("CHARACTER VARYING","VARCHAR"),("TIMESTAMPTZ","DATETIME"),("TIMESTAMP","DATETIME"),("JSONB","JSON"),("DOUBLE PRECISION","FLOAT"),("NUMERIC","FLOAT"),("DECIMAL","FLOAT"),("INTEGER","INTEGER"),("BIGINT","INTEGER"),("SMALLINT","INTEGER"),("BOOLEAN","BOOLEAN"),("UUID","VARCHAR"),("TEXT","TEXT"),("INET","VARCHAR"),("DATE","DATE"),("BYTEA","BLOB")]:
+        t = t.replace(a, b)
+    return t
+
+issues = []
+for table_name, table in Base.metadata.tables.items():
+    if table_name not in sql_cols: continue
+    for col in table.columns:
+        if col.name not in sql_cols[table_name]: continue
+        orm_t = norm(str(col.type))
+        sql_t = norm(sql_cols[table_name][col.name])
+        if orm_t.split("(")[0] != sql_t.split("(")[0]:
+            issues.append(f"{table_name}.{col.name}: ORM {str(col.type)} vs SQL {sql_cols[table_name][col.name]}")
+print(f"type mismatches: {len(issues)}")
+for i in issues:
+    print(" ", i)
+if os.path.exists("probe.db"): os.remove("probe.db")

--- a/scripts/sweep_uuid_pks.py
+++ b/scripts/sweep_uuid_pks.py
@@ -1,0 +1,43 @@
+"""Second sweep: convert remaining PK String(36) columns to PortableUUIDString."""
+import re
+from pathlib import Path
+
+MODEL_DIR = Path("portal/models")
+
+def sweep_file(path: Path) -> int:
+    text = path.read_text(encoding="utf-8")
+    orig = text
+
+    if "PortableUUIDString" not in text:
+        if "from portal.models.types import" in text:
+            text = text.replace("from portal.models.types import",
+                                "from portal.models.types import PortableUUIDString,")
+        elif "from .types import" in text:
+            text = text.replace("from .types import",
+                                "from .types import PortableUUIDString,")
+        elif "from ..database import Base" in text:
+            text = text.replace("from ..database import Base",
+                                "from ..database import Base\nfrom ..models.types import PortableUUIDString")
+
+    # Any remaining String(36), primary_key=True (various default patterns)
+    text = re.sub(
+        r'mapped_column\(\s*String\(36\),\s*primary_key=True',
+        'mapped_column(PortableUUIDString, primary_key=True',
+        text,
+    )
+
+    count = 0
+    if text != orig:
+        count = orig.count("String(36)") - text.count("String(36)")
+        path.write_text(text, encoding="utf-8")
+    return count
+
+total = 0
+for py in sorted(MODEL_DIR.glob("*.py")):
+    if py.name.startswith("__") or py.name == "types.py":
+        continue
+    n = sweep_file(py)
+    if n:
+        print(f"  {py.name}: {n} more replaced")
+        total += 1
+print(f"\nTotal: {total} additional PK columns converted")

--- a/scripts/sweep_uuid_pks.py
+++ b/scripts/sweep_uuid_pks.py
@@ -1,8 +1,10 @@
 """Second sweep: convert remaining PK String(36) columns to PortableUUIDString."""
+
 import re
 from pathlib import Path
 
 MODEL_DIR = Path("portal/models")
+
 
 def sweep_file(path: Path) -> int:
     text = path.read_text(encoding="utf-8")
@@ -10,19 +12,22 @@ def sweep_file(path: Path) -> int:
 
     if "PortableUUIDString" not in text:
         if "from portal.models.types import" in text:
-            text = text.replace("from portal.models.types import",
-                                "from portal.models.types import PortableUUIDString,")
+            text = text.replace(
+                "from portal.models.types import",
+                "from portal.models.types import PortableUUIDString,",
+            )
         elif "from .types import" in text:
-            text = text.replace("from .types import",
-                                "from .types import PortableUUIDString,")
+            text = text.replace("from .types import", "from .types import PortableUUIDString,")
         elif "from ..database import Base" in text:
-            text = text.replace("from ..database import Base",
-                                "from ..database import Base\nfrom ..models.types import PortableUUIDString")
+            text = text.replace(
+                "from ..database import Base",
+                "from ..database import Base\nfrom ..models.types import PortableUUIDString",
+            )
 
     # Any remaining String(36), primary_key=True (various default patterns)
     text = re.sub(
-        r'mapped_column\(\s*String\(36\),\s*primary_key=True',
-        'mapped_column(PortableUUIDString, primary_key=True',
+        r"mapped_column\(\s*String\(36\),\s*primary_key=True",
+        "mapped_column(PortableUUIDString, primary_key=True",
         text,
     )
 
@@ -31,6 +36,7 @@ def sweep_file(path: Path) -> int:
         count = orig.count("String(36)") - text.count("String(36)")
         path.write_text(text, encoding="utf-8")
     return count
+
 
 total = 0
 for py in sorted(MODEL_DIR.glob("*.py")):

--- a/scripts/sweep_uuid_type.py
+++ b/scripts/sweep_uuid_type.py
@@ -1,0 +1,91 @@
+"""Sweep portal/models/*.py: replace String(36) with PortableUUIDString
+for UUID-semantic columns (PK with uuid default or ForeignKey)."""
+import re
+from pathlib import Path
+
+MODEL_DIR = Path("portal/models")
+
+def sweep_file(path: Path) -> int:
+    text = path.read_text(encoding="utf-8")
+    orig = text
+
+    # ensure PortableUUIDString is imported
+    if "PortableUUIDString" not in text:
+        if "from portal.models.types import" in text:
+            text = text.replace(
+                "from portal.models.types import",
+                "from portal.models.types import PortableUUIDString,",
+            )
+        elif "from .types import" in text:
+            text = text.replace(
+                "from .types import",
+                "from .types import PortableUUIDString,",
+            )
+        elif "from ..database import Base" in text:
+            text = text.replace(
+                "from ..database import Base",
+                "from ..database import Base\nfrom ..models.types import PortableUUIDString",
+            )
+        else:
+            import_idx = text.find("\nfrom ")
+            if import_idx > 0:
+                text = text[:import_idx] + "\nfrom portal.models.types import PortableUUIDString" + text[import_idx:]
+            import_idx = text.find("\nimport ")
+            if import_idx > 0 and "PortableUUIDString" not in text:
+                text = text[:import_idx] + "\nfrom portal.models.types import PortableUUIDString" + text[import_idx:]
+
+    # PK pattern: mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    text = re.sub(
+        r'mapped_column\(\s*String\(36\),\s*primary_key=True,\s*default=lambda:\s*str\(uuid\.uuid4\(\)\)\)',
+        'mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)',
+        text,
+    )
+    # PK pattern: mapped_column(String(36), primary_key=True, default=uuid.uuid4)
+    text = re.sub(
+        r'mapped_column\(\s*String\(36\),\s*primary_key=True,\s*default=uuid\.uuid4\)',
+        'mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)',
+        text,
+    )
+
+    # Single-line FK: mapped_column(String(36), ForeignKey(...), ...)
+    def replace_single_fk(m):
+        return m.group(0).replace('String(36)', 'PortableUUIDString', 1)
+    text = re.sub(
+        r'mapped_column\(\s*String\(36\),\s*(ForeignKey\([^)]+\)[^,]*(?:,\s*\w+[^,]*)*)',
+        replace_single_fk,
+        text,
+    )
+
+    # Multi-line FK: mapped_column(\n        String(36),\n        ForeignKey(...),
+    def replace_multi_fk(m):
+        return m.group(0).replace('String(36)', 'PortableUUIDString', 1)
+    text = re.sub(
+        r'mapped_column\(\s*\n\s*String\(36\),\s*\n\s*(ForeignKey)',
+        replace_multi_fk,
+        text,
+    )
+
+    # Simple: mapped_column(String(36), index=True, ...) — tenant_id without explicit FK
+    text = re.sub(
+        r'mapped_column\(\s*String\(36\),\s*index=True,\s*nullable=False\)',
+        'mapped_column(PortableUUIDString, index=True, nullable=False)',
+        text,
+    )
+
+    count = 0
+    if text != orig:
+        count = orig.count("String(36)") - text.count("String(36)")
+        path.write_text(text, encoding="utf-8")
+    return count
+
+total = 0
+files_touched = 0
+for py in sorted(MODEL_DIR.glob("*.py")):
+    if py.name.startswith("__") or py.name == "types.py":
+        continue
+    n = sweep_file(py)
+    if n:
+        print(f"  {py.name}: {n} replaced")
+        total += n
+        files_touched += 1
+print(f"\nTotal: {total} String(36) -> PortableUUIDString across {files_touched} model files")

--- a/scripts/sweep_uuid_type.py
+++ b/scripts/sweep_uuid_type.py
@@ -1,9 +1,11 @@
 """Sweep portal/models/*.py: replace String(36) with PortableUUIDString
 for UUID-semantic columns (PK with uuid default or ForeignKey)."""
+
 import re
 from pathlib import Path
 
 MODEL_DIR = Path("portal/models")
+
 
 def sweep_file(path: Path) -> int:
     text = path.read_text(encoding="utf-8")
@@ -29,46 +31,56 @@ def sweep_file(path: Path) -> int:
         else:
             import_idx = text.find("\nfrom ")
             if import_idx > 0:
-                text = text[:import_idx] + "\nfrom portal.models.types import PortableUUIDString" + text[import_idx:]
+                text = (
+                    text[:import_idx]
+                    + "\nfrom portal.models.types import PortableUUIDString"
+                    + text[import_idx:]
+                )
             import_idx = text.find("\nimport ")
             if import_idx > 0 and "PortableUUIDString" not in text:
-                text = text[:import_idx] + "\nfrom portal.models.types import PortableUUIDString" + text[import_idx:]
+                text = (
+                    text[:import_idx]
+                    + "\nfrom portal.models.types import PortableUUIDString"
+                    + text[import_idx:]
+                )
 
     # PK pattern: mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     text = re.sub(
-        r'mapped_column\(\s*String\(36\),\s*primary_key=True,\s*default=lambda:\s*str\(uuid\.uuid4\(\)\)\)',
-        'mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)',
+        r"mapped_column\(\s*String\(36\),\s*primary_key=True,\s*default=lambda:\s*str\(uuid\.uuid4\(\)\)\)",
+        "mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)",
         text,
     )
     # PK pattern: mapped_column(String(36), primary_key=True, default=uuid.uuid4)
     text = re.sub(
-        r'mapped_column\(\s*String\(36\),\s*primary_key=True,\s*default=uuid\.uuid4\)',
-        'mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)',
+        r"mapped_column\(\s*String\(36\),\s*primary_key=True,\s*default=uuid\.uuid4\)",
+        "mapped_column(PortableUUIDString, primary_key=True, default=uuid.uuid4)",
         text,
     )
 
     # Single-line FK: mapped_column(String(36), ForeignKey(...), ...)
     def replace_single_fk(m):
-        return m.group(0).replace('String(36)', 'PortableUUIDString', 1)
+        return m.group(0).replace("String(36)", "PortableUUIDString", 1)
+
     text = re.sub(
-        r'mapped_column\(\s*String\(36\),\s*(ForeignKey\([^)]+\)[^,]*(?:,\s*\w+[^,]*)*)',
+        r"mapped_column\(\s*String\(36\),\s*(ForeignKey\([^)]+\)[^,]*(?:,\s*\w+[^,]*)*)",
         replace_single_fk,
         text,
     )
 
     # Multi-line FK: mapped_column(\n        String(36),\n        ForeignKey(...),
     def replace_multi_fk(m):
-        return m.group(0).replace('String(36)', 'PortableUUIDString', 1)
+        return m.group(0).replace("String(36)", "PortableUUIDString", 1)
+
     text = re.sub(
-        r'mapped_column\(\s*\n\s*String\(36\),\s*\n\s*(ForeignKey)',
+        r"mapped_column\(\s*\n\s*String\(36\),\s*\n\s*(ForeignKey)",
         replace_multi_fk,
         text,
     )
 
     # Simple: mapped_column(String(36), index=True, ...) — tenant_id without explicit FK
     text = re.sub(
-        r'mapped_column\(\s*String\(36\),\s*index=True,\s*nullable=False\)',
-        'mapped_column(PortableUUIDString, index=True, nullable=False)',
+        r"mapped_column\(\s*String\(36\),\s*index=True,\s*nullable=False\)",
+        "mapped_column(PortableUUIDString, index=True, nullable=False)",
         text,
     )
 
@@ -77,6 +89,7 @@ def sweep_file(path: Path) -> int:
         count = orig.count("String(36)") - text.count("String(36)")
         path.write_text(text, encoding="utf-8")
     return count
+
 
 total = 0
 files_touched = 0


### PR DESCRIPTION
## R1 Foundation Recovery — SP-DEF-001 (P1)

### What This PR Fixes

**ORM/Schema UUID type drift** that made Mission Control command persistence fail on PostgreSQL.

The repo had two competing type conventions:
- **SQL migrations**: UUID columns with  defaults
- **ORM models**:  for all UUID-semantic columns (id, tenant_id, FK)

On SQLite this worked (dynamic typing). On PostgreSQL:  against a UUID column → `operator does not exist: uuid = character varying`.

### Root Cause

15 model files used  while the SQL schema used native UUID. The repo's own guard test (`test_postgresql_orm_foreign_key_column_types_are_internally_consistent`) was failing on 7+ FK mismatches.

### Fix

1. **New type**: `PortableUUIDString` in `types.py` — PG stores native UUID, SQLite stores text, Python callers see `str` (zero churn)
2. **Sweep**: 14 model files, 100+ columns: `String(36)` → `PortableUUIDString`
3. **Guard test**: now PASSES
4. **audit_logs**: added missing ORM columns (session_id, changes, request_id, hash_chain), fixed `INET` → `VARCHAR(45)`

### Verified on PostgreSQL 15.17



### Deferred (per §94)

Broader schema drift in non-MC-path tables (time_entries, expenses, invoices, payments, trust_accounts, cases): 80 type mismatches, mostly intentional PG-native types (INET, TIMESTAMPTZ, TEXT[], JSONB) vs ORM generics. These tables are not in the MC canonical bootstrap path.

### Deficiency Updates

| ID | Status | Note |
|---|---|---|
| SP-DEF-001 | **FIXED** | UUID drift resolved, MC command on PG proven |
| SP-DEF-002 | **RETRACTED** | False positive — model uses `content`, not `body` |
| SP-DEF-011 | Deferred | JWT key length (non-blocking) |
| SP-DEF-012 | Deferred | Stale test imports (non-blocking) |

### Explicit Confirmations

NO MERGE (draft)
NO DEPLOY
NO PRODUCTION ACTIVATION