### PR TITLE
SP-AMR-001: governed autonomous mission runtime

### DIFF
--- a/apps/sintraprime/src/mission-runtime/adapters/browserL0Tool.ts
+++ b/apps/sintraprime/src/mission-runtime/adapters/browserL0Tool.ts
@@ -1,0 +1,34 @@
+import type { Tool } from '../../types/index.js';
+import {
+  browserL0DomExtract,
+  browserL0Navigate,
+  browserL0Screenshot,
+} from '../../browserOperator/l0.js';
+
+export class BrowserL0Tool implements Tool {
+  name = 'browser.l0';
+  description = 'Evidence-producing, allowlisted browser navigation, screenshot, and DOM extraction. No form submission or mutation.';
+
+  async execute(args: any): Promise<any> {
+    const operation = String(args?.operation ?? '').trim();
+    const input = {
+      execution_id: String(args?.execution_id ?? `amr_${Date.now()}`),
+      step_id: String(args?.step_id ?? `step_${Date.now()}`),
+      url: String(args?.url ?? ''),
+      timeoutMs: Number(args?.timeoutMs ?? 30_000),
+    };
+
+    if (!input.url) throw new Error('browser.l0 requires url');
+
+    switch (operation) {
+      case 'navigate':
+        return browserL0Navigate(input);
+      case 'screenshot':
+        return browserL0Screenshot({ ...input, fullPage: args?.fullPage !== false });
+      case 'extract':
+        return browserL0DomExtract({ ...input, maxChars: Number(args?.maxChars ?? 250_000) });
+      default:
+        throw new Error(`Unsupported browser.l0 operation: ${operation}`);
+    }
+  }
+}

--- a/apps/sintraprime/src/mission-runtime/adapters/openAICompatibleModelAdapter.ts
+++ b/apps/sintraprime/src/mission-runtime/adapters/openAICompatibleModelAdapter.ts
@@ -1,0 +1,72 @@
+import type { MissionSpec, MissionState, ModelAdapter, ModelProposal } from '../types.js';
+
+export interface OpenAICompatibleModelAdapterConfig {
+  id: string;
+  baseUrl: string;
+  model: string;
+  apiKeyEnv?: string;
+  timeoutMs?: number;
+}
+
+export class OpenAICompatibleModelAdapter implements ModelAdapter {
+  readonly id: string;
+  private readonly config: OpenAICompatibleModelAdapterConfig;
+
+  constructor(config: OpenAICompatibleModelAdapterConfig) {
+    this.id = config.id;
+    this.config = config;
+  }
+
+  async propose(spec: MissionSpec, state: MissionState, context?: unknown): Promise<ModelProposal> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.config.timeoutMs ?? 60_000);
+    const apiKey = this.config.apiKeyEnv ? process.env[this.config.apiKeyEnv] : undefined;
+
+    const system = [
+      'You are a proposal engine inside SintraPrime.',
+      'You do not have execution authority.',
+      'Return exactly one JSON object and no markdown.',
+      'Either propose one action or set stop=true.',
+      'Never claim an action occurred.',
+      'The runtime independently enforces model, tool, budget, and principal authority.',
+    ].join(' ');
+
+    const payload = {
+      model: this.config.model,
+      temperature: 0.2,
+      messages: [
+        { role: 'system', content: system },
+        {
+          role: 'user',
+          content: JSON.stringify({ mission: spec, state, context }),
+        },
+      ],
+      response_format: { type: 'json_object' },
+    };
+
+    try {
+      const response = await fetch(`${this.config.baseUrl.replace(/\/$/, '')}/v1/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Model ${this.id} failed with HTTP ${response.status}`);
+      }
+
+      const body = (await response.json()) as any;
+      const raw = body?.choices?.[0]?.message?.content;
+      if (typeof raw !== 'string') throw new Error(`Model ${this.id} returned no message content`);
+
+      const parsed = JSON.parse(raw) as ModelProposal;
+      return { ...parsed, modelId: this.id };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/apps/sintraprime/src/mission-runtime/authorityEngine.ts
+++ b/apps/sintraprime/src/mission-runtime/authorityEngine.ts
@@ -1,0 +1,47 @@
+import type { AuthorityDecision, MissionSpec, ProposedAction } from './types.js';
+
+export class AuthorityEngine {
+  evaluate(spec: MissionSpec, action: ProposedAction): AuthorityDecision {
+    if (!spec.allowedModels.includes(action.modelId)) {
+      return { decision: 'block', reason: `Model not authorized: ${action.modelId}` };
+    }
+
+    if (!spec.allowedTools.includes(action.tool)) {
+      return { decision: 'block', reason: `Tool not authorized: ${action.tool}` };
+    }
+
+    const level = spec.authority.byActionClass[action.actionClass];
+
+    if (level === 'prohibited') {
+      return {
+        decision: 'block',
+        reason: `Action class prohibited by mission constitution: ${action.actionClass}`,
+        requiredLevel: level,
+      };
+    }
+
+    if (action.actionClass === 'financial') {
+      const cost = action.estimatedCost ?? 0;
+      if (cost > spec.budget.totalCap) {
+        return { decision: 'block', reason: `Requested spend ${cost} exceeds mission budget cap ${spec.budget.totalCap}` };
+      }
+      if (cost > spec.budget.autonomousTransactionCap) {
+        return {
+          decision: 'require_approval',
+          reason: `Spend ${cost} exceeds autonomous transaction cap ${spec.budget.autonomousTransactionCap}`,
+          requiredLevel: 'principal',
+        };
+      }
+    }
+
+    if (level === 'principal' || level === 'supervisor') {
+      return {
+        decision: 'require_approval',
+        reason: `${action.actionClass} requires ${level} approval`,
+        requiredLevel: level,
+      };
+    }
+
+    return { decision: 'allow', reason: 'Action is within delegated mission authority', requiredLevel: level };
+  }
+}

