### PR TITLE
fix(db): align orchestration identity foreign keys

### DIFF
--- a/portal/migrations/add_adaptive_orchestration_domain.sql
+++ b/portal/migrations/add_adaptive_orchestration_domain.sql
@@ -240,56 +240,56 @@ ALTER TABLE orchestration_evidence_references ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS orchestration_runs_tenant_isolation ON orchestration_runs;
 CREATE POLICY orchestration_runs_tenant_isolation
     ON orchestration_runs
-    USING (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid)
-    WITH CHECK (tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid);
+    USING (tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), ''))
+    WITH CHECK (tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), ''));
 
 DROP POLICY IF EXISTS orchestration_nodes_tenant_isolation ON orchestration_nodes;
 CREATE POLICY orchestration_nodes_tenant_isolation
     ON orchestration_nodes
-    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid))
-    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid));
+    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')))
+    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')));
 
 DROP POLICY IF EXISTS orchestration_events_tenant_isolation ON orchestration_events;
 CREATE POLICY orchestration_events_tenant_isolation
     ON orchestration_events
-    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid))
-    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid));
+    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')))
+    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')));
 
 DROP POLICY IF EXISTS orchestration_routing_decisions_tenant_isolation ON orchestration_routing_decisions;
 CREATE POLICY orchestration_routing_decisions_tenant_isolation
     ON orchestration_routing_decisions
-    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid))
-    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid));
+    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')))
+    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')));
 
 DROP POLICY IF EXISTS orchestration_verification_results_tenant_isolation ON orchestration_verification_results;
 CREATE POLICY orchestration_verification_results_tenant_isolation
     ON orchestration_verification_results
-    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid))
-    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid));
+    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')))
+    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')));
 
 DROP POLICY IF EXISTS orchestration_reconciliation_results_tenant_isolation ON orchestration_reconciliation_results;
 CREATE POLICY orchestration_reconciliation_results_tenant_isolation
     ON orchestration_reconciliation_results
-    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid))
-    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid));
+    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')))
+    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')));
 
 DROP POLICY IF EXISTS orchestration_approval_requests_tenant_isolation ON orchestration_approval_requests;
 CREATE POLICY orchestration_approval_requests_tenant_isolation
     ON orchestration_approval_requests
-    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid))
-    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid));
+    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')))
+    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')));
 
 DROP POLICY IF EXISTS orchestration_budget_usage_tenant_isolation ON orchestration_budget_usage;
 CREATE POLICY orchestration_budget_usage_tenant_isolation
     ON orchestration_budget_usage
-    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid))
-    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid));
+    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')))
+    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')));
 
 DROP POLICY IF EXISTS orchestration_evidence_references_tenant_isolation ON orchestration_evidence_references;
 CREATE POLICY orchestration_evidence_references_tenant_isolation
     ON orchestration_evidence_references
-    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid))
-    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id = NULLIF(current_setting('app.current_tenant_id', true), '')::uuid));
+    USING (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')))
+    WITH CHECK (EXISTS (SELECT 1 FROM orchestration_runs r WHERE r.id = run_id AND r.tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), '')));
 
 COMMENT ON TABLE orchestration_runs IS
     'Governed adaptive orchestration run; Milestone One permits deterministic mock providers only.';

