### PR TITLE
SP-VOICE-002 Phase 1 + Phase 2A-1: Federated speech runtime + VibeVoice-Realtime adapter (preflight-only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,4 +91,5 @@ When the user requests a durable behavior change, record it here or in the relev
 | `.mesh/AGENTS.md` | Agent Mesh coordination | Ledger, registry, protocol messages, and transport status |
 | `governance/blackstone/AGENTS.md` | Blackstone Governance Library | Constitutional charter, standards, knowledge core, architecture, certification, registry, casebook |
 | `voice_concierge/governed/AGENTS.md` | SP-VOICE-001 Governed Voice Operations | Voice command envelope, risk classifier, policy decision, session state machine, confirmation, receipts, feature flags |
+| `voice_runtime/AGENTS.md` | SP-VOICE-002 Federated Speech Runtime (Phase 1) | Speech capability model, provider protocol/registry/router, preflight, provenance, mock/legacy/browser providers, audio normalization utilities |
 | `docs/orchestration/AGENTS.md` | Adaptive orchestration documentation | Architecture, provider, routing, security, governance, and certification contracts |

--- a/artifacts/voice/SP_VOICE_001_PR245_TERMINAL_STATE.md
+++ b/artifacts/voice/SP_VOICE_001_PR245_TERMINAL_STATE.md
@@ -1,0 +1,98 @@
+# SP-VOICE-001 — PR #245 Terminal State Certification
+
+**Status: OPTION A ALREADY SATISFIED EXTERNALLY. NO REPOSITORY MUTATION PERFORMED IN THIS ATTEMPT.**
+
+## Purpose
+
+This document certifies, via live GitHub API queries and local git ancestry/diff
+evidence (not narrative claims), that the previously-authorized "retarget/rebase
+PR #245 onto `main`" transition had **already completed and merged** before this
+session's Option-A execution attempt began. No rebase, force-push, reopen, reset,
+or code change was performed against PR #245 or its branch during this attempt.
+
+## Live verification performed
+
+1. `github-pull_request_read get` on PR #245 returned:
+   - `state: closed`
+   - `merged: true`
+   - `merged_by: ihoward40`
+   - `base.ref: main`, `base.sha: f9e5eeb07482e2a81f907270bb33df58ce0736ad`
+     (the PR #240 squash-merge commit)
+   - `head.sha: aa15ae6dfcd7ae810a9b144d3f40e5a63eb23c6f`
+   - `head.ref: feat/sp-voice-001-increment-two-orchestrator`
+   - `merged_at: 2026-08-02T16:09:30Z`
+   - final commit summary: "Fix governed voice confirmation review findings"
+   - `commits: 3`, `changed_files: 32`, `additions: 3113`, `deletions: 70`
+
+   This is materially different from the last locally-tracked state
+   (head `db9eb1582c068d93e4f5bbcdc17864bfc8441b79`, open, draft, base
+   pointing at the pre-merge `feat/sp-voice-001-governed-voice-operations`
+   branch SHA `0da54d7a...`). The transition, an additional review-finding
+   fix, and the merge all happened outside this session's tool calls.
+
+2. `git fetch origin --prune` in the stale local worktree
+   (`SintraPrime-Unified.worktrees\sp-voice-concierge-implementation`) confirmed:
+   - `origin/feat/sp-voice-001-increment-two-orchestrator` HEAD is `aa15ae6d`,
+     with two commits beyond the local worktree's `db9eb158`
+     (`f8661f12` relocate fix, `aa15ae6d` review-finding fix), and the local
+     worktree has 3 commits not on the remote branch tip in this form
+     (pre-rebase state) — i.e. the local and remote branches have diverged
+     because the remote branch was rebased onto `main` externally.
+
+3. Ancestry check:
+   ```
+   git merge-base --is-ancestor aa15ae6dfcd7ae810a9b144d3f40e5a63eb23c6f origin/main
+   → exit code 1 (NOT a direct ancestor)
+   ```
+   This is expected for a **squash merge**, not evidence the work is missing.
+
+4. Content-equivalence check (patch/tree diff, not commit-message inference):
+   ```
+   git log --oneline origin/main -- voice_concierge/governed
+   → e32c07c6 SP-VOICE-001 Increment Two: governed voice orchestrator,
+              mock providers, ledger API, and concierge panel (#245)
+
+   git diff e32c07c6 aa15ae6dfcd7ae810a9b144d3f40e5a63eb23c6f --stat
+   → (empty output — zero diff)
+   ```
+   The squash-merge commit `e32c07c6` on `main` is **byte-identical in tree
+   content** to PR #245's terminal head `aa15ae6d`. This certifies PR #245's
+   full changes (Increment Two orchestrator, mock providers, ledger API,
+   concierge panel, plus the confirmation-defect review fix) are present in
+   `main`, not merely claimed to be.
+
+5. `f9e5eeb07482e2a81f907270bb33df58ce0736ad` (PR #240's squash merge) **is**
+   a direct ancestor of `origin/main` (exit code 0) — also previously
+   certified in this session before PR #240's merge.
+
+## Current `origin/main` state at time of this certification
+
+- HEAD: `e2ada66e22f7992fec83c884fd6f7aa9329ccb25`
+- Tree: `c497ebfe99324ffcbd3743f2a95882808cb42dcc`
+- `main` has advanced well beyond PR #245's merge point — recent history
+  includes PR #247 (Browser Voice I/O), PR #263 (Adaptive Orchestration
+  Layer Milestone One), PR #266 (Phase 4 Autonomous Execution Plane), PR #273
+  (OmniBrain Memory Vault), PR #274 (Phase 10 platform hardening), and
+  subsequent remediation/certification commits.
+
+## Actions explicitly NOT taken during this attempt
+
+- No rebase of PR #245 or its branch.
+- No force-push.
+- No reopening of PR #245.
+- No reset or rewrite of the stale local worktree
+  (`SintraPrime-Unified.worktrees\sp-voice-concierge-implementation`,
+  still at `db9eb1582c068d93e4f5bbcdc17864bfc8441b79`, clean aside from
+  untracked leftover CI-polling JSON dumps from earlier diagnostic work).
+- No cherry-picks onto the stale branch to make it "look current."
+- No modification of any file under `voice_concierge/governed`, `portal/`,
+  or `web/` related to PR #245's scope.
+
+## Disposition
+
+- **PR #245: MERGED. Terminal head `aa15ae6dfcd7ae810a9b144d3f40e5a63eb23c6f`,
+  content-certified present in `main` at commit `e32c07c6`.**
+- **Stale local worktree preserved as historical evidence, not reset.**
+- **SP-VOICE-002 work begins from a fresh worktree/branch created directly
+  off current `origin/main` (`e2ada66e...`), not from either old SP-VOICE-001
+  feature branch.**

--- a/artifacts/voice/SP_VOICE_002_ARCHITECTURE_BASELINE.md
+++ b/artifacts/voice/SP_VOICE_002_ARCHITECTURE_BASELINE.md
@@ -1,0 +1,108 @@
+# SP-VOICE-002 — Architecture Baseline (Phase 0)
+
+**Baseline: `origin/main` @ `e2ada66e22f7992fec83c884fd6f7aa9329ccb25`.**
+**Branch: `feat/sp-voice-002-federated-speech-runtime`.**
+
+This document defines the control-plane/data-plane split that all future
+SP-VOICE-002 implementation phases must preserve. It does not authorize any
+implementation yet — Phase 0 stops after this artifact and the component
+matrix are produced.
+
+## Governing rule (unchanged, non-negotiable)
+
+> Voice may request and coordinate. Existing SintraPrime policy decides,
+> records, approves, executes, or refuses.
+
+Speech recognition and speech synthesis are **computation capabilities
+only**. They do not gain independent filing, sending, publishing,
+purchasing, payment, account-modification, or other consequential authority
+— regardless of how realistic, fast, or convenient a given speech engine is.
+
+## Control Plane — `voice_concierge/governed/` (SP-VOICE-001, authoritative, unchanged)
+
+Owns and remains the *only* place that:
+- classifies risk (`classifier.py`);
+- decides policy (`policy.py`);
+- manages session/cancellation state (`session.py`);
+- enforces exact-target confirmation (`confirmation.py`);
+- resolves and invokes **command capability** providers
+  (`providers.py`/`mock_providers.py`/`orchestrator.py`);
+- produces hash-chained events, receipts, and audit integration
+  (`receipts.py`, `portal/models/voice_command.py`,
+  `portal/services/voice_command_service.py`);
+- exposes the RBAC-gated, tenant-scoped REST API
+  (`portal/routers/voice_commands.py`).
+
+SP-VOICE-002 introduces **no new execution path**. Nothing in the new speech
+runtime may call a mock or real command provider directly, mint a
+`VoiceCommand`, or otherwise bypass `voice_concierge/governed/orchestrator.py`.
+Speech/audio output is always upstream (turning audio into a transcript that
+becomes a command request) or downstream (turning an already-governed
+response into audio) of this layer — never a parallel authority.
+
+## Speech/Data Plane — `voice_runtime/` (SP-VOICE-002, new)
+
+Owns speech **computation**, not decisions:
+- ASR / speech-to-text;
+- TTS / text-to-speech (streaming and long-form);
+- multi-speaker synthesis;
+- speaker diarization;
+- audio normalization/preprocessing;
+- speaker-profile handling (with consent governance, see Phase 4 of the
+  implementation plan already authorized for later phases);
+- provider capability declaration, discovery, routing, and lazy model
+  lifecycle/preflight.
+
+Proposed package shape (not yet created — Phase 1 work):
+
+```
+voice_runtime/
+├── __init__.py       # import-free facade, mirrors voice_concierge/__init__.py
+├── providers/         # one module per provider (browser, legacy adapter, VibeVoice-*, ...)
+├── registry.py        # capability-based provider discovery & fallback routing
+├── capabilities.py    # ASR / TTS / streaming-TTS / long-form / diarization / ... enum + protocol
+├── models.py          # structured transcript / synthesis-request / provenance schemas
+├── preflight.py        # dependency/hardware capability probing (no crash-on-missing-model)
+├── audio.py            # audio preprocessing utilities (harvested from legacy voice/)
+├── provenance.py       # media-provenance record construction, integrated with existing audit()
+└── policy.py           # speaker-profile consent gating, disclosure-state enforcement
+```
+
+Hard requirement carried from this session's diagnosis of the original
+PR #245 CI failure: **no module in `voice_runtime/__init__.py`'s import chain
+may eagerly import a heavy dependency** (numpy, torch, transformers, or any
+VibeVoice package). Application/test-suite startup must succeed with none of
+these installed; heavyweight providers load lazily only when selected and
+available (mirrors `voice_concierge/__init__.py`'s already-correct pattern,
+and directly fixes the class of defect found in legacy `voice/__init__.py`
+and still latent in `voice/wake_word.py` / `voice/voice_engine.py`, per the
+component matrix).
+
+## Existing building blocks available to `voice_runtime/` (from the component matrix)
+
+| Reusable source | What to take | What NOT to take |
+|---|---|---|
+| `voice/voice_engine.py` | `AudioBuffer` noise-floor/silence-detection logic | Session/event-bus orchestration (superseded by `voice_concierge/governed/session.py`); module-level `logging.basicConfig()` |
+| `voice/speech_processor.py` | Primary→fallback→offline provider-chain *pattern*; `LegalTermsDictionary`; `AudioPreprocessor`/`LanguageDetector` interfaces | Raw API-key dataclass fields; concrete mock-stub provider implementations |
+| `voice/legal_nlp.py` | Entire module, as a domain/language-layer adapter feeding transcripts into (not replacing) risk classification | — |
+| `voice/persona.py` | Entire module, as default synthetic-voice persona/profile metadata | — |
+| `voice/wake_word.py` | Phonetic-matching local wake-word detector | Direct numpy dependency without lazy-loading it |
+| `web/src/pages/VoiceConcierge.tsx` (PR #247) | Browser `SpeechRecognition`/`speechSynthesis` as the Tier-3 (zero-install) fallback provider | — |
+| `voice/voice_api.py`, `voice/README.md` | Nothing — retire | Mock-authenticated router; misleading docs |
+
+## Provider routing posture (for later Phase 7, informational only here)
+
+Any future routing table must never silently downgrade governance
+requirements, and must always keep the browser Web Speech API as a
+zero-install fallback tier, consistent with what PR #247 already ships.
+
+## What Phase 0 explicitly does NOT do
+
+- No `voice_runtime/` code has been written.
+- No VibeVoice (official or community-fork) package has been installed,
+  downloaded, or referenced as a dependency.
+- No model weights have been downloaded.
+- No real ASR/TTS execution has occurred.
+- No voice cloning or speaker enrollment has occurred.
+- No deletion or refactor of `voice/` has occurred — legacy code is
+  inventoried, not yet touched.

--- a/artifacts/voice/SP_VOICE_002_COMPONENT_MATRIX.md
+++ b/artifacts/voice/SP_VOICE_002_COMPONENT_MATRIX.md
@@ -1,0 +1,133 @@
+# SP-VOICE-002 — Component Matrix (Phase 0: Repository Archaeology)
+
+**Baseline: `origin/main` @ `e2ada66e22f7992fec83c884fd6f7aa9329ccb25`, worktree
+branch `feat/sp-voice-002-federated-speech-runtime`.**
+
+This inventory was produced entirely from the finalized, certified post-#245
+`main` baseline (see `SP_VOICE_001_PR245_TERMINAL_STATE.md`). No pre-rebase or
+mixed state was inspected for classification purposes.
+
+## Historical commits inspected
+
+| Commit | Date | Summary |
+|---|---|---|
+| `08e7c7f0` | 2026-04-25 | batch 18 — sintraprime speech, tools/security, connectors/platforms, watch |
+| `6746f677` | 2026-04-25 | batch 19 — sintraprime tools/security, connectors/platforms, watch, speech remaining |
+| `2fa9c1f7` | 2026-04-25 | "Phase 4 Complete: Voice, SaaS, Docket, DocuSign, Agencies, ML (29K lines)" |
+| `d57927c7` | 2026-04-25 | "Squad Omega — all 65 test failures resolved (case_law API, docket urllib3, federal/voice/esign logic, banking/saas imports)" |
+| `f9e5eeb0` | 2026-08-02 | SP-VOICE-001: Add governed voice operations foundation (#240, squash merge) |
+| `e32c07c6` | 2026-08-02 | SP-VOICE-001 Increment Two: governed voice orchestrator, mock providers, ledger API, and concierge panel (#245, squash merge) |
+| `6e3d2740` | 2026-08-02 | Browser Voice I/O for Voice Concierge (#247) |
+
+The April 2026 commits (`08e7c7f0`/`6746f677`/`2fa9c1f7`/`d57927c7`) are the
+origin of the legacy `voice/` package (Senior Partner persona, legal NLP,
+speech processor, wake word, voice engine, voice API) — roughly 3,219 lines
+across 8 non-test modules today (line count taken from the current tree, not
+the original commit, since the package has been touched since). PR #240/#245
+introduced the modern governed control plane at `voice_concierge/governed/`
+(~1,174 lines across 10 modules). PR #247 added browser mic/speech-synthesis
+I/O directly into the `voice_concierge/governed`-backed frontend
+(`web/src/pages/VoiceConcierge.tsx`, `web/src/api/voice.ts`) and a
+corresponding portal test (`portal/tests/test_voice_concierge_browser_io.py`).
+
+## Component classifications
+
+### Legacy `voice/` package (April 2026 origin)
+
+| Component | Origin | Status | Responsibility | Dependencies | Governance relevance | Overlap | Known debt | Disposition | Rationale |
+|---|---|---|---|---|---|---|---|---|---|
+| `voice/__init__.py` | 08e7c7f0 era | present, lazy `__getattr__` exports | Package facade | none eager | none — pure exports | superseded facade | Previously caused CI failures for PR #245 because eager submodule imports pulled `numpy` transitively into unrelated test collection paths (root-caused and fixed by relocating governed code out of `voice/` in PR #245's `f8661f12` commit). The lazy `__getattr__` pattern here *is* the correct fix shape and should be the template for `voice_runtime/`. | **KEEP (as template)** | Already lazy; safe to import `voice` itself. Any `voice.<X>` attribute access still requires `numpy` (undeclared dependency — see below). |
+| `voice/voice_engine.py` (`VoiceEngine`, `SessionManager`, `AudioBuffer`) | 08e7c7f0/2fa9c1f7 | present, all mock/no-op internals (`# Mock implementation` comments throughout: `_transcribe_audio`, `_synthesize_text`) | Async session/audio-buffer orchestration, event bus | `numpy` (module-level import, **undeclared** in `requirements.txt`) | No governance hooks at all — no RBAC, no tenant scoping, no policy/confirmation gate; a raw `speak()`/`process_audio()` call would execute unconditionally if ever wired to a real backend | Functionally duplicates the *session/event* concerns already handled far more rigorously by `voice_concierge/governed/session.py` and `orchestrator.py` | `numpy` import at module top-level; `logging.basicConfig()` called at import time (global side effect); no tenant/session isolation; mock TTS/STT baked in as literal stubs, not swappable providers | **ADAPT** — the `AudioBuffer`/noise-floor/silence-detection logic is reusable audio-preprocessing utility; the session/event-bus/orchestration layer should be retired in favor of `voice_concierge/governed/session.py`, which already has confirmation/cancellation/child-task semantics this module lacks entirely | Provides real audio-buffering logic worth harvesting, but it must never gain command/session authority — that already exists, governed, elsewhere |
+| `voice/speech_processor.py` (`SpeechProcessor`, `AudioPreprocessor`, `LanguageDetector`, `LegalTermsDictionary`) | 08e7c7f0/2fa9c1f7 | present, all provider calls are literal mock stubs returning canned text/zeroed audio arrays | STT/TTS provider fan-out with fallback chain (Whisper→Google; ElevenLabs→Polly→pyttsx3) | `numpy` (in mock synth helpers), designed for `openai`, `google-cloud-speech`, `elevenlabs`, `boto3`, `pyttsx3` (none installed/declared) | No provider ever contacts anything real today (good), but the module's design assumes **real, unguarded** provider credentials (`openai_api_key`, `elevenlabs_api_key`, `aws_access_key`/`aws_secret_key` fields directly on a dataclass) with **no consent, provenance, or governance layer** if ever activated | Directly overlaps the intended `voice_runtime/providers/` capability classes (ASR/TTS/streaming/long-form) that SP-VOICE-002 must build | Raw credential fields on a plain dataclass (no secrets-manager integration); provider fallback logic has no capability-declaration/preflight model; `LegalTermsDictionary`/`AudioPreprocessor`/`LanguageDetector` are reusable, provider-agnostic utilities | **ADAPT** — the fallback-chain *pattern* (primary→fallback→offline) and the legal-pronunciation dictionary are worth carrying into `voice_runtime/providers/registry.py` and a domain-specific normalization adapter; the concrete provider stubs and raw-credential dataclass should be **RETIRE**d in favor of governed provider classes with capability declarations and provenance metadata | Salvage the fallback-chain shape and legal-terms utility; do not carry over the ungoverned credential model |
+| `voice/legal_nlp.py` (`Intent` enum, `LegalNLPProcessor`) | 08e7c7f0/2fa9c1f7 | present, regex/keyword-based intent classification, 25+ legal intents | Domain-specific intent classification and entity extraction for legal queries | none heavy (`re`, stdlib) | Not governance — purely a language-understanding layer; does not decide or execute anything | Complements rather than duplicates `voice_concierge/governed/classifier.py` (which classifies **risk**, not legal domain/intent) — these are different axes of classification and could compose | none significant; well-contained, pure-Python, already lightweight | **KEEP** (as a language/domain layer, not a control-plane component) | Directly reusable as a "legal domain intent" adapter feeding into (but never replacing) the governed risk classifier; matches the plan's Phase 2 guidance to move legal NLP to "the language layer" |
+| `voice/persona.py` (`SeniorPartnerPersona`, `PersonaConfig`, `LegalDomain`, `ToneLevel`) | 08e7c7f0/2fa9c1f7 | present, template-based response generation with escalation-detection heuristics | Persona/tone selection and human-readable response templating | none heavy | No governance impact — persona selection is presentation, not authority | No overlap with existing control plane; complements future TTS voice-profile selection | Escalation heuristics are advisory text only, not tied to any real escalation/paging system | **KEEP** (as a persona/profile) | Matches the plan's explicit guidance ("Senior Partner persona KEEP as persona/profile"); can become the default synthetic-voice persona metadata for `voice_runtime` once speaker-profile governance (Phase 4 of SP-VOICE-002) exists |
+| `voice/response_formatter.py` | 08e7c7f0/2fa9c1f7 | present, not yet read in depth this pass | Converts text responses to voice-friendly formatting/SSML | none heavy expected | none | Complements TTS output stage | not yet assessed for defects | **KEEP** (pending closer read in Phase 1) | Formatting concern, independent of control plane |
+| `voice/wake_word.py` (`WakeWordDetector`, `PhoneticMatcher`) | 08e7c7f0/2fa9c1f7 | present, local-only, no network calls, phonetic distance matching | Local wake-word detection | `numpy` (module-level import, **undeclared** dependency) | None — purely a local audio-trigger utility, no execution authority | No current equivalent elsewhere in the repo | Same undeclared-`numpy`-dependency hazard as `voice_engine.py` | **KEEP** (adapt to lazy-load numpy) | Explicitly local/offline by design (a genuine strength — "no network calls" is already the right governance posture for this piece); just needs the dependency hazard fixed |
+| `voice/voice_api.py` | 08e7c7f0/2fa9c1f7 | present, FastAPI router with **mock JWT verification** (`# Mock JWT verification - in production use real verification`) hardcoded in `verify_token` | Legacy standalone REST/WebSocket voice API | `fastapi`, `jwt` (PyJWT) | **Significant governance hazard if ever mounted**: `verify_token` unconditionally returns a fake payload for any bearer token, i.e. **authentication is fully bypassed** in this module. This is exactly the kind of consequential-action risk the plan's Phase 3+ governance work must prevent from ever reaching a real deployment. | Directly duplicated/superseded by `portal/routers/voice_commands.py`, which uses the real portal auth/RBAC/tenant-scoping stack (`CurrentUser`, permission-gated dependencies) | Not mounted into the FastAPI app today (verified: no reference to `voice.voice_api` found in `portal/` router registration) — currently dead code, but its presence is a landmine for anyone who imports/mounts it without noticing the mock-auth comment | **RETIRE** | This router must not be adapted or reused; it should not exist alongside the governed `portal/routers/voice_commands.py` API surface. Any future real-time streaming API belongs behind the same RBAC/tenant middleware as the rest of `portal/routers/`, never a standalone unauthenticated router. |
+| `voice/tests/test_voice.py` | 08e7c7f0/2fa9c1f7/d57927c7 | present, ~24KB, imports `numpy` directly and depends on every legacy module above | Legacy package's own test suite (persona, NLP, formatting, wake word, speech processor, integration/edge cases per README: "50+ unit tests") | `numpy` (undeclared) | none | Tests exercise retired/adapted code; will need reshaping alongside each module's disposition | Test suite currently only "works" because `numpy` happens to be present transitively in this environment (confirmed: `numpy 2.3.5` importable, but **not listed** in `requirements.txt`) — this is the same unmanaged-dependency class of defect diagnosed for PR #245's CI failures, just not yet triggered because nothing eagerly imports `voice.*` from a path CI collects by default | **ADAPT** — split into per-disposition test files as modules are KEPT/ADAPTED/RETIRED; declare `numpy` explicitly wherever it remains needed, or remove the dependency by rewriting audio-buffer/wake-word math without it | Confirms the plan's stated lesson: undeclared heavy dependencies in `voice/` are a repeat hazard, not a one-off; SP-VOICE-002 must not repeat this pattern in `voice_runtime/` |
+| `voice/README.md` | 08e7c7f0 era | present, extensive (functional spec + API examples for a **fully real** ElevenLabs/Whisper/AWS Polly/Google STT system that was never actually implemented — every provider call in the code is a mock stub) | Documentation | n/a | Documentation risk: describes production behavior (real API keys, real transcription latency figures, a `/voice/transcribe` REST surface) that does not exist in the code — misleading if read at face value | n/a | Aspirational/stale relative to actual (mock-only) implementation | **RETIRE / rewrite** | Must not be used as a spec for SP-VOICE-002; any new README must accurately reflect governed, mock-first, capability-declared reality per this repo's conventions |
+
+### Modern governed control plane (PR #240/#245/#247 origin — `voice_concierge/`)
+
+| Component | Status | Disposition | Rationale |
+|---|---|---|---|
+| `voice_concierge/__init__.py` | present, deliberately import-free (docstring explicitly states the lazy-import design goal) | **KEEP — authoritative, untouched** | This is the fix for the exact "eager heavy import" class of defect found in legacy `voice/__init__.py`; it is the correct pattern to replicate for `voice_runtime/__init__.py`. |
+| `voice_concierge/governed/command_envelope.py` | present, immutable envelope + ID generation | **KEEP — authoritative, untouched** | Core control-plane data type. |
+| `voice_concierge/governed/classifier.py` | present, deterministic risk classifier | **KEEP — authoritative, untouched** | Risk classification is the governance backbone; SP-VOICE-002 must never bypass or duplicate it. |
+| `voice_concierge/governed/policy.py` | present, pure risk-class → decision matrix | **KEEP — authoritative, untouched** | |
+| `voice_concierge/governed/confirmation.py` | present, exact-target confirmation (defect fixed this session, commit `b9941096`/merged as part of `#240`) | **KEEP — authoritative, untouched** | Recently hardened; do not touch except for independently demonstrated defects. |
+| `voice_concierge/governed/session.py` | present, session state machine, cancellation/interruption | **KEEP — authoritative, untouched** | |
+| `voice_concierge/governed/receipts.py` | present, correlated machine-readable receipts, hash-only transcript retention | **KEEP — authoritative, untouched** | Template for SP-VOICE-002's Phase 5 media-provenance record — same hash-chained/audit-integrated pattern should be reused, not reinvented. |
+| `voice_concierge/governed/flags.py` | present, disabled-by-default feature flags | **KEEP — authoritative, untouched** | |
+| `voice_concierge/governed/providers.py` | present, `VoiceActionProvider` protocol + capability resolution (no I/O) | **KEEP — authoritative, untouched** | Distinct from and a good structural model for the *new* `voice_runtime` provider-capability protocol (ASR/TTS/etc.), but must remain a separate registry — this one resolves **command capabilities** (email/calendar/messaging/...), not **speech capabilities** (ASR/TTS/diarization/...). |
+| `voice_concierge/governed/mock_providers.py` | present, mock-only command-capability providers | **KEEP — authoritative, untouched** | |
+| `voice_concierge/governed/orchestrator.py` | present, ties classification+policy+session+confirmation+providers+receipts together | **KEEP — authoritative, untouched** | The single place command execution happens; SP-VOICE-002's speech runtime must never gain a parallel execution path that bypasses this. |
+| `voice_concierge/governed/AGENTS.md` | present, DOX child doc | **KEEP, extend narrowly if SP-VOICE-002 adds a sibling `voice_runtime/AGENTS.md`** | Already declares the governing rule this whole effort must preserve. |
+| `portal/models/voice_command.py` | present, tenant-scoped hash-chained ledger models | **KEEP — authoritative, untouched** | |
+| `portal/services/voice_command_service.py` | present, RBAC-gated service layer, `MockOnlyExecutionError` guard | **KEEP — authoritative, untouched** | |
+| `portal/routers/voice_commands.py` | present, RBAC-gated REST API (submit/get/list/confirm/cancel), real JWT-backed `CurrentUser` | **KEEP — authoritative, untouched** | The correct authenticated API pattern — the opposite of legacy `voice/voice_api.py`'s mock auth. |
+| `web/src/api/voice.ts` | present, typed API client, docstring explicitly disclaims real-world side effects | **KEEP — authoritative, untouched** | |
+| `web/src/pages/VoiceConcierge.tsx` (PR #247) | present, browser `SpeechRecognition`/`speechSynthesis` (Web Speech API) capture + playback, feeding the governed command API only | **KEEP — fallback tier** | This *is* the "browser speech input/output fallback" the plan calls for. It already exists and already only feeds the governed ledger — SP-VOICE-002 should treat it as Tier-3 fallback in the provider routing table (Phase 7), not replace it. |
+| `portal/tests/test_voice_commands.py`, `portal/tests/test_voice_concierge_browser_io.py`, `voice_concierge/governed/tests/*.py` | present, 153+ tests | **KEEP — authoritative, untouched** | |
+
+### Unrelated speech-adjacent code (false positive, out of scope)
+
+| Component | Status | Disposition | Rationale |
+|---|---|---|---|
+| `apps/SintraPrime/src/speech/*.ts` (`speak.ts`, `speechTiers.ts`, `decideSpeech.ts`, `emitSpeechBundle.ts`, `renderConfidenceSpeech.ts`, etc.) | present, TypeScript | **OUT OF SCOPE — not voice/audio at all** | This is a different, unrelated "speech" concept: rendering natural-language *status/confidence commentary* for a separate orchestration/gradient system (based on file names: `getRequalificationStatus`, `s3Deltas`, `s5Status`, `s6Feedback`, `writeSpeechArtifact`). It has nothing to do with audio, ASR, or TTS. Excluded from the SP-VOICE-002 inventory; flagged here only so a future reader doesn't conflate the two "speech" namespaces. |
+
+## Summary disposition counts
+
+- **KEEP (as-is / authoritative, no changes):** 20 components (all of `voice_concierge/governed/*`, `portal/*voice*`, `web/*voice*`, `voice/legal_nlp.py`, `voice/persona.py`, `voice/response_formatter.py`, `voice/wake_word.py` pending numpy fix)
+- **ADAPT (harvest logic, rebuild interface):** 3 components (`voice/voice_engine.py`'s `AudioBuffer`, `voice/speech_processor.py`'s fallback pattern + legal-terms/preprocessing utilities, `voice/tests/test_voice.py` restructuring)
+- **RETIRE:** 2 components (`voice/voice_api.py` — mock-auth hazard; `voice/README.md` — misleading aspirational spec)
+- **OUT OF SCOPE:** 1 false-positive namespace collision (`apps/SintraPrime/src/speech/`)
+
+## Phase 1 disposition updates (executed)
+
+Phase 1 ("SP-VOICE-002 — Federated Provider Architecture") has been
+implemented on branch `feat/sp-voice-002-federated-speech-runtime`. The
+following dispositions from the table above have now been **acted on**,
+not merely proposed:
+
+| Component | Phase-0 disposition | Phase-1 outcome |
+|---|---|---|
+| `voice/voice_engine.py`'s `AudioBuffer` (RMS/noise-floor/silence-detection, clip-normalize) | ADAPT | **Harvested** as a pure-Python (no `numpy`) reimplementation in `voice_runtime/audio/normalization.py` (`analyze_pcm16`, `clip_normalize`), exposed via `voice_runtime/providers/legacy.py::LegacyAudioAdapterProvider`. Declares only `AUDIO_NORMALIZATION`; cannot be routed to for ASR/TTS. See provenance comments in both files documenting the exact extraction source and rationale. |
+| `voice/speech_processor.py`'s primary→fallback→offline provider-chain *shape* | ADAPT | **Pattern reused** in `voice_runtime/router.py::route()` (explicit-preference → priority-ordered fallback → typed unavailable error), generalized to any capability rather than hard-coded to STT/TTS provider names. Concrete mock stubs and raw-credential dataclass fields were **not** carried over, per the Phase-0 finding. |
+| `voice/legal_nlp.py`, `voice/persona.py` | KEEP (as language/persona layer) | **Untouched.** Not imported by `voice_runtime` in Phase 1 (no ASR/TTS-adjacent use yet); remains available for a future language/persona adapter layer, per the architecture baseline. |
+| `voice/voice_api.py` | RETIRE | **Formally reclassified `RETIRED_UNSAFE_LEGACY_API`** (not deleted — deletion was not required for safety since it is already unreachable/unmounted, and the plan directs against deletion unless clearly isolated and necessary). A regression test (`voice_runtime/tests/test_legacy_and_browser_providers.py::test_no_import_of_legacy_voice_api_module`) enforces, via AST inspection of the legacy-adapter module's actual `import`/`from...import` statements (not a docstring substring match), that `voice_runtime` never imports `voice.voice_api` or any `voice.*` submodule. |
+| Undeclared `numpy` module-level imports (`voice/voice_engine.py`, `voice/wake_word.py`, `voice/tests/test_voice.py`) | Key finding — hazard persists | **Not reproduced.** `voice_runtime/tests/test_minimal_dependency_import.py::test_core_modules_import_without_heavy_dependencies` freshly imports every always-available `voice_runtime` submodule and asserts none of `numpy`/`torch`/`transformers`/`whisper`/`elevenlabs`/`boto3`/`pyttsx3`/`vibevoice` newly appear in `sys.modules` as a result. Passing. The legacy hazard itself remains unresolved in `voice/` (out of scope for Phase 1 — `voice/` was not modified). |
+| `web/src/pages/VoiceConcierge.tsx` (PR #247 browser Web Speech API) | KEEP — fallback tier | **Represented, not modified.** `voice_runtime/providers/browser.py::BrowserSpeechProvider` is a server-side capability *descriptor* only (declares ASR+TTS, reports `AVAILABLE_DEGRADED`/client-side-dependent via preflight); it never calls browser APIs from Python. A regression test asserts the frontend file still contains `SpeechRecognition`/`speechSynthesis` markers, unchanged. |
+
+See `SP_VOICE_002_PHASE1_CERTIFICATION.md` for the full architecture,
+test, and validation record.
+
+## Key finding: undeclared `numpy` dependency hazard persists
+
+`numpy` is imported at module level in `voice/voice_engine.py`, `voice/wake_word.py`,
+and `voice/tests/test_voice.py`, but is **not present in `requirements.txt`**.
+This is the same defect class that broke PR #245's exact-head CI before the
+`voice_concierge/` relocation (diagnosed and fixed earlier in this session).
+It has not resurfaced only because nothing in current CI paths eagerly imports
+`voice.<submodule>` attributes today, and because `numpy` happens to be
+installed transitively in this environment. **Any SP-VOICE-002 work that
+touches or re-exports `voice/` must either declare the dependency explicitly
+or remove the eager import**, per the plan's Phase 0 lazy-loading requirement.
+
+## Answer to the "key question": what should the legacy April implementation become?
+
+Per the evidence above, the correct answer is **(2) a compatibility/utility
+source behind new provider interfaces — not (1) the foundation, and not (4)
+wholesale retirement.** Specifically:
+- `persona.py` and `legal_nlp.py` are self-contained, low-risk, and genuinely
+  reusable **as-is** (option "KEEP", not even needing adaptation).
+- `voice_engine.py` and `speech_processor.py` contain real, useful
+  algorithmic content (audio buffering/noise-floor detection, provider
+  fallback-chain shape, legal pronunciation dictionary) but their *authority
+  model* (raw credentials on dataclasses, no capability declarations, no
+  governance hooks, global `logging.basicConfig()` side effects) is
+  incompatible with SP-VOICE-002's required architecture and must not be
+  reused verbatim — only specific functions/algorithms should be lifted into
+  the new `voice_runtime/` structure.
+- `voice_api.py` and `README.md` are net-negative artifacts (unauthenticated
+  router; misleading docs) and should be retired outright.

--- a/artifacts/voice/SP_VOICE_002_PHASE1_CERTIFICATION.md
+++ b/artifacts/voice/SP_VOICE_002_PHASE1_CERTIFICATION.md
@@ -1,0 +1,313 @@
+# SP-VOICE-002 — Phase 1 Certification: Federated Provider Architecture
+
+**Branch:** `feat/sp-voice-002-federated-speech-runtime`
+**Base:** `origin/main` @ `e2ada66e22f7992fec83c884fd6f7aa9329ccb25`
+**Phase:** 1 of the SP-VOICE-002 implementation plan (provider-neutral speech
+runtime skeleton only — no VibeVoice, no model downloads, no real
+provider calls, no voice cloning, no speaker enrollment, no GPU setup).
+
+## Governing rule (preserved, unchanged)
+
+> Voice may request and coordinate. Existing SintraPrime policy decides,
+> records, approves, executes, or refuses.
+
+`voice_runtime` is a speech/data plane only. It recognizes speech,
+synthesizes speech, normalizes audio, exposes provider capabilities,
+selects available providers, and produces structured transcripts/artifacts
+with provenance. It contains **zero** consequential-action authority: no
+code path decides whether an action is permitted, executes a filing, sends
+a message, moves money, modifies a record, bypasses confirmation, or
+bypasses tenant isolation. `voice_concierge/governed` was not modified and
+remains the sole authority for all of that.
+
+## Architecture implemented
+
+```
+voice_runtime/
+├── __init__.py         # import-free facade (mirrors voice_concierge/__init__.py's pattern)
+├── capabilities.py      # SpeechCapability enum (8 capabilities)
+├── errors.py            # typed error hierarchy
+├── models.py             # provider-neutral request/response schemas
+├── preflight.py           # PreflightState enum + PreflightResult
+├── provenance.py          # SpeechProvenance record + content_hash()
+├── registry.py            # ProviderRegistry + build_default_registry()
+├── router.py              # deterministic route() with fallback + evidence
+├── providers/
+│   ├── __init__.py        # import-free
+│   ├── base.py             # SpeechProvider Protocol + BaseSpeechProvider
+│   ├── mock.py              # MockSpeechProvider (deterministic, no real inference)
+│   ├── legacy.py             # LegacyAudioAdapterProvider (harvested AudioBuffer logic)
+│   └── browser.py             # BrowserSpeechProvider (PR #247 descriptor, no execution)
+├── audio/
+│   ├── __init__.py
+│   ├── normalization.py       # pure-Python RMS/silence/clip-normalize (no numpy)
+│   └── formats.py               # MIME/format classification helpers
+└── tests/                        # 54 tests (see below)
+```
+
+This matches the structure proposed in the Phase-1 authorization, with no
+material deviation.
+
+## Changed files
+
+**New files (30):**
+- `voice_runtime/__init__.py`
+- `voice_runtime/capabilities.py`
+- `voice_runtime/errors.py`
+- `voice_runtime/models.py`
+- `voice_runtime/preflight.py`
+- `voice_runtime/provenance.py`
+- `voice_runtime/registry.py`
+- `voice_runtime/router.py`
+- `voice_runtime/providers/__init__.py`
+- `voice_runtime/providers/base.py`
+- `voice_runtime/providers/mock.py`
+- `voice_runtime/providers/legacy.py`
+- `voice_runtime/providers/browser.py`
+- `voice_runtime/audio/__init__.py`
+- `voice_runtime/audio/normalization.py`
+- `voice_runtime/audio/formats.py`
+- `voice_runtime/tests/__init__.py`
+- `voice_runtime/tests/test_minimal_dependency_import.py`
+- `voice_runtime/tests/test_registry.py`
+- `voice_runtime/tests/test_router.py`
+- `voice_runtime/tests/test_mock_provider.py`
+- `voice_runtime/tests/test_legacy_and_browser_providers.py`
+- `voice_runtime/tests/test_models_and_provenance.py`
+- `voice_runtime/tests/test_no_side_effects.py`
+- `voice_runtime/tests/test_audio_normalization.py`
+- `voice_runtime/tests/test_preflight.py`
+- `artifacts/voice/SP_VOICE_001_PR245_TERMINAL_STATE.md` (Phase 0 carry-forward)
+- `artifacts/voice/SP_VOICE_002_COMPONENT_MATRIX.md` (Phase 0, updated this phase)
+- `artifacts/voice/SP_VOICE_002_ARCHITECTURE_BASELINE.md` (Phase 0 carry-forward)
+- `artifacts/voice/SP_VOICE_002_PHASE1_CERTIFICATION.md` (this file)
+
+**Modified files (2):**
+- `pytest.ini` — added `voice_runtime/tests` to `testpaths`
+- `pyproject.toml` — added `voice_runtime/tests` to `[tool.pytest.ini_options].testpaths`; added `voice_runtime` to `[tool.ruff.lint.isort].known-first-party`
+
+**Not modified:** nothing under `voice/`, `voice_concierge/`, `portal/`, or
+`web/` was touched in Phase 1. `voice_concierge/governed` remains
+byte-for-byte as merged in PR #245/#240.
+
+## Capability model
+
+`voice_runtime.capabilities.SpeechCapability`: `ASR`, `TTS`,
+`STREAMING_TTS`, `LONG_FORM_TTS`, `MULTI_SPEAKER_TTS`,
+`SPEAKER_DIARIZATION`, `AUDIO_NORMALIZATION`, `SPEAKER_PROFILE`.
+
+Providers declare a `frozenset[SpeechCapability]`; the registry/router
+never reason about provider identity, only declared capabilities — adding a
+future VibeVoice adapter requires no changes to `registry.py`/`router.py`.
+
+## Provider registry
+
+`ProviderRegistry` (in `voice_runtime/registry.py`):
+- `register(provider, priority=100, enabled=True)` — raises
+  `DuplicateProviderError` on ID collision.
+- `unregister`, `set_enabled`, `get`, `is_enabled`, `provider_ids()`.
+- `capability_map()` — provider ID → declared capabilities.
+- `preflight_map()` — provider ID → current `PreflightResult` (disabled
+  providers always report `DISABLED` regardless of their own `preflight()`).
+- `providers_for_capability(capability)` — all registered providers
+  declaring a capability, in deterministic `(priority, registration_order)`
+  order.
+- `build_default_registry()` — assembles the Phase-1 default set:
+  `legacy_audio_adapter` (priority 50), `browser_native` (priority 90),
+  `mock` (priority 100). No autonomous discovery; no plugin auto-install.
+
+## Routing rules
+
+`voice_runtime.router.route(registry, capability, preferred_provider_id=None)`:
+1. If a `preferred_provider_id` is given and usable, select it regardless
+   of configured priority (explicit caller preference wins).
+2. Otherwise, walk `providers_for_capability()` in priority order and
+   select the first provider whose current `preflight()` is `usable`.
+3. If no provider declares the capability at all →
+   `UnsupportedCapabilityError`.
+4. If one or more providers declare it but none are usable →
+   `ProviderUnavailableError` with per-provider rejection reasons.
+
+Every call returns full `RoutingDecision` evidence: requested capability,
+selected provider ID, all considered provider IDs, and a `rejected` tuple
+of `(provider_id, reason)` pairs — never a silent selection.
+
+Default routing tiers implemented, per the authorization's example (no
+VibeVoice hard-coded):
+1. legacy local audio-normalization adapter (priority 50)
+2. browser/native fallback descriptor (priority 90)
+3. mock (priority 100, dev/test default, always last)
+
+A real local ASR/TTS provider (e.g. a future VibeVoice adapter) would slot
+in at a lower priority number (e.g. 10) ahead of the legacy/browser tiers —
+no routing-logic changes required, only a new registration call.
+
+## Preflight
+
+`PreflightState`: `AVAILABLE`, `AVAILABLE_DEGRADED`, `DISABLED`,
+`DEPENDENCY_MISSING`, `MODEL_MISSING`, `HARDWARE_INSUFFICIENT`,
+`CONFIGURATION_ERROR`, `UNSUPPORTED` — exactly the 8 states specified.
+`PreflightResult` is a frozen dataclass with `.usable` (true only for
+`AVAILABLE`/`AVAILABLE_DEGRADED`), `.detail`, and `.checked_fields`.
+Convenience constructors (`available`, `dependency_missing`,
+`model_missing`, `disabled`) keep provider code concise. All Phase-1
+providers use static preflight (no real model integration exists yet);
+none can crash application startup — preflight is a pure function call.
+
+## Legacy adapter
+
+`voice_runtime/providers/legacy.py::LegacyAudioAdapterProvider`:
+- Declares **only** `AUDIO_NORMALIZATION` — cannot be routed to for ASR/TTS
+  (its inherited `recognize()`/`synthesize()` raise `NotImplementedError`
+  if ever called in error).
+- Wraps `analyze_pcm16()`/`clip_normalize()` in
+  `voice_runtime/audio/normalization.py`, which are **pure-Python
+  reimplementations** (documented via provenance comments) of the RMS/
+  noise-floor/silence-detection/clip-normalize logic from legacy
+  `voice/voice_engine.py::AudioBuffer` — not an import of that module.
+- Does **not** import the `voice` package at all (verified by AST
+  inspection in tests, not just a substring check on source text).
+- Exposes no legacy credentials, no legacy mock authentication
+  (`voice.voice_api.verify_token` is never referenced by import), and no
+  legacy direct-execution behavior.
+
+## Legacy code reused
+
+- `voice/voice_engine.py::AudioBuffer` RMS/noise-floor/silence-detection and
+  clip/normalize math → reimplemented pure-Python in
+  `voice_runtime/audio/normalization.py`.
+- `voice/speech_processor.py`'s primary→fallback→offline provider-chain
+  *shape* → generalized into `voice_runtime/router.py`'s
+  preferred→priority-ordered→typed-error routing algorithm.
+
+## Legacy code intentionally excluded
+
+- `voice/voice_api.py` — reclassified `RETIRED_UNSAFE_LEGACY_API` (hardcoded
+  mock bearer-token verification hazard, documented in the component
+  matrix). Not deleted (not required for safety since it is already
+  unreachable/unmounted); not imported or referenced by any `voice_runtime`
+  import statement (enforced by test).
+- `voice/speech_processor.py`'s raw API-key dataclass fields and concrete
+  provider stubs — not reproduced; a real provider's credentials belong in
+  the existing secrets-management pattern, not on a plain dataclass.
+- `voice/voice_engine.py`'s session/event-bus orchestration — superseded by
+  `voice_concierge/governed/session.py`, not duplicated.
+- `voice/legal_nlp.py`, `voice/persona.py` — left untouched per Phase-0 KEEP
+  disposition; not yet wired into `voice_runtime` (no ASR/TTS-adjacent use
+  in Phase 1).
+- `voice/README.md` — not used as a spec; this certification and the
+  architecture baseline are the authoritative Phase-1 documentation.
+
+## Dependency boundary (hard requirement, verified)
+
+Importing `voice_runtime` and all of its always-available submodules
+(`capabilities`, `errors`, `preflight`, `provenance`, `models`, `registry`,
+`router`, `providers`, `providers.base`, `providers.mock`,
+`providers.legacy`, `providers.browser`, `audio`, `audio.normalization`,
+`audio.formats`) does **not** require `numpy`, `torch`, `transformers`,
+`whisper`, `elevenlabs`, `boto3`, `pyttsx3`, or `vibevoice`. Verified by
+`voice_runtime/tests/test_minimal_dependency_import.py`, which purges any
+prior `voice_runtime.*` entries from `sys.modules`, freshly imports every
+listed submodule, and asserts none of the heavy-dependency module
+namespaces newly appear in `sys.modules` as a side effect.
+
+## Test commands and exact results
+
+```
+python -m pytest voice_runtime/tests/ -q
+→ 54 passed in 2.31s
+
+ruff check voice_runtime/
+→ All checks passed!
+
+python -m pytest voice_runtime/tests/ voice_concierge/governed/tests/ \
+    portal/tests/test_voice_commands.py portal/tests/test_voice_concierge_browser_io.py -q
+→ 172 passed in 55.47s
+    (54 voice_runtime + 88 voice_concierge/governed + 30 portal voice-related)
+
+python -m pytest --collect-only -q
+→ collects cleanly across the full default testpaths (tests/, portal/tests/,
+  voice_concierge/governed/tests/, voice_runtime/tests/) with zero collection
+  errors; only pre-existing, unrelated PytestCollectionWarning entries for
+  agents/sigma and agents/zero dataclasses (present before this change).
+```
+
+No test in `voice_concierge/governed/tests/`, `portal/tests/test_voice_commands.py`,
+or `portal/tests/test_voice_concierge_browser_io.py` was modified — all 118
+of those pre-existing tests pass unchanged, confirming zero regression to
+the merged SP-VOICE-001 foundation.
+
+## Test coverage against the Phase-1 checklist
+
+| Required test | Test file | Status |
+|---|---|---|
+| Core import without optional ML deps | `test_minimal_dependency_import.py` | ✅ |
+| Provider registration | `test_registry.py::test_register_and_get` | ✅ |
+| Duplicate provider rejection | `test_registry.py::test_duplicate_registration_rejected` | ✅ |
+| Capability discovery | `test_registry.py::test_capability_map_reports_all_providers` | ✅ |
+| Provider unavailable state | `test_router.py::test_route_all_providers_unavailable_raises_typed_error` | ✅ |
+| Deterministic routing | `test_router.py::test_route_selects_only_candidate`, `test_providers_for_capability_deterministic_priority_order` | ✅ |
+| Fallback routing | `test_router.py::test_route_falls_back_past_unavailable_provider`, `test_route_preferred_provider_unusable_falls_back` | ✅ |
+| All providers unavailable | `test_router.py::test_route_all_providers_unavailable_raises_typed_error` | ✅ |
+| Unsupported capability | `test_router.py::test_route_unsupported_capability_raises_typed_error` | ✅ |
+| Disabled provider | `test_registry.py::test_disabled_provider_reported_in_preflight_map`, `test_router.py::test_route_disabled_provider_is_skipped` | ✅ |
+| Preflight failure does not crash | `test_preflight.py` (all), `test_router.py` fallback tests | ✅ |
+| Mock ASR output | `test_mock_provider.py::test_mock_recognize_produces_structured_transcript` | ✅ |
+| Mock TTS output | `test_mock_provider.py::test_mock_synthesize_produces_speech_artifact` | ✅ |
+| Structured transcript model | `test_models_and_provenance.py::test_structured_transcript_roundtrip_fields` | ✅ |
+| Speech artifact model | `test_models_and_provenance.py::test_speech_artifact_provenance_serializes_to_dict` | ✅ |
+| Provenance generation | `test_mock_provider.py`, `test_models_and_provenance.py` (multiple) | ✅ |
+| Content hashing | `test_models_and_provenance.py::test_content_hash_deterministic_for_same_input`, `test_content_hash_differs_for_different_input` | ✅ |
+| Legacy adapter cannot expose command authority | `test_legacy_and_browser_providers.py::test_legacy_adapter_declares_only_audio_normalization`, `test_legacy_adapter_recognize_and_synthesize_not_implemented` | ✅ |
+| No import of `voice.voice_api` | `test_legacy_and_browser_providers.py::test_no_import_of_legacy_voice_api_module` (AST-based) | ✅ |
+| No external network side effects | `test_no_side_effects.py::test_mock_asr_flow_makes_no_network_calls`, `test_default_registry_routing_makes_no_network_calls` | ✅ |
+| No filesystem/model downloads | `test_no_side_effects.py::test_no_filesystem_model_downloads` | ✅ |
+| No browser API regression | `test_no_side_effects.py::test_voice_concierge_frontend_browser_speech_api_present` | ✅ |
+| SP-VOICE-001 governed tests remain green | Full regression run above (88 tests unchanged) | ✅ |
+
+## Known limitations
+
+- `voice/legal_nlp.py` and `voice/persona.py` are not yet wired into
+  `voice_runtime` — they remain standalone, per their Phase-0 KEEP
+  disposition, until a language/persona adapter is designed in a later
+  phase.
+- The undeclared-`numpy` hazard in `voice/voice_engine.py` and
+  `voice/wake_word.py` still exists in the legacy package itself (Phase 1
+  did not modify `voice/`, per scope). It is fully avoided within
+  `voice_runtime`, but anyone still importing `voice.voice_engine` or
+  `voice.wake_word` directly (outside this runtime) remains exposed to it.
+- `BrowserSpeechProvider.recognize()`/`.synthesize()` deliberately raise
+  `NotImplementedError` — there is no code path today that would route a
+  server-side capability request to the browser tier and expect a real
+  result; the descriptor exists for capability-reporting/routing-evidence
+  purposes only. Real browser-mediated flows continue to go through the
+  existing `portal/routers/voice_commands.py` API and
+  `web/src/pages/VoiceConcierge.tsx`, unchanged.
+- No real ASR/TTS provider exists yet (by design — Phase 1 scope excludes
+  VibeVoice/any real model integration).
+- `SPEAKER_PROFILE` capability is defined in the enum but no provider
+  declares or implements it yet; speaker-profile consent governance is
+  explicitly deferred to a later phase per the original increment plan.
+
+## Phase 2 recommendation
+
+Proceed to **SP-VOICE-002 Phase 2: official-provider certification**,
+evaluating VibeVoice-ASR and VibeVoice-Realtime-0.5B **one at a time**
+against this now-stable interface:
+1. Add a new `voice_runtime/providers/vibevoice_asr.py` (or similar)
+   implementing `SpeechProvider` with lazy-imported dependencies gated
+   behind `preflight()` — never imported at module load time.
+2. Register it at a low priority number (e.g. 10) ahead of the legacy/
+   browser tiers in a non-default registry assembly (not
+   `build_default_registry()`, to keep the zero-dependency default intact).
+3. Add explicit dependency/model-file/hardware preflight checks returning
+   `DEPENDENCY_MISSING`/`MODEL_MISSING`/`HARDWARE_INSUFFICIENT` as
+   appropriate — no installation, no download, no execution authorized yet
+   without a separate, explicit go-ahead per provider.
+4. Extend the mock-first test pattern established here: typed-error and
+   fallback tests must pass with the new provider intentionally left
+   unavailable (dependency/model absent) before any real integration is
+   attempted.
+
+No merge, deploy, push, or external side effect occurred in Phase 1. This
+branch has not been pushed to any remote.

--- a/artifacts/voice/SP_VOICE_002_PHASE2A_CERTIFICATION.md
+++ b/artifacts/voice/SP_VOICE_002_PHASE2A_CERTIFICATION.md
@@ -1,0 +1,260 @@
+# SP-VOICE-002 — Phase 2A-1 Certification: VibeVoice-Realtime-0.5B Adapter (Preflight-Only)
+
+**Branch:** `feat/sp-voice-002-federated-speech-runtime`
+**Prior checkpoint:** `4f9686b35f45921f0a571a5e813d24624e997437` (Phase 1)
+**Scope:** SP-VOICE-002 Phase 2A-1 — production-grade
+`VibeVoiceRealtimeProvider` adapter + hardware/dependency preflight. **No
+ML dependencies were installed and no model weights were downloaded on
+this host** in this pass, per explicit authorization to split Phase 2A
+into an adapter/preflight stage (2A-1, this document) and a later real
+end-to-end inference certification stage (2A-2, deferred to a
+better-suited host/environment).
+
+## Why Phase 2A was split before any install was attempted
+
+A hardware/environment preflight was performed **before installing
+anything**, per the required sequence. Findings:
+
+| Check | Result |
+|---|---|
+| OS | Windows 11 (build 26200) |
+| Python | 3.14.0 |
+| CPU | Intel, 12 cores / 16 threads |
+| RAM | 31.7 GB |
+| GPU | Intel Iris Xe (integrated) only — **no CUDA-capable GPU**, no `nvidia-smi` |
+| Free disk | **18.1–18.8 GB** at time of check |
+| `torch`/`transformers` installed | Neither present |
+| Existing model cache | None |
+
+Microsoft's own official documentation
+(`https://github.com/microsoft/VibeVoice/blob/main/docs/vibevoice-realtime-0.5b.md`,
+fetched live during this session) states real-time (~200–300ms)
+performance is verified only on **NVIDIA T4 / Apple M4 Pro** hardware, and
+recommends the NVIDIA PyTorch Docker container; weaker devices "may require
+further testing and speed optimizations." This host has no CUDA GPU, so it
+cannot be certified for the model's namesake real-time latency target —
+only CPU-degraded-mode compatibility is realistically achievable here.
+
+The official `vibevoice` package's `pyproject.toml` (fetched live from
+`github.com/microsoft/VibeVoice/main/pyproject.toml`) declares **hard,
+non-optional** dependencies including `torch`, `transformers`, `accelerate`,
+`diffusers`, `librosa`, `numba`, plus demo/server infrastructure
+(`gradio`, `aiortc`, `uvicorn`, `fastapi`) bundled as core requirements, not
+optional extras. `aiortc` in particular is a known-fragile native-build
+dependency on Windows. Estimated full-install footprint: roughly 4–6 GB
+(dependency stack + ~2.04 GB official model weights, per the Hugging Face
+model card's `model.safetensors` size), against only ~18 GB free — too
+thin a margin for a first attempt, especially given real risk of a
+partial/failed native-extension build consuming space without a working
+result.
+
+**Decision (per explicit authorization): do not install the full stack on
+this host now.** Instead, certify the adapter/preflight layer completely,
+and classify this host's real-inference readiness honestly:
+
+```
+AVAILABLE_DEGRADED_CANDIDATE — REAL INFERENCE NOT YET CERTIFIED
+```
+
+Real end-to-end inference certification (Phase 2A-2) is deferred to either
+(a) a CUDA-capable or Apple M-series host, or (b) this host after freeing
+substantially more disk (recommended: at least ~35–40 GB free before
+attempting the full install, so a failed install/build cannot strand the
+filesystem in a half-installed state).
+
+## What was implemented (Phase 2A-1)
+
+`voice_runtime/providers/vibevoice_realtime.py`:
+
+- **Official model only**: `OFFICIAL_MODEL_ID = "microsoft/VibeVoice-Realtime-0.5B"`
+  — no community fork is referenced anywhere in this module.
+- **`VibeVoiceRealtimeProvider(BaseSpeechProvider)`** declaring only `TTS`
+  and `STREAMING_TTS` (matches the officially documented capability of this
+  specific model — single-speaker, no cloning, no multi-speaker, no
+  arbitrary voice prompting; Microsoft's docs state voice prompts for this
+  model are embedded specifically "to mitigate deepfake risks").
+- **Fully lazy dependency imports**: `torch`/`transformers` are only ever
+  referenced inside `preflight()` (via a guarded `try: __import__(...)`)
+  and inside `_ensure_model_loaded()` — never at module import time.
+  Verified by test (`test_module_import_does_not_require_torch_or_transformers`)
+  and by the existing Phase 1 `test_minimal_dependency_import.py` suite,
+  which now also freshly imports this module.
+- **Layered preflight**, in order:
+  1. `_check_dependencies()` → `DEPENDENCY_MISSING` if `torch` or
+     `transformers` cannot be imported.
+  2. `_check_model_available()` → `MODEL_MISSING` if no local model path is
+     configured/exists and no local Hugging Face cache hit exists for
+     `OFFICIAL_MODEL_ID` (checked via `huggingface_hub.scan_cache_dir()`,
+     which is a **local-only** filesystem scan — never a network call).
+  3. `_check_hardware()` → `AVAILABLE` if CUDA is detected, else
+     `AVAILABLE_DEGRADED` with an explicit detail message citing Microsoft's
+     own real-time-hardware guidance. An explicit `device_preference="cpu"`
+     config always forces `AVAILABLE_DEGRADED` even if CUDA is present
+     (useful for deliberately testing/using the degraded path).
+- **Never-download guarantee**: no code path in this module ever triggers
+  a network request to fetch model weights. Model acquisition is
+  documented as a separate, explicit setup/admin action. Absence of local
+  weights is reported as `MODEL_MISSING`, not silently fetched.
+- **Resource limits / cancellation**: `synthesize()` accepts an optional
+  `cancel_event` (any object with `.is_set()`, e.g. `threading.Event`) and
+  raises `SynthesisCancelledError` if already set before model invocation.
+  `VibeVoiceRealtimeConfig.timeout_seconds` (default 30s) is defined as an
+  explicit per-request synthesis timeout field for the eventual real
+  inference call in Phase 2A-2 (not yet exercised, since no real inference
+  path exists in this pass).
+- **Input validation**: empty text raises `ValueError`; very short inputs
+  (≤4 words) are allowed but documented as reduced-stability per
+  Microsoft's own model card notes, not rejected.
+- **ASR not supported**: `recognize()` raises `NotImplementedError` — this
+  model is TTS-only.
+- **`synthesize()` in this pass**: after passing all preflight/validation
+  checks, calls `_ensure_model_loaded()`, which raises `RuntimeError` with
+  a preflight-derived message. On this real, unmodified host (dependencies
+  genuinely absent), this is not a stub/simulation — it is the honest,
+  correct behavior: no real inference is available here, and the provider
+  says so clearly instead of fabricating a result.
+
+## Not added to the default registry
+
+`VibeVoiceRealtimeProvider` is **not** registered in
+`voice_runtime.registry.build_default_registry()`. It must be explicitly
+constructed and registered by calling code that has verified its own
+environment — this keeps the zero-dependency default registry intact per
+the Phase 1 contract, and avoids ever silently attempting real-provider
+behavior in an environment (like this one) where it isn't certified.
+
+## Tests and results
+
+`voice_runtime/tests/test_vibevoice_realtime_provider.py` — 16 tests
+(using a lightweight fake `torch` module object injected into
+`sys.modules` for hardware-branch tests only; not a real PyTorch install,
+performs no computation):
+
+- Module import requires no `torch`/`transformers` (real, on this host).
+- Official model ID is exactly `microsoft/VibeVoice-Realtime-0.5B`.
+- Capability declaration is exactly `{TTS, STREAMING_TTS}` — no ASR, no
+  multi-speaker, no speaker-profile.
+- Preflight reports `DEPENDENCY_MISSING` on this real host (no torch).
+- Preflight reports `DEPENDENCY_MISSING` (transformers) with a fake torch
+  present but transformers absent.
+- Preflight reports `MODEL_MISSING` for a configured-but-nonexistent
+  `model_path`.
+- Preflight reports usable (`AVAILABLE`/`AVAILABLE_DEGRADED`) once a fake
+  dependency set + a real (empty, on-disk) `model_path` directory exist.
+- Preflight reports `AVAILABLE_DEGRADED` specifically for CPU-only (fake
+  `torch.cuda.is_available() == False`).
+- Preflight reports `AVAILABLE` for CUDA-available (fake
+  `torch.cuda.is_available() == True`).
+- Explicit `device_preference="cpu"` forces `AVAILABLE_DEGRADED` even with
+  CUDA "available" (fake).
+- `recognize()` raises `NotImplementedError`.
+- `synthesize()` raises `RuntimeError` on this real host (dependencies
+  genuinely missing) — proves no silent fabrication.
+- `synthesize()` rejects empty text with `ValueError`.
+- `synthesize()` honors an already-set `cancel_event`, raising
+  `SynthesisCancelledError` before any model invocation.
+- Never-download guarantee: no `model_path` and no `huggingface_hub`
+  installed → `MODEL_MISSING`, not a network attempt.
+- `health()` includes the preflight state in its summary string.
+
+### Exact commands and results
+
+```
+python -m pytest voice_runtime/tests/test_vibevoice_realtime_provider.py -q
+→ 16 passed
+
+ruff check voice_runtime/
+→ All checks passed!
+
+python -m pytest voice_runtime/tests/ -q
+→ 70 passed   (54 from Phase 1 + 16 new for the VibeVoice-Realtime adapter)
+
+python -m pytest voice_runtime/tests/ voice_concierge/governed/tests/ \
+    portal/tests/test_voice_commands.py portal/tests/test_voice_concierge_browser_io.py -q
+→ 188 passed in 48.77s   (70 voice_runtime + 118 governed/portal, 0 regressions)
+```
+
+Note: one test (`test_synthesize_honors_cancel_event_before_invocation`)
+initially failed only when run as part of the full `voice_runtime/tests/`
+suite (not in isolation) due to a genuine, now-fixed test-authoring defect:
+`test_minimal_dependency_import.py`'s heavy-dependency regression test
+purges and re-imports every `voice_runtime.*` submodule from `sys.modules`
+mid-suite (by design, to prove clean re-import). A local, in-test-body
+`from voice_runtime.providers.vibevoice_realtime import SynthesisCancelledError`
+executed *after* that purge resolved to a different (post-purge) module
+instance than the one the provider's own `raise` statement referenced
+(bound at collection time, pre-purge) — an exception-class-identity
+mismatch, not a logic defect in the provider. Fixed by moving all
+`voice_runtime` imports in this test file to the top of the module
+(bound once, consistently, at collection time), matching the pattern
+already used by every other Phase 1 test file. Verified fixed: the full
+188-test regression run above now passes cleanly.
+
+## Dependency/model/hardware boundary re-verified
+
+- `voice_runtime/tests/test_minimal_dependency_import.py` now also
+  freshly imports `voice_runtime.providers.vibevoice_realtime` and
+  confirms it does not pull `torch`/`transformers`/etc. into `sys.modules`
+  as a side effect of import alone.
+- No package was installed via `pip install` in this pass. (An earlier
+  `pip install --target ... torch` probe was started to check wheel
+  compatibility, then deliberately stopped mid-download and its partial
+  target directory removed — see preflight section above. Net disk impact
+  after cleanup: ~0.7 GB was not fully reclaimed by that probe attempt at
+  time of measurement; no lasting `torch` install exists on this host.)
+- No model weights were downloaded.
+
+## Known limitations
+
+- Real end-to-end inference (model load + actual audio synthesis) is
+  **not certified on this host** — `_ensure_model_loaded()` and the
+  inference body of `synthesize()` intentionally stop short of a real
+  model call and raise a clear `RuntimeError` explaining why.
+- `SynthesisCancelledError`/`SynthesisTimeoutError` cooperative-cancellation
+  and timeout plumbing exist as contracts (`cancel_event` parameter,
+  `VibeVoiceRealtimeConfig.timeout_seconds`) but have not been exercised
+  against a real, potentially-slow model call — only against the
+  before-invocation cancellation path.
+- `huggingface_hub`-based local cache detection has not been exercised
+  against a real populated cache (none exists on this host); it has been
+  exercised only against its absence (`MODEL_MISSING`) and against an
+  explicit `model_path` directory (empty, for preflight-branch testing
+  only — not a real model directory).
+
+## Phase 2A-2 recommendation (deferred, not started)
+
+Perform real end-to-end certification on a host that is either
+CUDA-capable, Apple M-series, or this host after securing at least
+~35–40 GB free disk. Sequence, once such an environment is available:
+
+1. Create an isolated virtual environment (do not pollute this host's
+   global Python).
+2. Install only what direct inference requires — evaluate whether the
+   full `pip install -e .[streamingtts]` (which pulls `gradio`/`aiortc`/
+   `uvicorn`/`fastapi` as hard dependencies per the package's
+   `pyproject.toml`) can be narrowed, or accept the full footprint if
+   disk allows.
+3. Download **only** the official `microsoft/VibeVoice-Realtime-0.5B`
+   weights (e.g. via `huggingface-cli download`), recording: exact
+   repository commit/release used, model revision/hash, installed package
+   versions (`pip freeze`), and resulting disk footprint.
+4. Implement the real model-loading body of `_ensure_model_loaded()` and
+   the real inference body of `synthesize()`, still gated by the existing
+   preflight checks (no behavior change to the already-certified
+   preflight/dependency/model-missing logic).
+5. Run the exact harmless smoke-test text specified in the Phase 2A
+   authorization ("SintraPrime local voice runtime certification test."),
+   save the resulting audio artifact, hash it, and attach the Phase 1
+   `SpeechProvenance` structure (`content_hash`, `model_id`, `provider_id`,
+   `provider_version`, tenant/principal correlation).
+6. Re-run the full validation checklist from the original Phase 2A
+   authorization: lazy load confirmed, app import still works without the
+   model loaded, preflight transitions from missing → available observed
+   live (not simulated), real TTS succeeds, artifact MIME/format correct,
+   fallback still works when the provider is disabled, model failure
+   doesn't crash the broader runtime, no network call after caching during
+   an offline inference test (if feasible), and the full 188-test (or
+   larger, if Phase 2A-2 grows the suite) regression remains green.
+
+No merge, deploy, push, or external side effect occurred in Phase 2A-1.
+This branch remains unpushed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,7 +220,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.isort]
-known-first-party = ["portal", "operator", "voice_concierge"]
+known-first-party = ["portal", "operator", "voice_concierge", "voice_runtime"]
 
 [tool.ruff.lint.per-file-ignores]
 # ── Per-file baseline ──────────────────────────────────────────────────
@@ -257,7 +257,7 @@ known-first-party = ["portal", "operator", "voice_concierge"]
 "tests/**" = ["ARG002", "F401", "F811", "F841", "N802", "N999", "PT009", "PT011", "PT027", "RUF059"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "portal/tests", "voice_concierge/governed/tests"]
+testpaths = ["tests", "portal/tests", "voice_concierge/governed/tests", "voice_runtime/tests"]
 python_files = "test_*.py"
 asyncio_mode = "auto"
 addopts = "-m 'not experimental'"

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ testpaths =
     tests
     portal/tests
     voice_concierge/governed/tests
+    voice_runtime/tests
 norecursedirs =
     apps
     deployment

--- a/voice_runtime/AGENTS.md
+++ b/voice_runtime/AGENTS.md
@@ -48,6 +48,17 @@ implemented.
   `voice` package import); declares `AUDIO_NORMALIZATION` only
 - `providers/browser.py` — server-side descriptor for the PR #247 browser
   Web Speech API fallback tier; never executes browser APIs from Python
+- `providers/vibevoice_realtime.py` — official
+  `microsoft/VibeVoice-Realtime-0.5B` single-speaker streaming TTS adapter
+  (Phase 2A). Declares only `TTS`/`STREAMING_TTS`. Fully lazy `torch`/
+  `transformers` imports (never at module level); layered preflight
+  (`DEPENDENCY_MISSING` → `MODEL_MISSING` → hardware `AVAILABLE`/
+  `AVAILABLE_DEGRADED`); never auto-downloads model weights (local-only
+  cache/path checks); not registered in `build_default_registry()` — must
+  be explicitly constructed by callers who have verified their own
+  environment. Real end-to-end inference is **not yet certified** on the
+  primary development host (no CUDA GPU, limited disk) — see
+  `artifacts/voice/SP_VOICE_002_PHASE2A_CERTIFICATION.md`.
 - `audio/normalization.py`, `audio/formats.py` — pure-Python audio
   preprocessing utilities (no `numpy`)
 - `tests/` — 54 tests covering import-dependency boundary, registry,
@@ -95,7 +106,12 @@ implemented.
   heavy dependencies lazily, inside methods gated by `preflight()` —
   never at module import time. See `providers/legacy.py`'s docstring for
   the pattern of harvesting an *algorithm* rather than importing an unsafe
-  module wholesale when adapting legacy code.
+  module wholesale when adapting legacy code. `providers/vibevoice_realtime.py`
+  follows this same pattern for real (not-yet-installed) ML dependencies.
+- Any real provider must never auto-download model weights at runtime;
+  model acquisition is always a separate, explicit setup/admin action, and
+  absence must be reported via `PreflightResult.model_missing()`, not
+  silently fetched.
 - Do not add real provider credentials as plain dataclass fields; follow
   the existing repository secrets-management pattern instead.
 

--- a/voice_runtime/AGENTS.md
+++ b/voice_runtime/AGENTS.md
@@ -1,0 +1,110 @@
+# voice_runtime — SP-VOICE-002 Federated Speech Runtime (Phase 1)
+
+## Purpose
+
+Speech/data-plane package: automatic speech recognition (ASR), speech
+synthesis (TTS), audio normalization, and provider capability
+discovery/routing for SintraPrime voice features. Converts audio to
+structured transcripts and text to speech artifacts — nothing more.
+
+Governing rule (shared with `voice_concierge/governed`, non-negotiable):
+
+> Voice may request and coordinate. Existing SintraPrime policy decides,
+> records, approves, executes, or refuses.
+
+This package is a **speech/data plane only**. It has no authority to decide
+whether a consequential action is permitted, execute filings, send
+messages, make payments, modify records, bypass confirmation, or bypass
+tenant isolation — all of that remains exclusively in
+`voice_concierge/governed`. See
+`artifacts/voice/SP_VOICE_002_ARCHITECTURE_BASELINE.md` for the full
+control-plane/data-plane split, and
+`artifacts/voice/SP_VOICE_002_PHASE1_CERTIFICATION.md` for what Phase 1
+implemented.
+
+## Ownership
+
+- `capabilities.py` — `SpeechCapability` enum (ASR, TTS, STREAMING_TTS,
+  LONG_FORM_TTS, MULTI_SPEAKER_TTS, SPEAKER_DIARIZATION,
+  AUDIO_NORMALIZATION, SPEAKER_PROFILE)
+- `errors.py` — typed error hierarchy (`VoiceRuntimeError` and subclasses)
+- `models.py` — provider-neutral request/response schemas
+  (`SpeechRecognitionRequest`, `StructuredTranscript`,
+  `SpeechSynthesisRequest`, `SpeechArtifact`, `AudioSource`, `TenantContext`)
+- `preflight.py` — `PreflightState`/`PreflightResult` (availability without
+  crashing on missing dependency/model/hardware)
+- `provenance.py` — `SpeechProvenance` record + `content_hash()`; designed
+  to feed the existing audit/receipt subsystem, not to compete with it
+- `registry.py` — `ProviderRegistry` (registration, duplicate rejection,
+  capability/preflight maps, priority-ordered capability lookup) +
+  `build_default_registry()`
+- `router.py` — deterministic `route()` with full routing evidence
+  (considered/rejected providers and reasons)
+- `providers/base.py` — `SpeechProvider` Protocol + `BaseSpeechProvider`
+- `providers/mock.py` — deterministic mock ASR/TTS provider (no real
+  inference)
+- `providers/legacy.py` — bounded adapter harvesting only the legacy
+  `voice/voice_engine.py::AudioBuffer` normalization math (pure Python, no
+  `voice` package import); declares `AUDIO_NORMALIZATION` only
+- `providers/browser.py` — server-side descriptor for the PR #247 browser
+  Web Speech API fallback tier; never executes browser APIs from Python
+- `audio/normalization.py`, `audio/formats.py` — pure-Python audio
+  preprocessing utilities (no `numpy`)
+- `tests/` — 54 tests covering import-dependency boundary, registry,
+  routing/fallback, mock provider, models/provenance, legacy/browser
+  provider boundaries, and no-side-effect guarantees
+
+## Local Contracts
+
+- `voice_runtime/__init__.py` and every always-available submodule
+  (everything except inside a specific provider's real-model activation
+  path) must remain importable with **no** optional heavy dependency
+  installed: no `numpy`, `torch`, `transformers`, `whisper`, `elevenlabs`,
+  `boto3`, `pyttsx3`, or `vibevoice`. Enforced by
+  `tests/test_minimal_dependency_import.py`.
+- Providers declare capabilities explicitly (`SpeechCapability` frozenset);
+  the registry/router never branch on provider identity or name.
+- `preflight()` must never raise or crash application startup — it always
+  returns a `PreflightResult`.
+- Unsupported capabilities and unavailable providers fail with typed errors
+  (`UnsupportedCapabilityError`, `ProviderUnavailableError`), never a silent
+  fallback to something unexpected.
+- This package must never import `voice.voice_api` (legacy, unauthenticated
+  mock-JWT router — classified `RETIRED_UNSAFE_LEGACY_API`) or reproduce
+  its mock bearer-token verification. Enforced by AST-based import
+  inspection in `tests/test_legacy_and_browser_providers.py`.
+- No provider in this package may perform a real network call, write a
+  file, or download a model as a side effect of registration or routing
+  (mock/legacy/browser providers are all local/deterministic). Any future
+  real provider (e.g. VibeVoice) must gate all such behavior behind an
+  explicit, separately-authorized activation path — never merely by being
+  registered.
+- This package routes NO consequential actions and never bypasses
+  `voice_concierge/governed`.
+
+## Work Guidance
+
+- Add new capabilities to `capabilities.py` conservatively; a capability
+  should represent a genuine, distinct computation class, not a
+  provider-specific feature flag.
+- New providers should subclass `BaseSpeechProvider` (or independently
+  satisfy the `SpeechProvider` Protocol) and declare only the capabilities
+  they actually implement; unimplemented `recognize()`/`synthesize()` must
+  raise `NotImplementedError`, never fabricate output.
+- Real/heavy providers (e.g. a future VibeVoice adapter) must import their
+  heavy dependencies lazily, inside methods gated by `preflight()` —
+  never at module import time. See `providers/legacy.py`'s docstring for
+  the pattern of harvesting an *algorithm* rather than importing an unsafe
+  module wholesale when adapting legacy code.
+- Do not add real provider credentials as plain dataclass fields; follow
+  the existing repository secrets-management pattern instead.
+
+## Verification
+
+- `python -m pytest voice_runtime/tests/ -q`
+- `ruff check voice_runtime/`
+- Regression: `python -m pytest voice_concierge/governed/tests/ portal/tests/test_voice_commands.py portal/tests/test_voice_concierge_browser_io.py -q`
+
+## Child DOX Index
+
+*(None — leaf modules.)*

--- a/voice_runtime/__init__.py
+++ b/voice_runtime/__init__.py
@@ -1,0 +1,39 @@
+"""
+SintraPrime Federated Speech Runtime (SP-VOICE-002)
+====================================================
+
+Speech/data-plane package: automatic speech recognition (ASR), speech
+synthesis (TTS), audio normalization, speaker-profile handling, and
+provider capability discovery/routing.
+
+Governing rule (unchanged from SP-VOICE-001, non-negotiable):
+
+    Voice may request and coordinate. Existing SintraPrime policy decides,
+    records, approves, executes, or refuses.
+
+This package is a **speech/data plane only**. It recognizes speech,
+synthesizes speech, normalizes audio, exposes provider capabilities, selects
+available providers, and produces structured transcripts / speech artifacts
+with provenance. It never decides whether a consequential action is
+permitted, never executes filings/messages/payments/record changes, never
+bypasses confirmation, and never bypasses tenant isolation. All command
+authority remains exclusively in ``voice_concierge.governed``.
+
+This package is intentionally kept free of eager imports so that importing
+``voice_runtime`` (or any of its always-available submodules: capabilities,
+models, registry, router, preflight, provenance, errors) never requires
+optional heavy dependencies such as numpy, torch, transformers, CUDA
+bindings, ffmpeg Python bindings, VibeVoice, Whisper, or any external
+provider SDK. Optional/heavy dependencies are only imported inside a
+specific provider's activation path, and only when that provider is
+actually selected for use. See ``voice_runtime/providers/`` and
+``voice_runtime/preflight.py``.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/voice_runtime/audio/__init__.py
+++ b/voice_runtime/audio/__init__.py
@@ -1,0 +1,9 @@
+"""Audio preprocessing utilities for the speech runtime.
+
+Kept free of eager heavy imports — see ``voice_runtime/audio/normalization.py``
+for the rationale (pure-Python reimplementation of legacy numpy-based logic).
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/voice_runtime/audio/formats.py
+++ b/voice_runtime/audio/formats.py
@@ -1,0 +1,32 @@
+"""Audio format/MIME helpers.
+
+Small, dependency-free helpers for reasoning about audio container/format
+strings. Real format *conversion* (e.g. via ffmpeg) is out of scope for
+Phase 1 and belongs in a lazily-loaded provider-specific path if ever
+implemented — this module only classifies/validates format identifiers.
+"""
+
+from __future__ import annotations
+
+#: MIME types the runtime recognizes as raw/uncompressed PCM containers.
+PCM_MIME_TYPES: frozenset[str] = frozenset({"audio/wav", "audio/x-wav", "audio/pcm"})
+
+#: MIME types the runtime recognizes as compressed audio containers.
+COMPRESSED_MIME_TYPES: frozenset[str] = frozenset(
+    {"audio/webm", "audio/mpeg", "audio/mp3", "audio/ogg", "audio/aac"}
+)
+
+#: All MIME types this module can classify.
+KNOWN_MIME_TYPES: frozenset[str] = PCM_MIME_TYPES | COMPRESSED_MIME_TYPES
+
+
+def is_pcm(mime_type: str) -> bool:
+    """Whether ``mime_type`` denotes a raw/uncompressed PCM container."""
+
+    return mime_type.lower() in PCM_MIME_TYPES
+
+
+def is_known_format(mime_type: str) -> bool:
+    """Whether ``mime_type`` is one this runtime recognizes at all."""
+
+    return mime_type.lower() in KNOWN_MIME_TYPES

--- a/voice_runtime/audio/normalization.py
+++ b/voice_runtime/audio/normalization.py
@@ -1,0 +1,94 @@
+"""Audio normalization utilities.
+
+Algorithms in this module are adapted from the legacy
+``voice/voice_engine.py::AudioBuffer`` and ``voice/speech_processor.py``
+modules (see ``artifacts/voice/SP_VOICE_002_COMPONENT_MATRIX.md`` for the
+full Phase-0 disposition). They are reimplemented here in pure Python
+(no ``numpy``) so that importing ``voice_runtime.audio`` never requires an
+undeclared/optional heavy dependency — this directly fixes the class of
+defect identified in the legacy modules, where ``numpy`` was imported at
+module level without being declared in ``requirements.txt``.
+
+If a caller wants numpy-accelerated versions of these same operations, that
+belongs in a provider-specific, lazily-imported code path — never here.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NormalizationResult:
+    """Outcome of a normalization/silence-detection pass."""
+
+    rms: float
+    peak: float
+    is_speech_detected: bool
+    clipped_sample_count: int
+
+
+def _iter_pcm16_samples(pcm16_bytes: bytes) -> list[float]:
+    """Decode little-endian 16-bit PCM bytes into floats in [-1.0, 1.0].
+
+    Pure-Python replacement for the numpy-based buffer handling in the
+    legacy ``AudioBuffer``. Not performance-optimized; adequate for tests
+    and small/streamed chunks. A future real-time provider may choose a
+    faster, lazily-imported implementation internally.
+    """
+
+    sample_count = len(pcm16_bytes) // 2
+    samples = []
+    for i in range(sample_count):
+        lo = pcm16_bytes[2 * i]
+        hi = pcm16_bytes[2 * i + 1]
+        value = (hi << 8) | lo
+        if value >= 32768:
+            value -= 65536
+        samples.append(value / 32768.0)
+    return samples
+
+
+def analyze_pcm16(pcm16_bytes: bytes, *, noise_floor: float = 0.02) -> NormalizationResult:
+    """Compute RMS/peak/speech-detection for a chunk of 16-bit PCM audio.
+
+    Mirrors ``voice.voice_engine.AudioBuffer.is_speech_detected`` /
+    ``get_audio_level`` behavior (RMS energy vs. a noise-floor threshold),
+    without any numpy dependency.
+    """
+
+    samples = _iter_pcm16_samples(pcm16_bytes)
+    if not samples:
+        return NormalizationResult(rms=0.0, peak=0.0, is_speech_detected=False, clipped_sample_count=0)
+
+    sum_sq = sum(s * s for s in samples)
+    rms = math.sqrt(sum_sq / len(samples))
+    peak = max(abs(s) for s in samples)
+    clipped = sum(1 for s in samples if abs(s) >= 1.0)
+
+    return NormalizationResult(
+        rms=rms,
+        peak=peak,
+        is_speech_detected=rms > noise_floor * 2,
+        clipped_sample_count=clipped,
+    )
+
+
+def clip_normalize(pcm16_bytes: bytes) -> bytes:
+    """Clip decoded samples to [-1.0, 1.0] and re-encode as 16-bit PCM.
+
+    Pure-Python equivalent of ``AudioBuffer.add_chunk``'s
+    ``np.clip(audio_chunk, -1.0, 1.0)`` normalization step.
+    """
+
+    samples = _iter_pcm16_samples(pcm16_bytes)
+    out = bytearray()
+    for s in samples:
+        clipped = max(-1.0, min(1.0, s))
+        value = round(clipped * 32767.0)
+        if value < 0:
+            value += 65536
+        out.append(value & 0xFF)
+        out.append((value >> 8) & 0xFF)
+    return bytes(out)

--- a/voice_runtime/capabilities.py
+++ b/voice_runtime/capabilities.py
@@ -9,10 +9,10 @@ touching routing logic.
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 
-class SpeechCapability(str, Enum):
+class SpeechCapability(StrEnum):
     """A single speech/audio computation capability a provider may support."""
 
     ASR = "asr"

--- a/voice_runtime/capabilities.py
+++ b/voice_runtime/capabilities.py
@@ -1,0 +1,45 @@
+"""Speech-runtime capability model.
+
+Capabilities are declared explicitly by providers instead of relying on
+name-based or type-based provider checks. The registry and router only ever
+reason about capabilities, never about specific provider identities, so new
+providers (including future VibeVoice adapters) can be added without
+touching routing logic.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class SpeechCapability(str, Enum):
+    """A single speech/audio computation capability a provider may support."""
+
+    ASR = "asr"
+    """Speech-to-text / automatic speech recognition."""
+
+    TTS = "tts"
+    """Basic text-to-speech synthesis."""
+
+    STREAMING_TTS = "streaming_tts"
+    """Low-latency, incrementally-streamed text-to-speech synthesis."""
+
+    LONG_FORM_TTS = "long_form_tts"
+    """Long-form (multi-minute) speech synthesis."""
+
+    MULTI_SPEAKER_TTS = "multi_speaker_tts"
+    """Multi-speaker / multi-voice synthesis (e.g. podcast-style scripts)."""
+
+    SPEAKER_DIARIZATION = "speaker_diarization"
+    """Identify and separate distinct speakers within a single audio stream."""
+
+    AUDIO_NORMALIZATION = "audio_normalization"
+    """Audio preprocessing: normalization, noise reduction, format conversion."""
+
+    SPEAKER_PROFILE = "speaker_profile"
+    """Enrollment/lookup of a governed speaker profile (consent-gated)."""
+
+
+#: Ordered tuple of all known capabilities, used for deterministic iteration
+#: (e.g. when reporting the full capability matrix for a provider).
+ALL_CAPABILITIES: tuple[SpeechCapability, ...] = tuple(SpeechCapability)

--- a/voice_runtime/errors.py
+++ b/voice_runtime/errors.py
@@ -1,0 +1,59 @@
+"""Typed error hierarchy for the speech runtime.
+
+All errors raised by ``voice_runtime`` public APIs derive from
+``VoiceRuntimeError`` so callers can catch the whole family, or a specific
+subtype for typed handling (e.g. distinguishing "no provider supports this
+capability" from "the provider that would support it is currently down").
+"""
+
+from __future__ import annotations
+
+from .capabilities import SpeechCapability
+
+
+class VoiceRuntimeError(Exception):
+    """Base class for all speech-runtime errors."""
+
+
+class DuplicateProviderError(VoiceRuntimeError):
+    """Raised when a provider is registered under an ID already in use."""
+
+    def __init__(self, provider_id: str) -> None:
+        self.provider_id = provider_id
+        super().__init__(f"a provider is already registered under id={provider_id!r}")
+
+
+class UnknownProviderError(VoiceRuntimeError):
+    """Raised when a provider ID is looked up but not registered."""
+
+    def __init__(self, provider_id: str) -> None:
+        self.provider_id = provider_id
+        super().__init__(f"no provider is registered under id={provider_id!r}")
+
+
+class UnsupportedCapabilityError(VoiceRuntimeError):
+    """Raised when no registered, enabled provider declares a requested capability."""
+
+    def __init__(self, capability: SpeechCapability) -> None:
+        self.capability = capability
+        super().__init__(f"no provider declares support for capability={capability.value!r}")
+
+
+class ProviderUnavailableError(VoiceRuntimeError):
+    """Raised when the only provider(s) that support a capability are unavailable."""
+
+    def __init__(self, capability: SpeechCapability, reasons: dict[str, str]) -> None:
+        self.capability = capability
+        self.reasons = dict(reasons)
+        detail = "; ".join(f"{pid}: {reason}" for pid, reason in reasons.items()) or "none registered"
+        super().__init__(
+            f"no available provider for capability={capability.value!r} ({detail})"
+        )
+
+
+class ProviderDisabledError(VoiceRuntimeError):
+    """Raised when a specific, explicitly-requested provider is disabled."""
+
+    def __init__(self, provider_id: str) -> None:
+        self.provider_id = provider_id
+        super().__init__(f"provider id={provider_id!r} is disabled")

--- a/voice_runtime/models.py
+++ b/voice_runtime/models.py
@@ -1,0 +1,121 @@
+"""Provider-neutral speech request/response schemas.
+
+These dataclasses are deliberately independent of any specific provider
+(VibeVoice, browser Web Speech API, legacy SintraPrime speech modules, or a
+future cloud provider). Providers translate to/from these shapes; nothing
+in ``voice_runtime`` outside a provider implementation should ever see a
+provider-specific type.
+
+No I/O, no heavy dependencies — pure dataclasses only.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from .provenance import SpeechProvenance
+
+
+def _new_request_id() -> str:
+    return f"vreq-{uuid.uuid4().hex}"
+
+
+@dataclass(frozen=True)
+class AudioSource:
+    """Abstraction over "where the audio bytes come from".
+
+    Exactly one of ``inline_bytes`` or ``reference`` should be set. Using a
+    reference (e.g. an artifact store key or file path recorded elsewhere)
+    lets large audio payloads be handled without holding raw bytes in every
+    layer of the call stack.
+    """
+
+    inline_bytes: bytes | None = None
+    reference: str | None = None
+    mime_type: str = "audio/wav"
+
+    def __post_init__(self) -> None:
+        if self.inline_bytes is None and self.reference is None:
+            raise ValueError("AudioSource requires either inline_bytes or reference")
+
+
+@dataclass(frozen=True)
+class TenantContext:
+    """Tenant/principal correlation metadata carried through every request.
+
+    Mirrors the tenant-isolation contract already enforced by
+    ``voice_concierge.governed`` / ``portal`` — this runtime never derives
+    tenant/principal identity itself, it only carries whatever the caller
+    (which must already be authenticated/authorized upstream) supplies.
+    """
+
+    tenant_id: str
+    principal_id: str
+    correlation_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SpeechRecognitionRequest:
+    """A provider-neutral request to transcribe audio to text."""
+
+    audio: AudioSource
+    tenant: TenantContext
+    language: str = "en"
+    hotwords: tuple[str, ...] = ()
+    request_id: str = field(default_factory=_new_request_id)
+
+
+@dataclass(frozen=True)
+class TranscriptSegment:
+    """One time-bounded segment of a structured transcript."""
+
+    text: str
+    start_seconds: float | None = None
+    end_seconds: float | None = None
+    speaker_label: str | None = None
+    confidence: float | None = None
+
+
+@dataclass(frozen=True)
+class StructuredTranscript:
+    """Provider-neutral structured transcription result."""
+
+    text: str
+    segments: tuple[TranscriptSegment, ...]
+    provider_id: str
+    model_id: str | None
+    request_id: str
+    provenance: SpeechProvenance
+    language: str = "en"
+    confidence: float | None = None
+
+
+@dataclass(frozen=True)
+class SpeechSynthesisRequest:
+    """A provider-neutral request to synthesize text to speech."""
+
+    text: str
+    tenant: TenantContext
+    voice_profile_id: str | None = None
+    language: str = "en"
+    output_format: str = "audio/wav"
+    streaming: bool = False
+    request_id: str = field(default_factory=_new_request_id)
+
+
+@dataclass(frozen=True)
+class SpeechArtifact:
+    """Provider-neutral synthesized-audio artifact with provenance."""
+
+    reference: str
+    mime_type: str
+    provider_id: str
+    model_id: str | None
+    request_id: str
+    provenance: SpeechProvenance
+    speaker_profile_id: str | None = None
+    duration_seconds: float | None = None
+    content_hash: str = ""
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))

--- a/voice_runtime/preflight.py
+++ b/voice_runtime/preflight.py
@@ -10,10 +10,10 @@ registration.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 
 
-class PreflightState(str, Enum):
+class PreflightState(StrEnum):
     """Coarse-grained availability state for a speech provider."""
 
     AVAILABLE = "available"

--- a/voice_runtime/preflight.py
+++ b/voice_runtime/preflight.py
@@ -1,0 +1,90 @@
+"""Provider/runtime preflight state model.
+
+Preflight answers "can this provider actually run right now, and if not,
+why?" without ever crashing application startup. A provider that requires a
+missing optional dependency, a missing model file, or insufficient hardware
+must report a typed, inspectable state instead of raising on import or on
+registration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class PreflightState(str, Enum):
+    """Coarse-grained availability state for a speech provider."""
+
+    AVAILABLE = "available"
+    """Provider is fully available and ready to use."""
+
+    AVAILABLE_DEGRADED = "available_degraded"
+    """Provider is usable but running in a reduced-capability/slower mode."""
+
+    DISABLED = "disabled"
+    """Provider is administratively disabled (feature-flagged off)."""
+
+    DEPENDENCY_MISSING = "dependency_missing"
+    """A required optional dependency (package) is not installed."""
+
+    MODEL_MISSING = "model_missing"
+    """A required model artifact/weights file is not present locally."""
+
+    HARDWARE_INSUFFICIENT = "hardware_insufficient"
+    """Available hardware (CPU/GPU/RAM/VRAM/disk) does not meet requirements."""
+
+    CONFIGURATION_ERROR = "configuration_error"
+    """Provider configuration is present but invalid/incomplete."""
+
+    UNSUPPORTED = "unsupported"
+    """Provider does not support the current platform/environment at all."""
+
+
+#: States in which a provider may actually be selected for routing.
+USABLE_STATES: frozenset[PreflightState] = frozenset(
+    {PreflightState.AVAILABLE, PreflightState.AVAILABLE_DEGRADED}
+)
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    """Outcome of checking whether a provider can currently be used.
+
+    ``detail`` should be a short, human-readable explanation — especially
+    important for non-``AVAILABLE`` states so operators/tests can see *why*
+    a provider was skipped without reading provider source code.
+    """
+
+    state: PreflightState
+    detail: str = ""
+    checked_fields: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def usable(self) -> bool:
+        """Whether a provider in this state may be selected for routing."""
+        return self.state in USABLE_STATES
+
+    @classmethod
+    def available(cls, detail: str = "", **checked_fields: str) -> PreflightResult:
+        return cls(PreflightState.AVAILABLE, detail=detail, checked_fields=checked_fields)
+
+    @classmethod
+    def dependency_missing(cls, dependency: str, detail: str = "") -> PreflightResult:
+        return cls(
+            PreflightState.DEPENDENCY_MISSING,
+            detail=detail or f"required dependency {dependency!r} is not installed",
+            checked_fields={"dependency": dependency},
+        )
+
+    @classmethod
+    def model_missing(cls, model_id: str, detail: str = "") -> PreflightResult:
+        return cls(
+            PreflightState.MODEL_MISSING,
+            detail=detail or f"required model {model_id!r} is not present locally",
+            checked_fields={"model_id": model_id},
+        )
+
+    @classmethod
+    def disabled(cls, detail: str = "provider is disabled by configuration") -> PreflightResult:
+        return cls(PreflightState.DISABLED, detail=detail)

--- a/voice_runtime/provenance.py
+++ b/voice_runtime/provenance.py
@@ -1,0 +1,97 @@
+"""Speech-runtime provenance record construction.
+
+This module builds provenance metadata for every ASR/TTS operation. It does
+**not** implement a competing audit ledger — it is designed so that
+existing SintraPrime receipt/audit services (e.g. the hash-chained
+``VoiceCommandEvent``/``VoiceCommandReceipt`` pattern in
+``portal/models/voice_command.py``) can consume a ``SpeechProvenance``
+record as an input when a speech operation is part of a governed voice
+command flow. No network/database I/O happens here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+
+def _new_provenance_id() -> str:
+    return f"vprov-{uuid.uuid4().hex}"
+
+
+def content_hash(data: bytes | str) -> str:
+    """Deterministic SHA-256 hex digest for provenance input/output hashing.
+
+    Accepts either raw bytes or text (encoded as UTF-8) so callers can hash
+    a transcript string or raw audio bytes with the same helper.
+    """
+
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass(frozen=True)
+class RoutingDecisionRef:
+    """A lightweight, serializable reference back to a routing decision.
+
+    Kept intentionally small (not the full ``RoutingDecision`` object) so
+    provenance records stay cheap to store/transmit; the full decision can
+    still be looked up/logged separately by request_id if needed.
+    """
+
+    requested_capability: str
+    selected_provider_id: str | None
+    considered_provider_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SpeechProvenance:
+    """Provenance metadata attached to every speech-runtime output.
+
+    Every field here is intentionally neutral/serializable (str/float/None)
+    so this can be embedded directly into a JSON payload consumed by the
+    existing audit/receipt subsystem without any speech-runtime-specific
+    deserialization logic.
+    """
+
+    provenance_id: str = field(default_factory=_new_provenance_id)
+    request_id: str = ""
+    provider_id: str = ""
+    provider_version: str = ""
+    model_id: str | None = None
+    input_hash: str = ""
+    output_hash: str | None = None
+    tenant_id: str = ""
+    principal_id: str = ""
+    correlation_id: str | None = None
+    routing: RoutingDecisionRef | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize to a plain dict suitable for existing audit/receipt storage."""
+
+        return {
+            "provenance_id": self.provenance_id,
+            "request_id": self.request_id,
+            "provider_id": self.provider_id,
+            "provider_version": self.provider_version,
+            "model_id": self.model_id,
+            "input_hash": self.input_hash,
+            "output_hash": self.output_hash,
+            "tenant_id": self.tenant_id,
+            "principal_id": self.principal_id,
+            "correlation_id": self.correlation_id,
+            "routing": (
+                {
+                    "requested_capability": self.routing.requested_capability,
+                    "selected_provider_id": self.routing.selected_provider_id,
+                    "considered_provider_ids": list(self.routing.considered_provider_ids),
+                }
+                if self.routing is not None
+                else None
+            ),
+            "created_at": self.created_at.isoformat(),
+        }

--- a/voice_runtime/providers/__init__.py
+++ b/voice_runtime/providers/__init__.py
@@ -1,0 +1,13 @@
+"""Speech-runtime provider implementations.
+
+This subpackage is intentionally free of eager heavy imports at the package
+level — importing ``voice_runtime.providers`` must not require numpy,
+torch, transformers, or any external provider SDK. Individual provider
+modules (e.g. a future VibeVoice adapter) may depend on heavy packages
+internally, but only import them lazily, inside methods that run after
+``preflight()`` has confirmed availability.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/voice_runtime/providers/base.py
+++ b/voice_runtime/providers/base.py
@@ -1,0 +1,102 @@
+"""Provider protocol/base interface for speech-runtime providers.
+
+Providers are the only place a heavy/optional dependency (numpy, torch,
+transformers, an external provider SDK, etc.) may ever be imported, and even
+then, only inside methods/activation paths that run after this module's
+lightweight ``preflight()`` has been consulted — never at module import
+time.
+
+Not every provider must implement every capability. A provider that does
+not support a capability should simply not declare it in ``capabilities``;
+the registry/router enforce that unsupported capabilities are never routed
+to a provider that doesn't declare them.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from ..capabilities import SpeechCapability
+from ..models import (
+    SpeechArtifact,
+    SpeechRecognitionRequest,
+    SpeechSynthesisRequest,
+    StructuredTranscript,
+)
+from ..preflight import PreflightResult
+
+
+@runtime_checkable
+class SpeechProvider(Protocol):
+    """Structural protocol every speech-runtime provider must satisfy.
+
+    Implementations are plain classes (no required base class) — anything
+    satisfying this shape can be registered. This keeps provider
+    implementations decoupled from ``voice_runtime`` internals and makes it
+    trivial to add a future VibeVoice/cloud adapter without inheritance
+    coupling.
+    """
+
+    @property
+    def provider_id(self) -> str:
+        """Stable, unique identifier for this provider (e.g. ``"mock"``)."""
+        ...
+
+    @property
+    def provider_version(self) -> str:
+        """Provider implementation version string (not a model version)."""
+        ...
+
+    @property
+    def capabilities(self) -> frozenset[SpeechCapability]:
+        """Capabilities this provider declares support for."""
+        ...
+
+    def preflight(self) -> PreflightResult:
+        """Check current availability without raising or crashing the app."""
+        ...
+
+    def health(self) -> str:
+        """Short human-readable health/status summary for diagnostics."""
+        ...
+
+    def recognize(self, request: SpeechRecognitionRequest) -> StructuredTranscript:
+        """Perform ASR. Only called if ``SpeechCapability.ASR`` is declared."""
+        ...
+
+    def synthesize(self, request: SpeechSynthesisRequest) -> SpeechArtifact:
+        """Perform TTS. Only called if a TTS-family capability is declared."""
+        ...
+
+
+class BaseSpeechProvider:
+    """Convenience base class implementing the boilerplate of the protocol.
+
+    Providers may subclass this instead of implementing ``SpeechProvider``
+    from scratch, but subclassing is never required — the registry accepts
+    anything structurally satisfying ``SpeechProvider``.
+    """
+
+    provider_id: str = "base"
+    provider_version: str = "0.0.0"
+    _capabilities: frozenset[SpeechCapability] = frozenset()
+
+    @property
+    def capabilities(self) -> frozenset[SpeechCapability]:
+        return self._capabilities
+
+    def preflight(self) -> PreflightResult:
+        return PreflightResult.available()
+
+    def health(self) -> str:
+        return "ok"
+
+    def recognize(self, request: SpeechRecognitionRequest) -> StructuredTranscript:
+        raise NotImplementedError(
+            f"provider {self.provider_id!r} does not implement recognize()"
+        )
+
+    def synthesize(self, request: SpeechSynthesisRequest) -> SpeechArtifact:
+        raise NotImplementedError(
+            f"provider {self.provider_id!r} does not implement synthesize()"
+        )

--- a/voice_runtime/providers/browser.py
+++ b/voice_runtime/providers/browser.py
@@ -1,0 +1,63 @@
+"""Browser/native speech provider descriptor.
+
+Represents the existing PR #247 client-side speech capability
+(``web/src/pages/VoiceConcierge.tsx``'s use of the browser
+``SpeechRecognition``/``speechSynthesis`` Web Speech APIs) as an entry in
+the server-side provider/capability model, **without** attempting to
+execute browser APIs from Python. There is no way (and no need) for this
+process to actually invoke a user's browser speech engine — this class
+exists purely so the registry/router can:
+
+- advertise browser/native ASR+TTS as a routing fallback tier;
+- correctly report that its real availability is client-side dependent
+  (i.e. this server-side descriptor can never promise ``AVAILABLE``, only
+  that the *capability exists in the frontend* — actual availability is
+  determined by the user's browser at runtime, which this process cannot
+  observe).
+
+Calling ``recognize()``/``synthesize()`` on this provider is a programming
+error server-side (the browser performs these operations directly and
+submits the resulting transcript, or plays the resulting speech, without
+ever round-tripping through this Python provider) — both raise
+``NotImplementedError`` with a clear explanation, inherited from
+``BaseSpeechProvider``.
+
+This module intentionally does not modify or interact with
+``web/src/pages/VoiceConcierge.tsx`` or ``web/src/api/voice.ts`` in any way.
+"""
+
+from __future__ import annotations
+
+from ..capabilities import SpeechCapability
+from ..preflight import PreflightResult, PreflightState
+from .base import BaseSpeechProvider
+
+
+class BrowserSpeechProvider(BaseSpeechProvider):
+    """Descriptor for the existing browser Web Speech API fallback tier.
+
+    Declares ASR + TTS capabilities (matching what PR #247 already ships:
+    ``SpeechRecognition``/``webkitSpeechRecognition`` for input,
+    ``window.speechSynthesis`` for output) purely for routing/reporting
+    purposes. This is always the last-resort fallback tier in routing
+    priority — see ``voice_runtime/router.py``.
+    """
+
+    provider_id = "browser_native"
+    provider_version = "1.0.0"
+    _capabilities = frozenset({SpeechCapability.ASR, SpeechCapability.TTS})
+
+    def preflight(self) -> PreflightResult:
+        # Server-side, this provider can never be positively confirmed
+        # "available" — actual availability depends on the requesting
+        # user's browser/client, which this process cannot observe. It is
+        # reported as AVAILABLE_DEGRADED to signal "usable as a fallback,
+        # but not verifiable/guaranteed from the server."
+        return PreflightResult(
+            state=PreflightState.AVAILABLE_DEGRADED,
+            detail="client-side dependent; actual availability determined by requesting browser",
+            checked_fields={"execution_location": "client"},
+        )
+
+    def health(self) -> str:
+        return "descriptor only — real execution happens client-side in the browser (PR #247)"

--- a/voice_runtime/providers/legacy.py
+++ b/voice_runtime/providers/legacy.py
@@ -1,0 +1,76 @@
+"""Bounded legacy adapter provider.
+
+Harvests only the specific, reusable algorithms identified in Phase 0
+(``artifacts/voice/SP_VOICE_002_COMPONENT_MATRIX.md``) from the legacy
+``voice/voice_engine.py`` (``AudioBuffer`` noise-floor/silence-detection
+logic) and ``voice/speech_processor.py`` (primary→fallback→offline provider
+chain *shape*). It does **not** import the legacy ``voice`` package at all
+— none of ``voice/__init__.py``'s lazy exports, none of its module-level
+``numpy`` dependency, none of its provider stubs, and critically, none of
+its unsafe pieces:
+
+- no legacy credentials (``voice.speech_processor.SpeechConfig`` raw API-key
+  fields are not reproduced here);
+- no legacy mock authentication (``voice.voice_api.verify_token`` is never
+  imported, referenced, or reachable through this provider);
+- no legacy direct action/execution behavior (this provider only performs
+  audio normalization; it declares no ASR/TTS capability and cannot be
+  routed to for those operations).
+
+This provider exists to demonstrate that the *algorithm*, not the
+*module*, is what gets reused — matching the Phase-0 finding that the
+legacy authority model (raw credentials on dataclasses, no capability
+declarations, no governance hooks, global ``logging.basicConfig()`` side
+effects) is incompatible with this runtime's architecture even though some
+of its underlying math is worth keeping.
+"""
+
+from __future__ import annotations
+
+from ..audio.normalization import analyze_pcm16, clip_normalize
+from ..capabilities import SpeechCapability
+from ..preflight import PreflightResult
+from .base import BaseSpeechProvider
+
+
+class LegacyAudioAdapterProvider(BaseSpeechProvider):
+    """Audio-normalization-only provider harvested from legacy ``voice/``.
+
+    Declares **only** ``AUDIO_NORMALIZATION`` — it must never be routed to
+    for ASR or TTS, and inherits ``recognize()``/``synthesize()`` from
+    ``BaseSpeechProvider`` which raise ``NotImplementedError`` if ever
+    invoked in error.
+    """
+
+    provider_id = "legacy_audio_adapter"
+    provider_version = "1.0.0"
+    _capabilities = frozenset({SpeechCapability.AUDIO_NORMALIZATION})
+
+    def __init__(self, *, noise_floor: float = 0.02) -> None:
+        self._noise_floor = noise_floor
+
+    def preflight(self) -> PreflightResult:
+        # Pure-Python implementation — no optional dependency required.
+        return PreflightResult.available(
+            detail="pure-Python reimplementation of legacy AudioBuffer logic; no numpy required"
+        )
+
+    def health(self) -> str:
+        return "ok (pure-Python legacy-derived normalization only)"
+
+    def analyze(self, pcm16_bytes: bytes):
+        """Expose the harvested RMS/silence-detection analysis directly.
+
+        Not part of the ``SpeechProvider`` protocol (it isn't ASR/TTS); this
+        is a capability-specific helper method callers may use when they
+        specifically need audio-normalization behavior, mirroring how
+        ``voice_runtime.router`` would select this provider for the
+        ``AUDIO_NORMALIZATION`` capability.
+        """
+
+        return analyze_pcm16(pcm16_bytes, noise_floor=self._noise_floor)
+
+    def normalize(self, pcm16_bytes: bytes) -> bytes:
+        """Expose the harvested clip/normalize step directly."""
+
+        return clip_normalize(pcm16_bytes)

--- a/voice_runtime/providers/mock.py
+++ b/voice_runtime/providers/mock.py
@@ -1,0 +1,113 @@
+"""Deterministic mock speech provider.
+
+Used for tests and as a safe, always-available default provider. Performs
+no real audio inference, no model loading, and no network/filesystem I/O —
+every ASR result is a fixed transcript derived deterministically from the
+request, and every TTS result is a synthetic artifact reference with a
+content hash computed from the input text (not real audio bytes).
+"""
+
+from __future__ import annotations
+
+from ..capabilities import SpeechCapability
+from ..models import (
+    SpeechArtifact,
+    SpeechRecognitionRequest,
+    SpeechSynthesisRequest,
+    StructuredTranscript,
+    TranscriptSegment,
+)
+from ..preflight import PreflightResult
+from ..provenance import SpeechProvenance, content_hash
+from .base import BaseSpeechProvider
+
+
+class MockSpeechProvider(BaseSpeechProvider):
+    """Always-available, deterministic mock ASR/TTS provider.
+
+    Every output is clearly a simulation: transcripts are literal fixed
+    strings, and synthesized "audio" is represented by a ``mock://``
+    reference with no underlying audio bytes ever produced.
+    """
+
+    provider_id = "mock"
+    provider_version = "1.0.0"
+    _capabilities = frozenset(
+        {
+            SpeechCapability.ASR,
+            SpeechCapability.TTS,
+            SpeechCapability.STREAMING_TTS,
+            SpeechCapability.AUDIO_NORMALIZATION,
+        }
+    )
+
+    def __init__(self, *, enabled: bool = True) -> None:
+        self._enabled = enabled
+
+    def preflight(self) -> PreflightResult:
+        if not self._enabled:
+            return PreflightResult.disabled()
+        return PreflightResult.available(detail="mock provider requires no dependencies")
+
+    def health(self) -> str:
+        return "ok (mock, no real inference)"
+
+    def recognize(self, request: SpeechRecognitionRequest) -> StructuredTranscript:
+        source_desc = request.audio.reference or "<inline-bytes>"
+        text = f"[mock transcript for {source_desc}]"
+        input_bytes = request.audio.inline_bytes or source_desc.encode("utf-8")
+        provenance = SpeechProvenance(
+            request_id=request.request_id,
+            provider_id=self.provider_id,
+            provider_version=self.provider_version,
+            model_id="mock-asr-v1",
+            input_hash=content_hash(input_bytes),
+            output_hash=content_hash(text),
+            tenant_id=request.tenant.tenant_id,
+            principal_id=request.tenant.principal_id,
+            correlation_id=request.tenant.correlation_id,
+        )
+        return StructuredTranscript(
+            text=text,
+            segments=(
+                TranscriptSegment(
+                    text=text,
+                    start_seconds=0.0,
+                    end_seconds=1.0,
+                    speaker_label="speaker-1",
+                    confidence=1.0,
+                ),
+            ),
+            provider_id=self.provider_id,
+            model_id="mock-asr-v1",
+            request_id=request.request_id,
+            provenance=provenance,
+            language=request.language,
+            confidence=1.0,
+        )
+
+    def synthesize(self, request: SpeechSynthesisRequest) -> SpeechArtifact:
+        reference = f"mock://synthesized/{request.request_id}"
+        output_hash = content_hash(request.text)
+        provenance = SpeechProvenance(
+            request_id=request.request_id,
+            provider_id=self.provider_id,
+            provider_version=self.provider_version,
+            model_id="mock-tts-v1",
+            input_hash=content_hash(request.text),
+            output_hash=output_hash,
+            tenant_id=request.tenant.tenant_id,
+            principal_id=request.tenant.principal_id,
+            correlation_id=request.tenant.correlation_id,
+        )
+        return SpeechArtifact(
+            reference=reference,
+            mime_type=request.output_format,
+            provider_id=self.provider_id,
+            model_id="mock-tts-v1",
+            request_id=request.request_id,
+            provenance=provenance,
+            speaker_profile_id=request.voice_profile_id,
+            duration_seconds=0.0,
+            content_hash=output_hash,
+        )

--- a/voice_runtime/providers/vibevoice_realtime.py
+++ b/voice_runtime/providers/vibevoice_realtime.py
@@ -1,0 +1,325 @@
+"""VibeVoice-Realtime-0.5B local TTS provider (SP-VOICE-002 Phase 2A).
+
+Official Microsoft model only: ``microsoft/VibeVoice-Realtime-0.5B``
+(https://huggingface.co/microsoft/VibeVoice-Realtime-0.5B). No community
+fork is referenced or supported by this module.
+
+Phase 2A-1 status: this adapter implements the full production-grade
+provider contract (capability declaration, preflight, lazy model loading,
+provenance, resource limits, cancellation support) but this repository has
+**not** installed the required ML dependencies (``torch``, ``transformers``,
+``accelerate``, etc.) or downloaded the model weights on the current
+development host, which has no CUDA-capable GPU and limited free disk. Real
+end-to-end inference has therefore not yet been certified here — see
+``artifacts/voice/SP_VOICE_002_PHASE2A_CERTIFICATION.md`` for the full
+preflight record and rationale. This host is classified:
+
+    AVAILABLE_DEGRADED_CANDIDATE — REAL INFERENCE NOT YET CERTIFIED
+
+The adapter is designed so that, once dependencies are installed and model
+weights are made available locally (a separate, explicit setup action —
+never an automatic runtime download), ``preflight()`` will correctly
+transition from ``DEPENDENCY_MISSING``/``MODEL_MISSING`` to
+``AVAILABLE``/``AVAILABLE_DEGRADED`` without any code change here, and
+``synthesize()`` will perform real local inference.
+
+Hard requirements enforced by this module:
+
+- No heavy dependency (``torch``, ``transformers``, ``accelerate``,
+  ``diffusers``, ``numba``, ``librosa``, etc.) is imported at module import
+  time — only inside ``preflight()`` (wrapped in ``try/except ImportError``)
+  and inside the lazy ``_ensure_model_loaded()`` path used by
+  ``synthesize()``.
+- The model is **never** downloaded automatically. ``local_files_only`` is
+  always passed to the underlying loader, and if the configured model path
+  does not exist locally, ``preflight()`` reports ``MODEL_MISSING`` rather
+  than attempting network access. Model acquisition is an explicit,
+  separate setup/admin operation outside this runtime.
+- Single-speaker only (matches the officially documented capability of this
+  specific model — no voice cloning, no multi-speaker synthesis, no custom
+  voice prompting; Microsoft's own docs state voice prompts for this model
+  are embedded, not user-suppliable, "to mitigate deepfake risks").
+- CPU-only environments are reported ``AVAILABLE_DEGRADED`` (usable, but not
+  meeting the model's ~200-300ms "real-time" latency target, which
+  Microsoft verifies only on NVIDIA T4 / Apple M-series hardware).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from ..capabilities import SpeechCapability
+from ..models import SpeechArtifact, SpeechRecognitionRequest, SpeechSynthesisRequest
+from ..preflight import PreflightResult, PreflightState
+from .base import BaseSpeechProvider
+
+#: Official Microsoft model identifier. No other model/fork is supported.
+OFFICIAL_MODEL_ID = "microsoft/VibeVoice-Realtime-0.5B"
+
+#: Minimum input length below which Microsoft's own docs note reduced
+#: stability ("very short inputs ... three words or fewer").
+_MIN_STABLE_WORD_COUNT = 4
+
+#: Default per-request synthesis timeout (seconds) — an explicit resource
+#: limit so a hung/slow model call cannot block the broader runtime
+#: indefinitely.
+DEFAULT_SYNTHESIS_TIMEOUT_SECONDS = 30.0
+
+
+class SynthesisCancelledError(RuntimeError):
+    """Raised when a synthesis request is cancelled via ``cancel_event``."""
+
+
+class SynthesisTimeoutError(RuntimeError):
+    """Raised when synthesis exceeds ``timeout_seconds``."""
+
+
+@dataclass(frozen=True)
+class VibeVoiceRealtimeConfig:
+    """Configuration for :class:`VibeVoiceRealtimeProvider`.
+
+    ``model_path`` should point at a local directory containing the
+    downloaded model weights (obtained via a separate, explicit setup step
+    — e.g. ``huggingface-cli download microsoft/VibeVoice-Realtime-0.5B``).
+    If unset, the provider looks for a local Hugging Face cache entry for
+    :data:`OFFICIAL_MODEL_ID` but **never** triggers a network download;
+    absence is reported as ``MODEL_MISSING``, not fetched.
+    """
+
+    model_path: str | None = None
+    device_preference: str = "auto"  # "auto" | "cpu" | "cuda"
+    timeout_seconds: float = DEFAULT_SYNTHESIS_TIMEOUT_SECONDS
+
+
+class VibeVoiceRealtimeProvider(BaseSpeechProvider):
+    """Official VibeVoice-Realtime-0.5B single-speaker streaming TTS provider."""
+
+    provider_id = "vibevoice_realtime_0_5b"
+    provider_version = "1.0.0"
+    _capabilities = frozenset({SpeechCapability.TTS, SpeechCapability.STREAMING_TTS})
+
+    def __init__(self, config: VibeVoiceRealtimeConfig | None = None) -> None:
+        self._config = config or VibeVoiceRealtimeConfig()
+        self._model = None  # lazily populated by _ensure_model_loaded()
+        self._tokenizer = None
+        self._resolved_device: str | None = None
+
+    # -- Preflight ---------------------------------------------------------
+
+    def preflight(self) -> PreflightResult:
+        dependency_check = self._check_dependencies()
+        if dependency_check is not None:
+            return dependency_check
+
+        model_check = self._check_model_available()
+        if model_check is not None:
+            return model_check
+
+        hardware_state, hardware_detail = self._check_hardware()
+        return PreflightResult(
+            state=hardware_state,
+            detail=hardware_detail,
+            checked_fields={
+                "model_id": OFFICIAL_MODEL_ID,
+                "model_path": self._config.model_path or "(hf-cache-lookup)",
+            },
+        )
+
+    def _check_dependencies(self) -> PreflightResult | None:
+        """Return a non-None PreflightResult iff a required dependency is missing.
+
+        Imports are performed here, inside preflight, never at module
+        level — this is the only place ``torch``/``transformers`` are
+        referenced before an actual synthesis call.
+        """
+
+        for dependency in ("torch", "transformers"):
+            try:
+                __import__(dependency)
+            except ImportError:
+                return PreflightResult.dependency_missing(dependency)
+        return None
+
+    def _check_model_available(self) -> PreflightResult | None:
+        """Return a non-None PreflightResult iff model weights are not local.
+
+        Never triggers a network request. If ``model_path`` is configured,
+        checks only the local filesystem. Otherwise, checks for a
+        Hugging Face cache hit for the official model id via
+        ``huggingface_hub``'s local-only cache scan (also no network call).
+        """
+
+        if self._config.model_path:
+            if not os.path.isdir(self._config.model_path):
+                return PreflightResult.model_missing(
+                    OFFICIAL_MODEL_ID,
+                    detail=f"configured model_path {self._config.model_path!r} does not exist locally",
+                )
+            return None
+
+        try:
+            from huggingface_hub import scan_cache_dir
+        except ImportError:
+            # huggingface_hub not installed is itself a dependency gap, but
+            # we do not fail synthesis-blocking preflight on it alone if a
+            # model_path was otherwise provided (handled above); with no
+            # model_path and no huggingface_hub, we cannot verify a local
+            # cache exists, so report MODEL_MISSING rather than guessing.
+            return PreflightResult.model_missing(
+                OFFICIAL_MODEL_ID,
+                detail=(
+                    "no model_path configured and huggingface_hub is not installed "
+                    "to check the local cache; configure model_path explicitly"
+                ),
+            )
+
+        try:
+            cache_info = scan_cache_dir()
+        except Exception as exc:  # pragma: no cover - defensive, cache dir issues
+            return PreflightResult.model_missing(
+                OFFICIAL_MODEL_ID,
+                detail=f"could not scan local Hugging Face cache: {exc}",
+            )
+
+        for repo in cache_info.repos:
+            if repo.repo_id == OFFICIAL_MODEL_ID:
+                return None
+
+        return PreflightResult.model_missing(
+            OFFICIAL_MODEL_ID,
+            detail=(
+                f"{OFFICIAL_MODEL_ID!r} not found in local Hugging Face cache; "
+                "model acquisition is a separate, explicit setup step, never "
+                "an automatic runtime download"
+            ),
+        )
+
+    def _check_hardware(self) -> tuple[PreflightState, str]:
+        """Classify hardware as AVAILABLE (CUDA) or AVAILABLE_DEGRADED (CPU-only).
+
+        Never raises; both branches are considered usable by this provider,
+        matching Microsoft's own guidance that CPU-only devices "may
+        require further testing and speed optimizations" rather than being
+        entirely unsupported.
+        """
+
+        try:
+            import torch
+        except ImportError:  # pragma: no cover - guarded by _check_dependencies
+            return PreflightState.DEPENDENCY_MISSING, "torch not importable"
+
+        if self._config.device_preference == "cpu":
+            self._resolved_device = "cpu"
+            return (
+                PreflightState.AVAILABLE_DEGRADED,
+                "device_preference explicitly set to cpu; real-time latency target not guaranteed",
+            )
+
+        if torch.cuda.is_available():
+            self._resolved_device = "cuda"
+            return PreflightState.AVAILABLE, "CUDA-capable GPU detected"
+
+        self._resolved_device = "cpu"
+        return (
+            PreflightState.AVAILABLE_DEGRADED,
+            (
+                "no CUDA-capable GPU detected; Microsoft verifies ~200-300ms "
+                "real-time latency only on NVIDIA T4 / Apple M-series hardware, "
+                "CPU-only inference is usable but not real-time-certified"
+            ),
+        )
+
+    def health(self) -> str:
+        result = self.preflight()
+        return f"{result.state.value}: {result.detail}"
+
+    # -- ASR (not supported) -------------------------------------------------
+
+    def recognize(self, request: SpeechRecognitionRequest):
+        raise NotImplementedError(
+            f"provider {self.provider_id!r} does not support ASR "
+            "(VibeVoice-Realtime-0.5B is a TTS-only model)"
+        )
+
+    # -- TTS -----------------------------------------------------------------
+
+    def synthesize(
+        self,
+        request: SpeechSynthesisRequest,
+        *,
+        cancel_event: object | None = None,
+    ) -> SpeechArtifact:
+        """Synthesize ``request.text`` using the local VibeVoice-Realtime model.
+
+        Raises ``RuntimeError`` (via preflight-derived typed errors upstream
+        in the router) if dependencies/model are unavailable —
+        callers should route through ``voice_runtime.router.route()``,
+        which already checks ``preflight()`` before ever calling this
+        method. Direct callers of this method should still check
+        ``preflight()`` themselves first.
+
+        ``cancel_event`` (optional): any object exposing ``.is_set()`` (e.g.
+        ``threading.Event``) may be polled between synthesis steps to
+        support cooperative cancellation; if set before/during synthesis,
+        raises ``SynthesisCancelledError`` instead of returning a partial
+        artifact.
+        """
+
+        word_count = len(request.text.split())
+        if word_count == 0:
+            raise ValueError("synthesis text must not be empty")
+        if word_count <= _MIN_STABLE_WORD_COUNT:
+            # Not an error — Microsoft's docs note reduced stability, not
+            # failure, for very short inputs. Proceed, but this is
+            # documented for callers who may want to pad short prompts.
+            pass
+
+        if cancel_event is not None and getattr(cancel_event, "is_set", lambda: False)():
+            raise SynthesisCancelledError("synthesis cancelled before model invocation")
+
+        self._ensure_model_loaded()
+
+        # Actual model inference is intentionally not implemented in
+        # Phase 2A-1: no dependencies are installed and no weights are
+        # present on this host (see module docstring / Phase 2A
+        # certification report). `_ensure_model_loaded()` above will raise
+        # a clear RuntimeError before reaching this point on a host where
+        # preflight() is not AVAILABLE/AVAILABLE_DEGRADED, so this code is
+        # only reachable once real dependencies + weights are present.
+        raise NotImplementedError(
+            "real VibeVoice-Realtime-0.5B inference is not yet certified on this "
+            "host (Phase 2A-1 scope: adapter + preflight only, no dependencies "
+            "installed / no weights downloaded here). See "
+            "artifacts/voice/SP_VOICE_002_PHASE2A_CERTIFICATION.md."
+        )
+
+    def _ensure_model_loaded(self) -> None:
+        """Lazily load the model/tokenizer on first use. No network access.
+
+        Raises ``RuntimeError`` with a preflight-derived message if
+        dependencies or weights are unavailable, rather than silently
+        attempting (and failing at) a network download.
+        """
+
+        if self._model is not None:
+            return
+
+        preflight = self.preflight()
+        if not preflight.usable:
+            raise RuntimeError(
+                f"cannot load {OFFICIAL_MODEL_ID}: preflight={preflight.state.value} "
+                f"({preflight.detail})"
+            )
+
+        # Real model loading is deferred to a future certification pass
+        # once dependencies are installed and weights are downloaded via
+        # an explicit setup step (never here). This method intentionally
+        # stops before importing torch/transformers model classes further
+        # than the dependency-existence check already performed by
+        # preflight(), keeping this file free of any real load attempt
+        # until Phase 2A-2 hardware/environment is available.
+        raise RuntimeError(
+            "model loading not yet implemented in Phase 2A-1 (adapter + "
+            "preflight certification only)"
+        )

--- a/voice_runtime/registry.py
+++ b/voice_runtime/registry.py
@@ -1,0 +1,156 @@
+"""Deterministic provider registry.
+
+Registers providers by ID, rejects ambiguous duplicate registrations,
+exposes capability maps and availability/preflight state, and supports
+retrieving providers by capability in a deterministic (insertion-ordered,
+then explicit-priority-ordered) manner. Performs no autonomous discovery —
+providers must be explicitly constructed and registered by calling code.
+No plugin auto-install of any kind.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .capabilities import SpeechCapability
+from .errors import DuplicateProviderError, UnknownProviderError
+from .preflight import PreflightResult
+from .providers.base import SpeechProvider
+
+
+@dataclass
+class _RegistryEntry:
+    provider: SpeechProvider
+    priority: int
+    enabled: bool = True
+
+
+class ProviderRegistry:
+    """Holds a deterministic set of registered speech providers."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, _RegistryEntry] = {}
+        self._registration_order: list[str] = []
+
+    def register(
+        self,
+        provider: SpeechProvider,
+        *,
+        priority: int = 100,
+        enabled: bool = True,
+    ) -> None:
+        """Register ``provider``. Raises ``DuplicateProviderError`` on ID collision.
+
+        Lower ``priority`` values are preferred during routing (priority 0
+        is tried before priority 100). Providers registered with the same
+        priority are considered in registration order, which keeps routing
+        fully deterministic.
+        """
+
+        provider_id = provider.provider_id
+        if provider_id in self._entries:
+            raise DuplicateProviderError(provider_id)
+        self._entries[provider_id] = _RegistryEntry(provider=provider, priority=priority, enabled=enabled)
+        self._registration_order.append(provider_id)
+
+    def unregister(self, provider_id: str) -> None:
+        """Remove a provider from the registry. No-op if not registered."""
+
+        self._entries.pop(provider_id, None)
+        if provider_id in self._registration_order:
+            self._registration_order.remove(provider_id)
+
+    def set_enabled(self, provider_id: str, enabled: bool) -> None:
+        """Enable or disable a registered provider without unregistering it."""
+
+        entry = self._require_entry(provider_id)
+        entry.enabled = enabled
+
+    def get(self, provider_id: str) -> SpeechProvider:
+        """Retrieve a provider by ID. Raises ``UnknownProviderError`` if absent."""
+
+        return self._require_entry(provider_id).provider
+
+    def is_enabled(self, provider_id: str) -> bool:
+        return self._require_entry(provider_id).enabled
+
+    def provider_ids(self) -> tuple[str, ...]:
+        """All registered provider IDs, in registration order."""
+
+        return tuple(self._registration_order)
+
+    def capability_map(self) -> dict[str, frozenset[SpeechCapability]]:
+        """Provider ID -> declared capabilities, for every registered provider."""
+
+        return {
+            provider_id: entry.provider.capabilities
+            for provider_id, entry in self._entries.items()
+        }
+
+    def preflight_map(self) -> dict[str, PreflightResult]:
+        """Provider ID -> current preflight result, for every registered provider.
+
+        Disabled providers are reported with a synthetic ``DISABLED`` result
+        regardless of what the provider's own ``preflight()`` would say,
+        since administrative disablement always takes precedence.
+        """
+
+        results: dict[str, PreflightResult] = {}
+        for provider_id, entry in self._entries.items():
+            if not entry.enabled:
+                results[provider_id] = PreflightResult.disabled()
+            else:
+                results[provider_id] = entry.provider.preflight()
+        return results
+
+    def providers_for_capability(self, capability: SpeechCapability) -> tuple[SpeechProvider, ...]:
+        """All *registered* providers declaring ``capability``, in priority order.
+
+        Includes disabled/unavailable providers — callers wanting only
+        currently-usable providers should combine this with
+        ``preflight_map()``. Kept separate so routing evidence can report
+        *why* a provider was rejected (disabled vs. unavailable vs. simply
+        not supporting the capability).
+        """
+
+        matching = [
+            (entry.priority, order_index, entry.provider)
+            for order_index, provider_id in enumerate(self._registration_order)
+            for entry in (self._entries[provider_id],)
+            if capability in entry.provider.capabilities
+        ]
+        matching.sort(key=lambda item: (item[0], item[1]))
+        return tuple(provider for _, _, provider in matching)
+
+    def _require_entry(self, provider_id: str) -> _RegistryEntry:
+        entry = self._entries.get(provider_id)
+        if entry is None:
+            raise UnknownProviderError(provider_id)
+        return entry
+
+
+def build_default_registry() -> ProviderRegistry:
+    """Construct the default registry with the Phase-1 provider set.
+
+    Priority order (lower = preferred): mock (0, dev/test default) is not
+    included by default in production-shaped registries — callers assemble
+    their own registry explicitly. This helper exists mainly for tests and
+    documentation of the intended default priority ordering:
+
+        1. local/native providers (none in Phase 1 — reserved for a future
+           VibeVoice adapter, priority ~10)
+        2. legacy audio adapter (AUDIO_NORMALIZATION only, priority ~50)
+        3. browser/native fallback (ASR/TTS, priority ~90)
+        4. mock (priority ~100, always last so it never masks a real
+           provider in an environment where both are registered)
+    """
+
+    from .providers.browser import BrowserSpeechProvider
+    from .providers.legacy import LegacyAudioAdapterProvider
+    from .providers.mock import MockSpeechProvider
+
+    registry = ProviderRegistry()
+    registry.register(LegacyAudioAdapterProvider(), priority=50)
+    registry.register(BrowserSpeechProvider(), priority=90)
+    registry.register(MockSpeechProvider(), priority=100)
+    return registry

--- a/voice_runtime/router.py
+++ b/voice_runtime/router.py
@@ -1,0 +1,119 @@
+"""Deterministic speech-capability router.
+
+Routes a requested capability to the highest-priority currently-usable
+registered provider, and returns full routing evidence (considered
+providers, rejected providers with reasons, and the final selection) rather
+than silently picking a provider. Routing never downgrades a governance
+requirement — this module only ever selects among providers that already
+declared the requested capability; it has no authority of its own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .capabilities import SpeechCapability
+from .errors import ProviderUnavailableError, UnsupportedCapabilityError
+from .provenance import RoutingDecisionRef
+from .providers.base import SpeechProvider
+from .registry import ProviderRegistry
+
+
+@dataclass(frozen=True)
+class RejectedProvider:
+    """A provider that was considered but not selected, and why."""
+
+    provider_id: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    """Full evidence for a single routing decision."""
+
+    requested_capability: SpeechCapability
+    selected_provider_id: str | None
+    considered_provider_ids: tuple[str, ...]
+    rejected: tuple[RejectedProvider, ...] = field(default_factory=tuple)
+
+    def to_provenance_ref(self) -> RoutingDecisionRef:
+        return RoutingDecisionRef(
+            requested_capability=self.requested_capability.value,
+            selected_provider_id=self.selected_provider_id,
+            considered_provider_ids=self.considered_provider_ids,
+        )
+
+
+def route(
+    registry: ProviderRegistry,
+    capability: SpeechCapability,
+    *,
+    preferred_provider_id: str | None = None,
+) -> tuple[SpeechProvider, RoutingDecision]:
+    """Select a provider for ``capability``.
+
+    Raises ``UnsupportedCapabilityError`` if no *registered* provider
+    declares the capability at all, or ``ProviderUnavailableError`` if one
+    or more providers declare it but none are currently usable (disabled,
+    dependency missing, etc.) — these are distinct, typed outcomes so
+    callers can react differently (e.g. "this will never work here" vs.
+    "this might work once a dependency is installed").
+
+    If ``preferred_provider_id`` is given and that provider both declares
+    the capability and is currently usable, it is selected regardless of
+    its configured priority (an explicit caller preference always wins over
+    the default priority ordering).
+    """
+
+    candidates = registry.providers_for_capability(capability)
+    if not candidates:
+        raise UnsupportedCapabilityError(capability)
+
+    preflights = registry.preflight_map()
+    considered: list[str] = []
+    rejected: list[RejectedProvider] = []
+
+    if preferred_provider_id is not None:
+        preferred = next((p for p in candidates if p.provider_id == preferred_provider_id), None)
+        if preferred is not None:
+            considered.append(preferred.provider_id)
+            result = preflights.get(preferred.provider_id)
+            if result is not None and result.usable:
+                decision = RoutingDecision(
+                    requested_capability=capability,
+                    selected_provider_id=preferred.provider_id,
+                    considered_provider_ids=tuple(considered),
+                    rejected=tuple(rejected),
+                )
+                return preferred, decision
+            rejected.append(
+                RejectedProvider(
+                    provider_id=preferred.provider_id,
+                    reason=f"explicitly preferred but unusable: {result.state.value if result else 'unknown'}",
+                )
+            )
+
+    for provider in candidates:
+        if provider.provider_id in considered:
+            continue
+        considered.append(provider.provider_id)
+        result = preflights.get(provider.provider_id)
+        if result is not None and result.usable:
+            decision = RoutingDecision(
+                requested_capability=capability,
+                selected_provider_id=provider.provider_id,
+                considered_provider_ids=tuple(considered),
+                rejected=tuple(rejected),
+            )
+            return provider, decision
+        rejected.append(
+            RejectedProvider(
+                provider_id=provider.provider_id,
+                reason=(result.detail or result.state.value) if result else "no preflight result",
+            )
+        )
+
+    raise ProviderUnavailableError(
+        capability,
+        {r.provider_id: r.reason for r in rejected},
+    )

--- a/voice_runtime/tests/__init__.py
+++ b/voice_runtime/tests/__init__.py
@@ -1,0 +1,1 @@
+"""voice_runtime test package."""

--- a/voice_runtime/tests/test_audio_normalization.py
+++ b/voice_runtime/tests/test_audio_normalization.py
@@ -1,0 +1,50 @@
+"""Tests for the pure-Python audio normalization utilities."""
+
+from __future__ import annotations
+
+from voice_runtime.audio.formats import is_known_format, is_pcm
+from voice_runtime.audio.normalization import analyze_pcm16, clip_normalize
+
+
+def _pcm16_tone(amplitude: float, samples: int) -> bytes:
+    import struct
+
+    value = int(amplitude * 32767)
+    return struct.pack(f"<{samples}h", *([value] * samples))
+
+
+def test_analyze_pcm16_silence():
+    result = analyze_pcm16(bytes(200))
+    assert result.rms == 0.0
+    assert result.peak == 0.0
+    assert not result.is_speech_detected
+    assert result.clipped_sample_count == 0
+
+
+def test_analyze_pcm16_detects_speech_above_noise_floor():
+    tone = _pcm16_tone(0.5, 100)
+    result = analyze_pcm16(tone, noise_floor=0.02)
+    assert result.is_speech_detected
+    assert result.rms > 0.02
+
+
+def test_analyze_pcm16_empty_bytes():
+    result = analyze_pcm16(b"")
+    assert result.rms == 0.0
+    assert not result.is_speech_detected
+
+
+def test_clip_normalize_preserves_length():
+    tone = _pcm16_tone(0.8, 50)
+    normalized = clip_normalize(tone)
+    assert len(normalized) == len(tone)
+
+
+def test_is_pcm_recognizes_wav():
+    assert is_pcm("audio/wav")
+    assert not is_pcm("audio/webm")
+
+
+def test_is_known_format():
+    assert is_known_format("audio/webm")
+    assert not is_known_format("audio/does-not-exist")

--- a/voice_runtime/tests/test_legacy_and_browser_providers.py
+++ b/voice_runtime/tests/test_legacy_and_browser_providers.py
@@ -1,0 +1,104 @@
+"""Tests for the legacy audio adapter and browser provider descriptors,
+and for the security-boundary guarantees identified in Phase 0.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from voice_runtime.capabilities import SpeechCapability
+from voice_runtime.preflight import PreflightState
+from voice_runtime.providers.browser import BrowserSpeechProvider
+from voice_runtime.providers.legacy import LegacyAudioAdapterProvider
+
+
+def test_legacy_adapter_declares_only_audio_normalization():
+    provider = LegacyAudioAdapterProvider()
+    assert provider.capabilities == frozenset({SpeechCapability.AUDIO_NORMALIZATION})
+    # Must never declare command/execution-adjacent or ASR/TTS capability —
+    # this provider is normalization-only by design (Phase 0 finding).
+    assert SpeechCapability.ASR not in provider.capabilities
+    assert SpeechCapability.TTS not in provider.capabilities
+
+
+def test_legacy_adapter_recognize_and_synthesize_not_implemented():
+    """The legacy adapter cannot be routed to for ASR/TTS, and even if
+    called directly in error, must not silently succeed or expose any
+    legacy execution/authentication behavior."""
+
+    provider = LegacyAudioAdapterProvider()
+    with pytest.raises(NotImplementedError):
+        provider.recognize(None)  # type: ignore[arg-type]
+    with pytest.raises(NotImplementedError):
+        provider.synthesize(None)  # type: ignore[arg-type]
+
+
+def test_legacy_adapter_preflight_available_without_numpy():
+    provider = LegacyAudioAdapterProvider()
+    result = provider.preflight()
+    assert result.usable
+    assert True  # numpy presence is unrelated to this pure-Python provider; see minimal-dependency import test
+
+
+def test_legacy_adapter_analyze_and_normalize_pure_python():
+    provider = LegacyAudioAdapterProvider()
+    silence = bytes(200)  # 100 16-bit samples of silence
+    result = provider.analyze(silence)
+    assert result.rms == 0.0
+    assert not result.is_speech_detected
+
+    normalized = provider.normalize(silence)
+    assert len(normalized) == len(silence)
+
+
+def test_no_import_of_legacy_voice_api_module():
+    """Hard guarantee: nothing in voice_runtime imports the unsafe legacy
+    voice.voice_api module (hardcoded mock bearer-token verification)."""
+
+    assert "voice.voice_api" not in sys.modules
+
+    # Confirm no voice_runtime source file actually imports it (docstrings
+    # are allowed to *mention* it, by name, to document that it is
+    # deliberately excluded — only real import statements are forbidden).
+    import ast
+    import inspect
+
+    import voice_runtime.providers.legacy as legacy_module
+
+    source = inspect.getsource(legacy_module)
+    tree = ast.parse(source)
+    import_targets: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            import_targets.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            import_targets.append(node.module)
+
+    assert not any("voice_api" in target for target in import_targets)
+    assert not any(target == "voice" or target.startswith("voice.") for target in import_targets)
+
+
+def test_browser_provider_declares_asr_and_tts():
+    provider = BrowserSpeechProvider()
+    assert provider.capabilities == frozenset({SpeechCapability.ASR, SpeechCapability.TTS})
+
+
+def test_browser_provider_preflight_reports_client_side_dependent():
+    provider = BrowserSpeechProvider()
+    result = provider.preflight()
+    assert result.state == PreflightState.AVAILABLE_DEGRADED
+    assert result.usable  # usable as a fallback tier
+    assert result.checked_fields.get("execution_location") == "client"
+
+
+def test_browser_provider_recognize_and_synthesize_not_implemented():
+    """Real execution happens client-side (PR #247); calling these methods
+    server-side must never silently return fabricated results."""
+
+    provider = BrowserSpeechProvider()
+    with pytest.raises(NotImplementedError):
+        provider.recognize(None)  # type: ignore[arg-type]
+    with pytest.raises(NotImplementedError):
+        provider.synthesize(None)  # type: ignore[arg-type]

--- a/voice_runtime/tests/test_minimal_dependency_import.py
+++ b/voice_runtime/tests/test_minimal_dependency_import.py
@@ -1,0 +1,74 @@
+"""Regression test: importing voice_runtime never requires optional heavy deps.
+
+This directly guards against the class of defect diagnosed earlier in this
+session for the legacy ``voice/`` package (module-level ``numpy`` imports
+absent from ``requirements.txt``, which broke PR #245's exact-head CI when
+an unrelated test path eagerly triggered them).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+_HEAVY_MODULE_PREFIXES = (
+    "numpy",
+    "torch",
+    "transformers",
+    "whisper",
+    "elevenlabs",
+    "boto3",
+    "pyttsx3",
+    "vibevoice",
+)
+
+_VOICE_RUNTIME_MODULES = (
+    "voice_runtime",
+    "voice_runtime.capabilities",
+    "voice_runtime.errors",
+    "voice_runtime.preflight",
+    "voice_runtime.provenance",
+    "voice_runtime.models",
+    "voice_runtime.registry",
+    "voice_runtime.router",
+    "voice_runtime.providers",
+    "voice_runtime.providers.base",
+    "voice_runtime.providers.mock",
+    "voice_runtime.providers.legacy",
+    "voice_runtime.providers.browser",
+    "voice_runtime.audio",
+    "voice_runtime.audio.normalization",
+    "voice_runtime.audio.formats",
+)
+
+
+def _purge_voice_runtime_from_sys_modules() -> None:
+    for name in list(sys.modules):
+        if name == "voice_runtime" or name.startswith("voice_runtime."):
+            del sys.modules[name]
+
+
+def test_core_modules_import_without_heavy_dependencies():
+    """Freshly importing every always-available voice_runtime module must
+    never cause a heavy/optional dependency to appear in sys.modules."""
+
+    _purge_voice_runtime_from_sys_modules()
+    before = {name for name in sys.modules if name.split(".")[0] in {p.split(".")[0] for p in _HEAVY_MODULE_PREFIXES}}
+
+    for module_name in _VOICE_RUNTIME_MODULES:
+        importlib.import_module(module_name)
+
+    after = {name for name in sys.modules if name.split(".")[0] in {p.split(".")[0] for p in _HEAVY_MODULE_PREFIXES}}
+
+    newly_imported = after - before
+    assert not newly_imported, (
+        f"importing voice_runtime modules unexpectedly pulled in heavy "
+        f"dependencies: {sorted(newly_imported)}"
+    )
+
+
+def test_voice_runtime_package_has_version():
+    import voice_runtime
+
+    assert isinstance(voice_runtime.__version__, str)
+    assert voice_runtime.__version__

--- a/voice_runtime/tests/test_minimal_dependency_import.py
+++ b/voice_runtime/tests/test_minimal_dependency_import.py
@@ -36,6 +36,7 @@ _VOICE_RUNTIME_MODULES = (
     "voice_runtime.providers.mock",
     "voice_runtime.providers.legacy",
     "voice_runtime.providers.browser",
+    "voice_runtime.providers.vibevoice_realtime",
     "voice_runtime.audio",
     "voice_runtime.audio.normalization",
     "voice_runtime.audio.formats",

--- a/voice_runtime/tests/test_mock_provider.py
+++ b/voice_runtime/tests/test_mock_provider.py
@@ -1,0 +1,90 @@
+"""Tests for the mock provider's ASR/TTS behavior, models, and provenance."""
+
+from __future__ import annotations
+
+from voice_runtime.models import (
+    AudioSource,
+    SpeechRecognitionRequest,
+    SpeechSynthesisRequest,
+    TenantContext,
+)
+from voice_runtime.preflight import PreflightState
+from voice_runtime.provenance import content_hash
+from voice_runtime.providers.mock import MockSpeechProvider
+
+
+def _tenant() -> TenantContext:
+    return TenantContext(tenant_id="tenant-1", principal_id="user-1", correlation_id="corr-1")
+
+
+def test_mock_provider_preflight_available():
+    provider = MockSpeechProvider()
+    result = provider.preflight()
+    assert result.state == PreflightState.AVAILABLE
+    assert result.usable
+
+
+def test_mock_provider_disabled_preflight():
+    provider = MockSpeechProvider(enabled=False)
+    result = provider.preflight()
+    assert result.state == PreflightState.DISABLED
+    assert not result.usable
+
+
+def test_mock_recognize_produces_structured_transcript():
+    provider = MockSpeechProvider()
+    request = SpeechRecognitionRequest(
+        audio=AudioSource(reference="artifact://some-audio.wav"),
+        tenant=_tenant(),
+    )
+
+    transcript = provider.recognize(request)
+
+    assert transcript.text
+    assert transcript.provider_id == "mock"
+    assert transcript.request_id == request.request_id
+    assert len(transcript.segments) == 1
+    assert transcript.provenance.tenant_id == "tenant-1"
+    assert transcript.provenance.principal_id == "user-1"
+    assert transcript.provenance.correlation_id == "corr-1"
+    assert transcript.provenance.provider_id == "mock"
+    assert transcript.provenance.input_hash == content_hash("artifact://some-audio.wav")
+    assert transcript.provenance.output_hash == content_hash(transcript.text)
+
+
+def test_mock_recognize_with_inline_bytes():
+    provider = MockSpeechProvider()
+    request = SpeechRecognitionRequest(
+        audio=AudioSource(inline_bytes=b"\x00\x01\x02\x03"),
+        tenant=_tenant(),
+    )
+
+    transcript = provider.recognize(request)
+    assert transcript.provenance.input_hash == content_hash(b"\x00\x01\x02\x03")
+
+
+def test_mock_synthesize_produces_speech_artifact():
+    provider = MockSpeechProvider()
+    request = SpeechSynthesisRequest(text="hello world", tenant=_tenant(), voice_profile_id="voice-a")
+
+    artifact = provider.synthesize(request)
+
+    assert artifact.reference.startswith("mock://")
+    assert artifact.provider_id == "mock"
+    assert artifact.request_id == request.request_id
+    assert artifact.speaker_profile_id == "voice-a"
+    assert artifact.content_hash == content_hash("hello world")
+    assert artifact.provenance.output_hash == artifact.content_hash
+
+
+def test_mock_provider_no_real_audio_bytes_produced():
+    """The mock provider must never produce real synthesized audio bytes —
+    only a reference string, confirming no real inference occurs."""
+
+    provider = MockSpeechProvider()
+    request = SpeechSynthesisRequest(text="hello", tenant=_tenant())
+
+    artifact = provider.synthesize(request)
+
+    assert artifact.reference == f"mock://synthesized/{request.request_id}"
+    assert artifact.duration_seconds == 0.0

--- a/voice_runtime/tests/test_models_and_provenance.py
+++ b/voice_runtime/tests/test_models_and_provenance.py
@@ -1,0 +1,94 @@
+"""Tests for provider-neutral models and provenance/content-hash determinism."""
+
+from __future__ import annotations
+
+from voice_runtime.models import (
+    AudioSource,
+    SpeechArtifact,
+    StructuredTranscript,
+    TenantContext,
+    TranscriptSegment,
+)
+from voice_runtime.provenance import SpeechProvenance, content_hash
+
+
+def test_content_hash_deterministic_for_same_input():
+    assert content_hash("hello") == content_hash("hello")
+    assert content_hash(b"hello") == content_hash("hello")
+
+
+def test_content_hash_differs_for_different_input():
+    assert content_hash("hello") != content_hash("world")
+
+
+def test_audio_source_requires_bytes_or_reference():
+    import pytest
+
+    with pytest.raises(ValueError, match="AudioSource requires"):
+        AudioSource()
+
+
+def test_audio_source_accepts_reference_only():
+    source = AudioSource(reference="artifact://x.wav")
+    assert source.inline_bytes is None
+
+
+def test_structured_transcript_roundtrip_fields():
+    provenance = SpeechProvenance(
+        request_id="vreq-1",
+        provider_id="mock",
+        provider_version="1.0.0",
+        input_hash=content_hash("audio"),
+        tenant_id="tenant-1",
+        principal_id="user-1",
+    )
+    transcript = StructuredTranscript(
+        text="hello",
+        segments=(TranscriptSegment(text="hello", confidence=0.9),),
+        provider_id="mock",
+        model_id="mock-asr-v1",
+        request_id="vreq-1",
+        provenance=provenance,
+    )
+    assert transcript.text == "hello"
+    assert transcript.segments[0].confidence == 0.9
+    assert transcript.provenance.provider_id == "mock"
+
+
+def test_speech_artifact_provenance_serializes_to_dict():
+    provenance = SpeechProvenance(
+        request_id="vreq-2",
+        provider_id="mock",
+        provider_version="1.0.0",
+        tenant_id="tenant-1",
+        principal_id="user-1",
+        correlation_id="corr-9",
+    )
+    artifact = SpeechArtifact(
+        reference="mock://x",
+        mime_type="audio/wav",
+        provider_id="mock",
+        model_id="mock-tts-v1",
+        request_id="vreq-2",
+        provenance=provenance,
+        content_hash=content_hash("hello"),
+    )
+
+    payload = artifact.provenance.to_dict()
+    assert payload["request_id"] == "vreq-2"
+    assert payload["tenant_id"] == "tenant-1"
+    assert payload["correlation_id"] == "corr-9"
+    assert "created_at" in payload
+
+
+def test_tenant_context_is_immutable():
+    import dataclasses
+
+    tenant = TenantContext(tenant_id="t1", principal_id="p1")
+    assert dataclasses.is_dataclass(tenant)
+    try:
+        tenant.tenant_id = "other"  # type: ignore[misc]
+        raised = False
+    except dataclasses.FrozenInstanceError:
+        raised = True
+    assert raised

--- a/voice_runtime/tests/test_no_side_effects.py
+++ b/voice_runtime/tests/test_no_side_effects.py
@@ -1,0 +1,70 @@
+"""Tests asserting voice_runtime performs no external side effects and does
+not regress the existing PR #247 browser voice frontend.
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+from voice_runtime.capabilities import SpeechCapability
+from voice_runtime.models import AudioSource, SpeechRecognitionRequest, TenantContext
+from voice_runtime.providers.mock import MockSpeechProvider
+from voice_runtime.registry import build_default_registry
+from voice_runtime.router import route
+
+
+class _NetworkAttemptError(RuntimeError):
+    pass
+
+
+def _blocked_socket(*_args, **_kwargs):
+    raise _NetworkAttemptError("voice_runtime attempted a real network connection")
+
+
+def test_mock_asr_flow_makes_no_network_calls(monkeypatch):
+    monkeypatch.setattr(socket.socket, "connect", _blocked_socket)
+
+    provider = MockSpeechProvider()
+    request = SpeechRecognitionRequest(
+        audio=AudioSource(reference="artifact://audio.wav"),
+        tenant=TenantContext(tenant_id="t1", principal_id="p1"),
+    )
+
+    transcript = provider.recognize(request)
+    assert transcript.text  # completed without raising _NetworkAttemptError
+
+
+def test_default_registry_routing_makes_no_network_calls(monkeypatch):
+    monkeypatch.setattr(socket.socket, "connect", _blocked_socket)
+
+    registry = build_default_registry()
+    provider, _decision = route(registry, SpeechCapability.AUDIO_NORMALIZATION)
+    assert provider.provider_id == "legacy_audio_adapter"
+
+
+def test_no_filesystem_model_downloads(tmp_path):
+    """Building the default registry and routing must not write any files
+    (no model download / cache population)."""
+
+    before = set(Path(tmp_path).iterdir())
+    registry = build_default_registry()
+    route(registry, SpeechCapability.ASR)
+    after = set(Path(tmp_path).iterdir())
+    assert before == after
+
+
+def test_voice_concierge_frontend_browser_speech_api_present():
+    """Guard against accidentally regressing PR #247's browser speech I/O
+    while building the server-side provider descriptor for it."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    frontend_file = repo_root / "web" / "src" / "pages" / "VoiceConcierge.tsx"
+    if not frontend_file.exists():
+        pytest.skip("web/ frontend not present in this checkout")
+
+    content = frontend_file.read_text(encoding="utf-8")
+    assert "SpeechRecognition" in content
+    assert "speechSynthesis" in content

--- a/voice_runtime/tests/test_preflight.py
+++ b/voice_runtime/tests/test_preflight.py
@@ -1,0 +1,42 @@
+"""Tests for the preflight state model itself."""
+
+from __future__ import annotations
+
+from voice_runtime.preflight import PreflightResult, PreflightState
+
+
+def test_available_is_usable():
+    result = PreflightResult.available()
+    assert result.usable
+
+
+def test_dependency_missing_is_not_usable():
+    result = PreflightResult.dependency_missing("torch")
+    assert not result.usable
+    assert result.state == PreflightState.DEPENDENCY_MISSING
+    assert "torch" in result.detail
+
+
+def test_model_missing_is_not_usable():
+    result = PreflightResult.model_missing("vibevoice-1.5b")
+    assert not result.usable
+    assert result.state == PreflightState.MODEL_MISSING
+
+
+def test_disabled_is_not_usable():
+    result = PreflightResult.disabled()
+    assert not result.usable
+    assert result.state == PreflightState.DISABLED
+
+
+def test_degraded_is_still_usable():
+    result = PreflightResult(state=PreflightState.AVAILABLE_DEGRADED, detail="slow path")
+    assert result.usable
+
+
+def test_preflight_result_is_frozen():
+    import dataclasses
+
+    result = PreflightResult.available()
+    with __import__("pytest").raises(dataclasses.FrozenInstanceError):
+        result.state = PreflightState.DISABLED  # type: ignore[misc]

--- a/voice_runtime/tests/test_registry.py
+++ b/voice_runtime/tests/test_registry.py
@@ -1,0 +1,86 @@
+"""Tests for voice_runtime.registry.ProviderRegistry."""
+
+from __future__ import annotations
+
+import pytest
+
+from voice_runtime.capabilities import SpeechCapability
+from voice_runtime.errors import DuplicateProviderError, UnknownProviderError
+from voice_runtime.preflight import PreflightResult
+from voice_runtime.providers.base import BaseSpeechProvider
+from voice_runtime.providers.mock import MockSpeechProvider
+from voice_runtime.registry import ProviderRegistry, build_default_registry
+
+
+class _StubProvider(BaseSpeechProvider):
+    provider_id = "stub"
+    provider_version = "1.0.0"
+    _capabilities = frozenset({SpeechCapability.ASR})
+
+
+def test_register_and_get():
+    registry = ProviderRegistry()
+    provider = MockSpeechProvider()
+    registry.register(provider)
+
+    assert registry.get("mock") is provider
+    assert registry.provider_ids() == ("mock",)
+
+
+def test_duplicate_registration_rejected():
+    registry = ProviderRegistry()
+    registry.register(MockSpeechProvider())
+
+    with pytest.raises(DuplicateProviderError):
+        registry.register(MockSpeechProvider())
+
+
+def test_unknown_provider_lookup_raises():
+    registry = ProviderRegistry()
+
+    with pytest.raises(UnknownProviderError):
+        registry.get("does-not-exist")
+
+
+def test_capability_map_reports_all_providers():
+    registry = ProviderRegistry()
+    registry.register(MockSpeechProvider())
+    registry.register(_StubProvider())
+
+    capability_map = registry.capability_map()
+    assert capability_map["mock"] >= {SpeechCapability.ASR, SpeechCapability.TTS}
+    assert capability_map["stub"] == {SpeechCapability.ASR}
+
+
+def test_providers_for_capability_deterministic_priority_order():
+    registry = ProviderRegistry()
+    registry.register(_StubProvider(), priority=50)
+    registry.register(MockSpeechProvider(), priority=10)
+
+    providers = registry.providers_for_capability(SpeechCapability.ASR)
+    assert [p.provider_id for p in providers] == ["mock", "stub"]
+
+
+def test_disabled_provider_reported_in_preflight_map():
+    registry = ProviderRegistry()
+    registry.register(MockSpeechProvider(), enabled=False)
+
+    preflight = registry.preflight_map()["mock"]
+    assert preflight.state == PreflightResult.disabled().state
+    assert not preflight.usable
+
+
+def test_set_enabled_toggles_state():
+    registry = ProviderRegistry()
+    registry.register(MockSpeechProvider())
+    assert registry.is_enabled("mock")
+
+    registry.set_enabled("mock", False)
+    assert not registry.is_enabled("mock")
+    assert not registry.preflight_map()["mock"].usable
+
+
+def test_build_default_registry_has_expected_providers():
+    registry = build_default_registry()
+
+    assert set(registry.provider_ids()) == {"legacy_audio_adapter", "browser_native", "mock"}

--- a/voice_runtime/tests/test_router.py
+++ b/voice_runtime/tests/test_router.py
@@ -1,0 +1,103 @@
+"""Tests for voice_runtime.router deterministic routing/fallback behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+from voice_runtime.capabilities import SpeechCapability
+from voice_runtime.errors import ProviderUnavailableError, UnsupportedCapabilityError
+from voice_runtime.preflight import PreflightResult
+from voice_runtime.providers.base import BaseSpeechProvider
+from voice_runtime.providers.mock import MockSpeechProvider
+from voice_runtime.registry import ProviderRegistry
+from voice_runtime.router import route
+
+
+class _AlwaysUnavailableProvider(BaseSpeechProvider):
+    provider_id = "always_unavailable"
+    provider_version = "1.0.0"
+    _capabilities = frozenset({SpeechCapability.ASR})
+
+    def preflight(self) -> PreflightResult:
+        return PreflightResult.dependency_missing("some-optional-package")
+
+
+def test_route_selects_only_candidate():
+    registry = ProviderRegistry()
+    registry.register(MockSpeechProvider())
+
+    provider, decision = route(registry, SpeechCapability.ASR)
+
+    assert provider.provider_id == "mock"
+    assert decision.selected_provider_id == "mock"
+    assert decision.requested_capability == SpeechCapability.ASR
+    assert decision.considered_provider_ids == ("mock",)
+    assert decision.rejected == ()
+
+
+def test_route_falls_back_past_unavailable_provider():
+    registry = ProviderRegistry()
+    registry.register(_AlwaysUnavailableProvider(), priority=10)
+    registry.register(MockSpeechProvider(), priority=100)
+
+    provider, decision = route(registry, SpeechCapability.ASR)
+
+    assert provider.provider_id == "mock"
+    assert decision.considered_provider_ids == ("always_unavailable", "mock")
+    assert len(decision.rejected) == 1
+    assert decision.rejected[0].provider_id == "always_unavailable"
+    assert "some-optional-package" in decision.rejected[0].reason
+
+
+def test_route_unsupported_capability_raises_typed_error():
+    registry = ProviderRegistry()
+    registry.register(MockSpeechProvider())
+
+    with pytest.raises(UnsupportedCapabilityError) as exc_info:
+        route(registry, SpeechCapability.SPEAKER_DIARIZATION)
+
+    assert exc_info.value.capability == SpeechCapability.SPEAKER_DIARIZATION
+
+
+def test_route_all_providers_unavailable_raises_typed_error():
+    registry = ProviderRegistry()
+    registry.register(_AlwaysUnavailableProvider())
+
+    with pytest.raises(ProviderUnavailableError) as exc_info:
+        route(registry, SpeechCapability.ASR)
+
+    assert exc_info.value.capability == SpeechCapability.ASR
+    assert "always_unavailable" in exc_info.value.reasons
+
+
+def test_route_disabled_provider_is_skipped():
+    registry = ProviderRegistry()
+    registry.register(MockSpeechProvider(), enabled=False)
+
+    with pytest.raises(ProviderUnavailableError):
+        route(registry, SpeechCapability.ASR)
+
+
+def test_route_honors_explicit_preferred_provider():
+    registry = ProviderRegistry()
+    registry.register(_AlwaysUnavailableProvider(), priority=1)
+    mock = MockSpeechProvider()
+    registry.register(mock, priority=100)
+
+    provider, decision = route(registry, SpeechCapability.ASR, preferred_provider_id="mock")
+
+    assert provider is mock
+    assert decision.selected_provider_id == "mock"
+
+
+def test_route_preferred_provider_unusable_falls_back():
+    registry = ProviderRegistry()
+    registry.register(_AlwaysUnavailableProvider(), priority=1)
+    registry.register(MockSpeechProvider(), priority=100)
+
+    provider, decision = route(
+        registry, SpeechCapability.ASR, preferred_provider_id="always_unavailable"
+    )
+
+    assert provider.provider_id == "mock"
+    assert any(r.provider_id == "always_unavailable" for r in decision.rejected)

--- a/voice_runtime/tests/test_vibevoice_realtime_provider.py
+++ b/voice_runtime/tests/test_vibevoice_realtime_provider.py
@@ -1,0 +1,238 @@
+"""Tests for the VibeVoice-Realtime-0.5B provider adapter (Phase 2A-1).
+
+This host has neither ``torch``/``transformers`` installed nor any model
+weights downloaded (see ``artifacts/voice/SP_VOICE_002_PHASE2A_CERTIFICATION.md``).
+These tests therefore certify the *adapter/preflight logic*, not real
+inference. Where hardware-branch logic (CUDA vs. CPU-only) needs to be
+exercised, a minimal fake ``torch`` module is injected into ``sys.modules``
+for the duration of the test only — this is not a real PyTorch install and
+performs no computation; it exists purely to test our own branching logic
+against both possible ``torch.cuda.is_available()`` outcomes.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from voice_runtime.capabilities import SpeechCapability
+from voice_runtime.models import SpeechSynthesisRequest, TenantContext
+from voice_runtime.preflight import PreflightState
+from voice_runtime.providers.vibevoice_realtime import (
+    OFFICIAL_MODEL_ID,
+    SynthesisCancelledError,
+    VibeVoiceRealtimeConfig,
+    VibeVoiceRealtimeProvider,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_torch_transformers_modules():
+    """Ensure a clean sys.modules state around fake-module injection tests."""
+
+    saved = {
+        name: sys.modules.pop(name, None)
+        for name in ("torch", "transformers", "huggingface_hub")
+    }
+    yield
+    for name, module in saved.items():
+        sys.modules.pop(name, None)
+        if module is not None:
+            sys.modules[name] = module
+
+
+def _install_fake_torch(cuda_available: bool) -> None:
+    fake_torch = types.ModuleType("torch")
+    fake_cuda = types.SimpleNamespace(is_available=lambda: cuda_available)
+    fake_torch.cuda = fake_cuda  # type: ignore[attr-defined]
+    sys.modules["torch"] = fake_torch
+
+
+def _install_fake_transformers() -> None:
+    sys.modules["transformers"] = types.ModuleType("transformers")
+
+
+def test_module_import_does_not_require_torch_or_transformers():
+    """Importing the provider module itself must not require torch/transformers
+    (they are only imported lazily, inside preflight()/_ensure_model_loaded())."""
+
+    assert "torch" not in sys.modules
+    assert "transformers" not in sys.modules
+
+    import importlib
+
+    module = importlib.import_module("voice_runtime.providers.vibevoice_realtime")
+    assert module.OFFICIAL_MODEL_ID == "microsoft/VibeVoice-Realtime-0.5B"
+    assert "torch" not in sys.modules
+    assert "transformers" not in sys.modules
+
+
+def test_official_model_id_is_correct():
+    assert OFFICIAL_MODEL_ID == "microsoft/VibeVoice-Realtime-0.5B"
+
+
+def test_provider_declares_tts_capabilities_only():
+    provider = VibeVoiceRealtimeProvider()
+    assert provider.capabilities == frozenset(
+        {SpeechCapability.TTS, SpeechCapability.STREAMING_TTS}
+    )
+    assert SpeechCapability.ASR not in provider.capabilities
+    assert SpeechCapability.MULTI_SPEAKER_TTS not in provider.capabilities
+    assert SpeechCapability.SPEAKER_PROFILE not in provider.capabilities
+
+
+def test_preflight_reports_dependency_missing_without_torch():
+    """On this host (no torch/transformers installed), preflight must
+    report DEPENDENCY_MISSING, not crash or silently claim availability."""
+
+    provider = VibeVoiceRealtimeProvider()
+    result = provider.preflight()
+    assert result.state == PreflightState.DEPENDENCY_MISSING
+    assert not result.usable
+    assert "torch" in result.detail or "transformers" in result.detail
+
+
+def test_preflight_reports_transformers_missing_when_only_torch_present():
+    _install_fake_torch(cuda_available=False)
+    # transformers deliberately not installed
+
+    provider = VibeVoiceRealtimeProvider()
+    result = provider.preflight()
+    assert result.state == PreflightState.DEPENDENCY_MISSING
+    assert "transformers" in result.detail
+
+
+def test_preflight_reports_model_missing_with_nonexistent_model_path(tmp_path):
+    _install_fake_torch(cuda_available=False)
+    _install_fake_transformers()
+
+    missing_path = str(tmp_path / "does-not-exist")
+    provider = VibeVoiceRealtimeProvider(VibeVoiceRealtimeConfig(model_path=missing_path))
+
+    result = provider.preflight()
+    assert result.state == PreflightState.MODEL_MISSING
+    assert not result.usable
+    assert "does not exist locally" in result.detail
+
+
+def test_preflight_reports_model_available_with_real_local_path(tmp_path):
+    _install_fake_torch(cuda_available=False)
+    _install_fake_transformers()
+
+    model_dir = tmp_path / "vibevoice-realtime-0.5b"
+    model_dir.mkdir()
+    provider = VibeVoiceRealtimeProvider(VibeVoiceRealtimeConfig(model_path=str(model_dir)))
+
+    result = provider.preflight()
+    # Dependencies present (fake) + model path exists -> hardware branch
+    # decides AVAILABLE vs AVAILABLE_DEGRADED; either way must be usable.
+    assert result.usable
+    assert result.state in (PreflightState.AVAILABLE, PreflightState.AVAILABLE_DEGRADED)
+
+
+def test_preflight_cpu_only_reports_available_degraded(tmp_path):
+    _install_fake_torch(cuda_available=False)
+    _install_fake_transformers()
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    provider = VibeVoiceRealtimeProvider(VibeVoiceRealtimeConfig(model_path=str(model_dir)))
+
+    result = provider.preflight()
+    assert result.state == PreflightState.AVAILABLE_DEGRADED
+    assert result.usable
+    assert "real-time" in result.detail.lower() or "cuda" in result.detail.lower()
+
+
+def test_preflight_cuda_available_reports_available(tmp_path):
+    _install_fake_torch(cuda_available=True)
+    _install_fake_transformers()
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    provider = VibeVoiceRealtimeProvider(VibeVoiceRealtimeConfig(model_path=str(model_dir)))
+
+    result = provider.preflight()
+    assert result.state == PreflightState.AVAILABLE
+
+
+def test_preflight_explicit_cpu_preference_forces_degraded_even_with_cuda(tmp_path):
+    _install_fake_torch(cuda_available=True)
+    _install_fake_transformers()
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    provider = VibeVoiceRealtimeProvider(
+        VibeVoiceRealtimeConfig(model_path=str(model_dir), device_preference="cpu")
+    )
+
+    result = provider.preflight()
+    assert result.state == PreflightState.AVAILABLE_DEGRADED
+
+
+def test_recognize_not_supported():
+    provider = VibeVoiceRealtimeProvider()
+    with pytest.raises(NotImplementedError):
+        provider.recognize(None)  # type: ignore[arg-type]
+
+
+def test_synthesize_raises_when_dependencies_missing():
+    """On this (real, unmodified) host, dependencies genuinely are absent —
+    synthesize() must fail loudly and clearly, never silently fabricate a
+    result or attempt a network download."""
+
+    provider = VibeVoiceRealtimeProvider()
+    request = SpeechSynthesisRequest(
+        text="SintraPrime local voice runtime certification test.",
+        tenant=TenantContext(tenant_id="t1", principal_id="p1"),
+    )
+
+    with pytest.raises(RuntimeError):
+        provider.synthesize(request)
+
+
+def test_synthesize_rejects_empty_text():
+    provider = VibeVoiceRealtimeProvider()
+    request = SpeechSynthesisRequest(text="", tenant=TenantContext(tenant_id="t1", principal_id="p1"))
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        provider.synthesize(request)
+
+
+def test_synthesize_honors_cancel_event_before_invocation():
+    class _AlreadyCancelled:
+        def is_set(self) -> bool:
+            return True
+
+    provider = VibeVoiceRealtimeProvider()
+    request = SpeechSynthesisRequest(
+        text="SintraPrime local voice runtime certification test.",
+        tenant=TenantContext(tenant_id="t1", principal_id="p1"),
+    )
+
+    with pytest.raises(SynthesisCancelledError):
+        provider.synthesize(request, cancel_event=_AlreadyCancelled())
+
+
+def test_no_model_download_attempted_without_local_files():
+    """Never-download guarantee: with no model_path and no huggingface_hub
+    cache hit, preflight must report MODEL_MISSING, never attempt network
+    access to fetch the model."""
+
+    _install_fake_torch(cuda_available=False)
+    _install_fake_transformers()
+    # huggingface_hub deliberately absent -> falls back to explicit
+    # "configure model_path" guidance rather than guessing/downloading.
+
+    provider = VibeVoiceRealtimeProvider()  # no model_path configured
+    result = provider.preflight()
+    assert result.state == PreflightState.MODEL_MISSING
+    assert not result.usable
+
+
+def test_health_reports_preflight_summary():
+    provider = VibeVoiceRealtimeProvider()
+    health = provider.health()
+    assert PreflightState.DEPENDENCY_MISSING.value in health


### PR DESCRIPTION
## Scope of this PR

**Phase 1** (`4f9686b3`): provider-neutral speech/data-plane runtime foundation.
**Phase 2A-1** (`8dab7528`): first real-provider boundary — official VibeVoice-Realtime-0.5B adapter, preflight/dependency-boundary only.

Governing rule (unchanged from SP-VOICE-001, non-negotiable):

> Voice may request and coordinate. Existing SintraPrime policy decides, records, approves, executes, or refuses.

`voice_runtime` is a speech/data plane only. It has no authority to decide whether a consequential action is permitted, execute filings, send messages, make payments, modify records, bypass confirmation, or bypass tenant isolation. `voice_concierge/governed` (SP-VOICE-001, merged via #240/#245) is **untouched** by this PR and remains the sole authority for all of that.

## Hard limits of this PR — please read before reviewing

- **No model weights are included in this PR.**
- **No `torch`/`transformers`/ML dependencies are installed** in the repo, `requirements.txt`, or CI as part of this change.
- **No real inference certification has occurred yet.** The VibeVoice-Realtime-0.5B adapter is fully implemented and tested against its *absence* (dependency/model missing) on the development host, which has no CUDA GPU and limited disk. The host is explicitly classified:

  ```
  AVAILABLE_DEGRADED_CANDIDATE — REAL INFERENCE NOT YET CERTIFIED
  ```

- **No voice cloning, no ASR, no multi-speaker synthesis, no speaker enrollment** — the adapter declares only `TTS`/`STREAMING_TTS`, matching the officially documented single-speaker, no-cloning capability of this specific Microsoft model.
- **No deployment, no production activation.** This is a draft PR; nothing here is wired into any running service.
- **The provider is not in the default registry.** `voice_runtime.registry.build_default_registry()` does not include `VibeVoiceRealtimeProvider` — it must be explicitly constructed by a caller who has verified their own environment. The zero-dependency default registry (`legacy_audio_adapter`, `browser_native`, `mock`) is unchanged.
- **`voice_concierge/governed` is untouched** — byte-identical to what merged in PR #240/#245.

## What's included

### Phase 1 — `voice_runtime/` foundation
- `capabilities.py`, `errors.py`, `preflight.py`, `provenance.py`, `models.py` — provider-neutral capability/error/preflight/provenance/request-response types
- `registry.py`, `router.py` — deterministic provider registry + capability router with full routing evidence (considered/rejected providers and reasons)
- `providers/base.py`, `providers/mock.py`, `providers/legacy.py`, `providers/browser.py` — provider protocol, deterministic mock provider, a bounded legacy-algorithm adapter (audio normalization only, harvested from `voice/voice_engine.py::AudioBuffer`, reimplemented pure-Python with no `numpy`), and a server-side descriptor for the existing PR #247 browser Web Speech API fallback
- `audio/normalization.py`, `audio/formats.py` — pure-Python audio utilities (no `numpy`)
- **Hard requirement, verified by test**: importing `voice_runtime` and every always-available submodule requires **zero** optional heavy dependencies (no numpy/torch/transformers/whisper/elevenlabs/boto3/pyttsx3/vibevoice)
- `voice_runtime/AGENTS.md` — new DOX child doc for this package boundary

### Phase 2A-1 — `providers/vibevoice_realtime.py`
- Official `microsoft/VibeVoice-Realtime-0.5B` model ID only — no community fork referenced
- `torch`/`transformers` imported only inside `preflight()`/`_ensure_model_loaded()`, never at module level
- Layered preflight: `DEPENDENCY_MISSING` → `MODEL_MISSING` (local-only path/cache check via `huggingface_hub.scan_cache_dir()`, **never** a network call) → hardware `AVAILABLE` (CUDA) / `AVAILABLE_DEGRADED` (CPU-only, citing Microsoft's own documented real-time-hardware guidance: verified only on NVIDIA T4 / Apple M4 Pro)
- **Never auto-downloads model weights** — absence is always reported via preflight, never silently fetched
- `cancel_event` (cooperative cancellation) and `timeout_seconds` config as explicit resource-limit contracts

## Legacy code disposition (Phase 0 archaeology, carried forward)

- `voice/voice_api.py` reclassified `RETIRED_UNSAFE_LEGACY_API` (hardcoded mock bearer-token verification hazard) — not deleted (not required for safety since already unreachable/unmounted), but an AST-based test proves `voice_runtime` never imports it or any `voice.*` module.
- The undeclared-`numpy`-module-level-import hazard that broke PR #245's original CI is not reproduced anywhere in `voice_runtime`.

## Validation

```
ruff check voice_runtime/
→ All checks passed!

python -m pytest voice_runtime/tests/ voice_concierge/governed/tests/ \
    portal/tests/test_voice_commands.py portal/tests/test_voice_concierge_browser_io.py -q
→ 188 passed, 0 regressions against the merged SP-VOICE-001 foundation

python -m pytest --collect-only -q
→ zero collection errors across the full default testpaths
```

## Documentation / evidence trail

- `artifacts/voice/SP_VOICE_001_PR245_TERMINAL_STATE.md` — PR #245 terminal-state certification (ancestry + content-equivalence verification)
- `artifacts/voice/SP_VOICE_002_COMPONENT_MATRIX.md` — Phase 0 KEEP/ADAPT/RETIRE inventory of legacy `voice/` vs. modern `voice_concierge/governed`
- `artifacts/voice/SP_VOICE_002_ARCHITECTURE_BASELINE.md` — control-plane vs. speech/data-plane split
- `artifacts/voice/SP_VOICE_002_PHASE1_CERTIFICATION.md` — Phase 1 full test/architecture record
- `artifacts/voice/SP_VOICE_002_PHASE2A_CERTIFICATION.md` — Phase 2A-1 hardware preflight record, rationale for deferring real install, test results, Phase 2A-2 recommendation

## Deferred / explicitly out of scope for this PR

- **Phase 2A-2** (real end-to-end inference certification) — deferred to a CUDA-capable or Apple M-series host, or this host after securing substantially more free disk. Will either be added to this PR if narrowly scoped, or opened as a separate follow-on PR if it grows the provider surface materially.
- **Phase 2B** (VibeVoice-ASR / VibeASR.cpp) — a new capability class (ASR), deliberately scoped to its own separate PR/review surface, not combined with this TTS work.
- Voice cloning, speaker enrollment, multi-speaker long-form synthesis — deferred to a future increment with a formal consent/provenance layer.

## Merge status

**Draft. Not to be merged in this state.** Real inference for the VibeVoice-Realtime-0.5B adapter is not yet certified on any host in this review; that certification (Phase 2A-2) is a prerequisite for promoting the provider from `AVAILABLE_DEGRADED_CANDIDATE` to a hardware-specific certification such as `CERTIFIED_LOCAL_TTS — CUDA`.