--- a/apps/sintraprime/src/mission-runtime/budgetGovernor.ts
+++ b/apps/sintraprime/src/mission-runtime/budgetGovernor.ts
@@ -1,0 +1,25 @@
+import type { MissionSpec, MissionState, ProposedAction } from './types.js';
+
+export class BudgetGovernor {
+  check(spec: MissionSpec, state: MissionState, action: ProposedAction): { allow: boolean; reason: string } {
+    const cost = action.estimatedCost ?? 0;
+
+    if (cost < 0 || !Number.isFinite(cost)) {
+      return { allow: false, reason: 'Invalid estimated cost' };
+    }
+
+    if (state.spent + cost > spec.budget.totalCap) {
+      return {
+        allow: false,
+        reason: `Projected spend ${state.spent + cost} exceeds mission cap ${spec.budget.totalCap}`,
+      };
+    }
+
+    return { allow: true, reason: 'Within mission budget' };
+  }
+
+  apply(state: MissionState, action: ProposedAction): MissionState {
+    const cost = action.estimatedCost ?? 0;
+    return { ...state, spent: state.spent + cost, lastActionId: action.id };
+  }
+}

--- a/apps/sintraprime/src/mission-runtime/index.ts
+++ b/apps/sintraprime/src/mission-runtime/index.ts
@@ -1,0 +1,7 @@
+export * from './types.js';
+export * from './authorityEngine.js';
+export * from './budgetGovernor.js';
+export * from './modelRouter.js';
+export * from './missionRuntime.js';
+export * from './adapters/openAICompatibleModelAdapter.js';
+export * from './adapters/browserL0Tool.js';

--- a/apps/sintraprime/src/mission-runtime/index.ts
+++ b/apps/sintraprime/src/mission-runtime/index.ts
@@ -3,5 +3,6 @@ export * from './authorityEngine.js';
 export * from './budgetGovernor.js';
 export * from './modelRouter.js';
 export * from './missionRuntime.js';
+export * from './install.js';
 export * from './adapters/openAICompatibleModelAdapter.js';
 export * from './adapters/browserL0Tool.js';