--- a/portal/migrations/align_orchestration_identity_fk_types.sql
+++ b/portal/migrations/align_orchestration_identity_fk_types.sql
@@ -1,0 +1,123 @@
+-- Align orchestration references with the deployed tenant/user parent types.
+--
+-- The repository supports two PostgreSQL creation paths: the authoritative raw
+-- SQL bootstrap uses native UUID identity columns, while the ORM create_all test
+-- path uses VARCHAR(36).  This migration derives each child type from its actual
+-- parent instead of coercing an existing deployment to one representation.
+
+DO $migration$
+DECLARE
+    mapping RECORD;
+    child_rel REGCLASS;
+    parent_rel REGCLASS;
+    child_attnum SMALLINT;
+    parent_type TEXT;
+    child_type TEXT;
+    fk_name TEXT;
+BEGIN
+    FOR mapping IN
+        SELECT *
+        FROM (VALUES
+            ('orchestration_runs', 'tenant_id', 'tenants', 'id', 'NO ACTION'),
+            ('orchestration_runs', 'created_by', 'users', 'id', 'NO ACTION'),
+            ('orchestration_approval_requests', 'principal_id', 'users', 'id', 'NO ACTION'),
+            ('orchestration_linkages', 'tenant_id', 'tenants', 'id', 'NO ACTION'),
+            ('orchestration_principal_authorities', 'tenant_id', 'tenants', 'id', 'NO ACTION'),
+            ('orchestration_principal_authorities', 'user_id', 'users', 'id', 'NO ACTION'),
+            ('memory_vault', 'tenant_id', 'tenants', 'id', 'CASCADE')
+        ) AS identity_fk(child_table, child_column, parent_table, parent_column, delete_action)
+    LOOP
+        child_rel := to_regclass('public.' || mapping.child_table);
+        parent_rel := to_regclass('public.' || mapping.parent_table);
+
+        IF child_rel IS NULL OR parent_rel IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        SELECT a.attnum, format_type(a.atttypid, a.atttypmod)
+          INTO child_attnum, child_type
+          FROM pg_attribute a
+         WHERE a.attrelid = child_rel
+           AND a.attname = mapping.child_column
+           AND NOT a.attisdropped;
+
+        SELECT format_type(a.atttypid, a.atttypmod)
+          INTO parent_type
+          FROM pg_attribute a
+         WHERE a.attrelid = parent_rel
+           AND a.attname = mapping.parent_column
+           AND NOT a.attisdropped;
+
+        IF child_attnum IS NULL OR parent_type IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        IF child_type <> parent_type THEN
+            FOR fk_name IN
+                SELECT c.conname
+                  FROM pg_constraint c
+                 WHERE c.conrelid = child_rel
+                   AND c.contype = 'f'
+                   AND child_attnum = ANY(c.conkey)
+            LOOP
+                EXECUTE format('ALTER TABLE %s DROP CONSTRAINT %I', child_rel, fk_name);
+            END LOOP;
+
+            IF parent_type = 'uuid' THEN
+                EXECUTE format(
+                    'ALTER TABLE %s ALTER COLUMN %I TYPE uuid USING NULLIF(%I::text, '''')::uuid',
+                    child_rel,
+                    mapping.child_column,
+                    mapping.child_column
+                );
+            ELSIF parent_type = 'character varying(36)' THEN
+                EXECUTE format(
+                    'ALTER TABLE %s ALTER COLUMN %I TYPE varchar(36) USING %I::text',
+                    child_rel,
+                    mapping.child_column,
+                    mapping.child_column
+                );
+            ELSE
+                RAISE EXCEPTION
+                    'unsupported parent identity type %.%: %',
+                    mapping.parent_table,
+                    mapping.parent_column,
+                    parent_type;
+            END IF;
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1
+              FROM pg_constraint c
+             WHERE c.conrelid = child_rel
+               AND c.confrelid = parent_rel
+               AND c.contype = 'f'
+               AND child_attnum = ANY(c.conkey)
+        ) THEN
+            EXECUTE format(
+                'ALTER TABLE %s ADD CONSTRAINT %I FOREIGN KEY (%I) REFERENCES %s(%I) ON DELETE %s',
+                child_rel,
+                mapping.child_table || '_' || mapping.child_column || '_fkey',
+                mapping.child_column,
+                parent_rel,
+                mapping.parent_column,
+                mapping.delete_action
+            );
+        END IF;
+    END LOOP;
+END
+$migration$;
+
+-- RLS comparisons use text-normalized identity values so the policy is valid
+-- for both native UUID and VARCHAR(36) parent-authority deployments.
+DROP POLICY IF EXISTS orchestration_runs_tenant_isolation ON orchestration_runs;
+CREATE POLICY orchestration_runs_tenant_isolation
+    ON orchestration_runs
+    USING (tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), ''))
+    WITH CHECK (tenant_id::text = NULLIF(current_setting('app.current_tenant_id', true), ''));
+
+-- DOWN migration notes:
+-- This compatibility migration intentionally has no automatic type-reversal.
+-- It derives child types from their referenced parents and is therefore
+-- idempotent.  Roll back by restoring the prior constraint/policy definitions;
+-- do not change column types without first verifying every stored identifier.

--- a/portal/models/orchestration.py
+++ b/portal/models/orchestration.py
@@ -108,8 +108,8 @@ class OrchestrationRun(Base):
     __tablename__ = "orchestration_runs"
 
     id: Mapped[str] = mapped_column(UUID(as_uuid=True), primary_key=True, default=lambda: str(uuid.uuid4()))
-    tenant_id: Mapped[str] = mapped_column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
-    created_by: Mapped[str | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    tenant_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
+    created_by: Mapped[str | None] = mapped_column(String(36), ForeignKey("users.id"), nullable=True)
     objective: Mapped[str] = mapped_column(Text, nullable=False)
     constraints: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
     task_type: Mapped[str] = mapped_column(String(40), nullable=False)
@@ -336,7 +336,7 @@ class ApprovalRequest(Base):
     risk_level: Mapped[str] = mapped_column(String(40), nullable=False)
     status: Mapped[str] = mapped_column(String(40), nullable=False, default=ApprovalStatus.REQUESTED)
     requested_by_role: Mapped[str] = mapped_column(String(40), nullable=False)
-    principal_id: Mapped[str | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=True)
+    principal_id: Mapped[str | None] = mapped_column(String(36), ForeignKey("users.id"), nullable=True)
     decided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     decision_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
@@ -357,7 +357,7 @@ class OrchestrationLinkage(Base):
     id: Mapped[str] = mapped_column(UUID(as_uuid=True), primary_key=True, default=lambda: str(uuid.uuid4()))
     event_id: Mapped[str] = mapped_column(UUID(as_uuid=True), ForeignKey("orchestration_events.id", ondelete="CASCADE"), nullable=False)
     node_id: Mapped[str] = mapped_column(UUID(as_uuid=True), ForeignKey("orchestration_nodes.id", ondelete="CASCADE"), nullable=False)
-    tenant_id: Mapped[str] = mapped_column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+    tenant_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
     linked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     __table_args__ = (
@@ -373,8 +373,8 @@ class PrincipalAuthority(Base):
     __tablename__ = "orchestration_principal_authorities"
 
     id: Mapped[str] = mapped_column(UUID(as_uuid=True), primary_key=True, default=lambda: str(uuid.uuid4()))
-    tenant_id: Mapped[str] = mapped_column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
-    user_id: Mapped[str] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    tenant_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id"), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
     scope: Mapped[str] = mapped_column(String(80), nullable=False, default="GLOBAL")
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     authorized_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
@@ -443,7 +443,7 @@ class MemoryEntry(Base):
     __tablename__ = "memory_vault"
 
     id: Mapped[str] = mapped_column(UUID(as_uuid=True), primary_key=True)
-    tenant_id: Mapped[str] = mapped_column(UUID(as_uuid=True), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False)
+    tenant_id: Mapped[str] = mapped_column(String(36), ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False)
     type: Mapped[str] = mapped_column(String(80), nullable=False)
     content: Mapped[dict] = mapped_column(JSON, nullable=False)
     metadata_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)

--- a/portal/scripts/postgresql_bootstrap.py
+++ b/portal/scripts/postgresql_bootstrap.py
@@ -20,6 +20,8 @@ MIGRATION_SEQUENCE = (
     Path("portal/migrations/add_audit_records.sql"),
     Path("portal/migrations/add_mission_control_command_ledger.sql"),
     Path("portal/migrations/add_mission_control_run_control_projection.sql"),
+    Path("portal/migrations/add_adaptive_orchestration_domain.sql"),
+    Path("portal/migrations/align_orchestration_identity_fk_types.sql"),
 )
 EXPECTED_TABLES = (
     "tenants",
@@ -35,6 +37,10 @@ EXPECTED_TABLES = (
     "mission_control_command_receipts",
     "mission_control_run_controls",
     "mission_control_run_control_events",
+    "orchestration_runs",
+    "orchestration_nodes",
+    "orchestration_events",
+    "orchestration_approval_requests",
 )
 
 

--- a/portal/tests/test_postgresql_bootstrap_schema_authority.py
+++ b/portal/tests/test_postgresql_bootstrap_schema_authority.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import uuid
+from pathlib import Path
 
 import psycopg2
 import pytest
@@ -109,6 +110,8 @@ def test_authoritative_migration_sequence_is_ordered() -> None:
         "portal/migrations/add_audit_records.sql",
         "portal/migrations/add_mission_control_command_ledger.sql",
         "portal/migrations/add_mission_control_run_control_projection.sql",
+        "portal/migrations/add_adaptive_orchestration_domain.sql",
+        "portal/migrations/align_orchestration_identity_fk_types.sql",
     ]
 
 
@@ -128,6 +131,22 @@ def test_postgresql_orm_foreign_key_column_types_are_internally_consistent() -> 
                         f"{referred.table.name}.{referred.name} {referred_type}"
                     )
     assert mismatches == []
+
+
+def test_orchestration_identity_compatibility_migration_covers_known_drift() -> None:
+    sql = Path("portal/migrations/align_orchestration_identity_fk_types.sql")
+    migration = sql.read_text(encoding="utf-8")
+    expected_references = {
+        "('orchestration_runs', 'tenant_id', 'tenants', 'id', 'NO ACTION')",
+        "('orchestration_runs', 'created_by', 'users', 'id', 'NO ACTION')",
+        "('orchestration_approval_requests', 'principal_id', 'users', 'id', 'NO ACTION')",
+        "('orchestration_linkages', 'tenant_id', 'tenants', 'id', 'NO ACTION')",
+        "('orchestration_principal_authorities', 'tenant_id', 'tenants', 'id', 'NO ACTION')",
+        "('orchestration_principal_authorities', 'user_id', 'users', 'id', 'NO ACTION')",
+        "('memory_vault', 'tenant_id', 'tenants', 'id', 'CASCADE')",
+    }
+    assert all(reference in migration for reference in expected_references)
+    assert "tenant_id::text = NULLIF(current_setting('app.current_tenant_id'" in migration
 
 
 def test_postgresql_race_prepare_schema_create_all_path_executes() -> None:


### PR DESCRIPTION
## Lane A — PostgreSQL identity foreign-key drift

Closes the PostgreSQL identity-type lane in #287. This PR intentionally excludes authentication reconciliation and Ruff cleanup.

### Change

- Align the seven orchestration ORM references to the ORM parent authority (`String(36)` for `tenants.id` / `users.id`).
- Preserve native PostgreSQL `UUID` for orchestration-owned primary keys and internal orchestration foreign keys.
- Normalize adaptive-domain RLS comparisons through `tenant_id::text`, making session identity comparison representation-safe.
- Add an idempotent compatibility migration that derives each child type from the deployed parent type, drops/recreates only affected FKs, rejects unsupported parent types, and fails transactionally on unsafe UUID conversion.
- Add adaptive orchestration plus the compatibility migration to the authoritative PostgreSQL bootstrap sequence.
- Extend focused certification coverage for the known seven-column drift.

### Seven corrected ORM references

1. `OrchestrationRun.tenant_id`
2. `OrchestrationRun.created_by`
3. `ApprovalRequest.principal_id`
4. `OrchestrationLinkage.tenant_id`
5. `PrincipalAuthority.tenant_id`
6. `PrincipalAuthority.user_id`
7. `MemoryEntry.tenant_id`

### Local evidence

- 3 focused authority/migration tests: **PASS**
- Python compile check: **PASS**
- `git diff --check`: **PASS**
- Focused Ruff on touched Python files still reports the same five pre-existing findings in `portal/models/orchestration.py`; no Ruff cleanup is included because that belongs to Lane C.

### Required CI gates before ready/merge

- `postgresql-bootstrap-certification`
- `postgresql-race`
- ORM FK-type consistency
- docs/claims and unaffected security/auth lanes must show no regression

This PR remains draft until PostgreSQL container evidence is green.