--- a/apps/sintraprime/src/mission-runtime/install.ts
+++ b/apps/sintraprime/src/mission-runtime/install.ts
@@ -1,0 +1,60 @@
+import type { ReceiptLedger } from '../audit/receiptLedger.js';
+import type { Executor } from '../core/executor.js';
+import type { ToolRegistry } from '../tools/toolRegistry.js';
+import { AuthorityEngine } from './authorityEngine.js';
+import { BrowserL0Tool } from './adapters/browserL0Tool.js';
+import { OpenAICompatibleModelAdapter } from './adapters/openAICompatibleModelAdapter.js';
+import { BudgetGovernor } from './budgetGovernor.js';
+import { MissionRuntime } from './missionRuntime.js';
+import { ModelRouter } from './modelRouter.js';
+
+export interface InstallMissionRuntimeArgs {
+  toolRegistry: ToolRegistry;
+  executor: Executor;
+  receiptLedger: ReceiptLedger;
+  modelAdapters?: Array<{
+    id: string;
+    baseUrl: string;
+    model: string;
+    apiKeyEnv?: string;
+    timeoutMs?: number;
+  }>;
+}
+
+/**
+ * Installs the governed autonomy layer on top of SintraPrime's existing
+ * ToolRegistry, Executor, and immutable ReceiptLedger.
+ *
+ * No provider receives execution authority. Models only propose actions;
+ * the MissionRuntime authorizes, budgets, executes, and records them.
+ */
+export function installMissionRuntime(args: InstallMissionRuntimeArgs) {
+  if (!args.toolRegistry.getTool('browser.l0')) {
+    args.toolRegistry.registerTool(new BrowserL0Tool());
+  }
+
+  const models = new ModelRouter();
+  for (const config of args.modelAdapters ?? []) {
+    models.register(new OpenAICompatibleModelAdapter(config));
+  }
+
+  const authority = new AuthorityEngine();
+  const budget = new BudgetGovernor();
+  const runtime = new MissionRuntime({
+    executor: args.executor,
+    receiptLedger: args.receiptLedger,
+    authority,
+    budget,
+    models,
+  });
+
+  return { runtime, models, authority, budget };
+}
+
+export function missionModelAdaptersFromEnv() {
+  const raw = process.env.SINTRAPRIME_MODEL_ADAPTERS_JSON;
+  if (!raw) return [];
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error('SINTRAPRIME_MODEL_ADAPTERS_JSON must be a JSON array');
+  return parsed;
+}

--- a/apps/sintraprime/src/mission-runtime/missionRuntime.ts
+++ b/apps/sintraprime/src/mission-runtime/missionRuntime.ts
@@ -1,0 +1,108 @@
+import { Executor } from '../core/executor.js';
+import { ReceiptLedger } from '../audit/receiptLedger.js';
+import { AuthorityEngine } from './authorityEngine.js';
+import { BudgetGovernor } from './budgetGovernor.js';
+import { ModelRouter } from './modelRouter.js';
+import type { MissionSpec, MissionState, ProposedAction } from './types.js';
+
+export interface MissionRuntimeDependencies {
+  executor: Executor;
+  receiptLedger: ReceiptLedger;
+  authority: AuthorityEngine;
+  budget: BudgetGovernor;
+  models: ModelRouter;
+}
+
+export class MissionRuntime {
+  constructor(private readonly deps: MissionRuntimeDependencies) {}
+
+  createState(spec: MissionSpec): MissionState {
+    return {
+      missionId: spec.id,
+      status: 'ready',
+      spent: 0,
+      iteration: 0,
+      evidenceIds: [],
+    };
+  }
+
+  async run(spec: MissionSpec, initialState?: MissionState, context?: unknown): Promise<MissionState> {
+    let state = initialState ?? this.createState(spec);
+    state = { ...state, status: 'running' };
+
+    while (state.iteration < spec.maxIterations) {
+      const proposals = await this.deps.models.collect(spec, state, context);
+      const selected = this.deps.models.select(proposals);
+
+      if (!selected || selected.stop || !selected.action) {
+        await this.record(spec.id, 'mission_stopped:no_action', { iteration: state.iteration, proposals });
+        return { ...state, status: 'stopped' };
+      }
+
+      const action: ProposedAction = {
+        ...selected.action,
+        id: `action_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+        missionId: spec.id,
+      };
+
+      const authority = this.deps.authority.evaluate(spec, action);
+      await this.record(action.id, 'authority_decision', { action, authority });
+
+      if (authority.decision === 'block') {
+        await this.record(action.id, 'mission_action_blocked', { reason: authority.reason });
+        return { ...state, status: 'stopped', lastActionId: action.id };
+      }
+
+      if (authority.decision === 'require_approval') {
+        await this.record(action.id, 'mission_waiting_approval', {
+          principalId: spec.authority.principalId,
+          requiredLevel: authority.requiredLevel,
+          reason: authority.reason,
+          action,
+        });
+        return { ...state, status: 'waiting_approval', lastActionId: action.id };
+      }
+
+      const budget = this.deps.budget.check(spec, state, action);
+      await this.record(action.id, 'budget_decision', { action, budget, spent: state.spent });
+      if (!budget.allow) {
+        await this.record(action.id, 'mission_budget_blocked', { reason: budget.reason });
+        return { ...state, status: 'stopped', lastActionId: action.id };
+      }
+
+      const result = await this.deps.executor.executeTool(action.tool, action.args);
+      state = this.deps.budget.apply(state, action);
+      state = {
+        ...state,
+        iteration: state.iteration + 1,
+        lastActionId: action.id,
+        evidenceIds: [...state.evidenceIds, action.id],
+      };
+
+      await this.record(action.id, 'mission_action_completed', {
+        modelId: action.modelId,
+        agentId: action.agentId,
+        tool: action.tool,
+        actionClass: action.actionClass,
+        estimatedCost: action.estimatedCost ?? 0,
+        result,
+      });
+    }
+
+    await this.record(spec.id, 'mission_iteration_limit_reached', { maxIterations: spec.maxIterations });
+    return { ...state, status: 'stopped' };
+  }
+
+  private async record(toolCallId: string, action: string, result: unknown): Promise<void> {
+    const id = `amr_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    await this.deps.receiptLedger.recordAction({
+      id,
+      toolCallId,
+      actor: 'mission-runtime',
+      action,
+      timestamp: new Date().toISOString(),
+      result,
+      hash: '',
+    });
+  }
+}

--- a/apps/sintraprime/src/mission-runtime/modelRouter.ts
+++ b/apps/sintraprime/src/mission-runtime/modelRouter.ts
@@ -1,0 +1,36 @@
+import type { MissionSpec, MissionState, ModelAdapter, ModelProposal } from './types.js';
+
+export class ModelRouter {
+  private readonly adapters = new Map<string, ModelAdapter>();
+
+  register(adapter: ModelAdapter): void {
+    if (this.adapters.has(adapter.id)) {
+      throw new Error(`Model adapter already registered: ${adapter.id}`);
+    }
+    this.adapters.set(adapter.id, adapter);
+  }
+
+  get(id: string): ModelAdapter | undefined {
+    return this.adapters.get(id);
+  }
+
+  list(): string[] {
+    return [...this.adapters.keys()];
+  }
+
+  async collect(spec: MissionSpec, state: MissionState, context?: unknown): Promise<ModelProposal[]> {
+    const selected = spec.allowedModels.map((id) => {
+      const adapter = this.adapters.get(id);
+      if (!adapter) throw new Error(`Authorized model adapter is not registered: ${id}`);
+      return adapter;
+    });
+
+    return Promise.all(selected.map((adapter) => adapter.propose(spec, state, context)));
+  }
+
+  select(proposals: ModelProposal[]): ModelProposal | undefined {
+    const actionable = proposals.filter((p) => p.action && !p.stop);
+    actionable.sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0));
+    return actionable[0] ?? proposals.find((p) => p.stop);
+  }
+}

--- a/apps/sintraprime/src/mission-runtime/types.ts
+++ b/apps/sintraprime/src/mission-runtime/types.ts
@@ -1,0 +1,75 @@
+export type AuthorityLevel = 'autonomous' | 'supervisor' | 'principal' | 'prohibited';
+export type ActionClass =
+  | 'reasoning'
+  | 'research'
+  | 'computer_use'
+  | 'communication'
+  | 'financial'
+  | 'human_delegation'
+  | 'legal'
+  | 'physical';
+
+export interface MissionBudget {
+  currency: string;
+  totalCap: number;
+  autonomousTransactionCap: number;
+  approvalThreshold: number;
+}
+
+export interface MissionAuthorityPolicy {
+  byActionClass: Record<ActionClass, AuthorityLevel>;
+  principalId: string;
+}
+
+export interface MissionSpec {
+  id: string;
+  objective: string;
+  successCriteria: string[];
+  stopConditions: string[];
+  budget: MissionBudget;
+  authority: MissionAuthorityPolicy;
+  allowedModels: string[];
+  allowedTools: string[];
+  maxIterations: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ProposedAction {
+  id: string;
+  missionId: string;
+  agentId: string;
+  modelId: string;
+  tool: string;
+  actionClass: ActionClass;
+  args: unknown;
+  estimatedCost?: number;
+  rationale: string;
+}
+
+export interface AuthorityDecision {
+  decision: 'allow' | 'require_approval' | 'block';
+  reason: string;
+  requiredLevel?: AuthorityLevel;
+}
+
+export interface MissionState {
+  missionId: string;
+  status: 'ready' | 'running' | 'waiting_approval' | 'paused' | 'completed' | 'failed' | 'stopped';
+  spent: number;
+  iteration: number;
+  lastActionId?: string;
+  evidenceIds: string[];
+}
+
+export interface ModelProposal {
+  modelId: string;
+  summary: string;
+  confidence?: number;
+  action?: Omit<ProposedAction, 'id' | 'missionId'>;
+  stop?: boolean;
+}
+
+export interface ModelAdapter {
+  id: string;
+  propose(spec: MissionSpec, state: MissionState, context?: unknown): Promise<ModelProposal>;
+}


### PR DESCRIPTION
## What changed

Adds the first implementation of SP-AMR-001, a persistent multimodel mission runtime that keeps SintraPrime above model providers and real-world tools as the constitutional, financial, evidence, and authority layer.

### Runtime
- persistent mission state and bounded iteration loop
- multimodel proposal collection and selection
- model and tool allowlists
- action-class authority matrix
- principal/supervisor approval gates
- prohibited-action hard blocks
- total mission budget and autonomous transaction caps
- immutable authority, budget, action, and stop receipts through the existing ReceiptLedger

### Provider layer
- OpenAI-compatible model adapter with configurable base URL/model/API-key environment variable
- model output is proposal-only; provider models receive no direct execution authority
- multiple adapters can be registered in one ModelRouter

### Computer-use layer
- wraps the existing Browser L0 Playwright implementation as `browser.l0`
- navigation, screenshot, and DOM extraction only
- preserves existing URL allowlist / SSRF protections and evidence artifacts
- intentionally does not add autonomous form submission or mutating browser actions in this phase

### Integration
- installer composes the existing ToolRegistry, Executor, and ReceiptLedger rather than replacing them
- no existing core files changed in this first slice

## Governance invariant

`MODEL -> PROPOSAL -> AUTHORITY -> BUDGET -> EXECUTOR -> RECEIPT`

A model cannot directly authorize spending, legal activity, human delegation, or physical-world execution. Mission policy remains authoritative and approval-required actions stop in `waiting_approval`.

## Validation posture

Draft / integration review. Connector-side code creation is complete, but local typecheck/unit execution has not yet been independently certified. CI results should be treated as the next gate before any merge or broader write-capability adapters are added.
